### PR TITLE
Map Zod errors to 400 HTTP status

### DIFF
--- a/src/modules/tracking/interface/http/refresh.controllers.test.ts
+++ b/src/modules/tracking/interface/http/refresh.controllers.test.ts
@@ -85,6 +85,25 @@ describe('refresh controllers', () => {
     expect(body.error).toContain('MSCU7654321')
   })
 
+  it('returns 400 for invalid refresh payload', async () => {
+    const controllers = createRefreshControllers({
+      refreshRestUseCase: vi.fn(),
+      refreshMaerskUseCase: vi.fn(),
+    })
+
+    const request = new Request('http://localhost/api/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ container: 'MSCU7654321' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await controllers.refresh({ request })
+    const body = RefreshSchemas.responses.error.parse(await response.json())
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('carrier')
+  })
+
   it('parses params/query and returns maersk success', async () => {
     const refreshMaerskUseCase = vi.fn(async () => ({
       kind: 'ok' as const,

--- a/src/shared/api/errorToResponse.ts
+++ b/src/shared/api/errorToResponse.ts
@@ -1,3 +1,4 @@
+import { ZodError } from 'zod/v4'
 import { TypedFetchError } from '~/shared/api/typedFetch'
 import {
   CannotRemoveLastContainerError,
@@ -22,6 +23,11 @@ export function mapErrorToResponse(err: unknown): Response {
   // TypedFetchError carries HTTP status from remote fetch
   if (err instanceof TypedFetchError) {
     return jsonResponse({ error: err.message }, err.status)
+  }
+
+  // ZodError at API boundaries means client payload/query/params validation failure
+  if (err instanceof ZodError) {
+    return jsonResponse({ error: err.message }, 400)
   }
 
   // Domain-specific errors -> map to appropriate codes


### PR DESCRIPTION
Implement error mapping for Zod validation failures to return a 400 status code, ensuring proper client payload validation handling in the API. Additionally, add a test case to verify this behavior.