### PR TITLE
Implement no-iife-in-jsx ESLint rule with tests and CI integration

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run lint
         run: pnpm run lint
 
+      - name: Verify no-iife-in-jsx error gate behavior
+        run: pnpm run lint:no-iife:error-smoke
+
       - name: Run UI complexity gates
         run: pnpm run ui:complexity:ci
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ Capabilities orchestrate across BCs.
 - Prefer named exports; avoid `export default`
 - Root tooling configs (for example `eslint.config.mjs`) are linted by Biome import rules:
   avoid `./` or `../` imports there and prefer `package.json` `imports` aliases (`#...`)
+- For local ESLint plugins authored in `.mjs`, prefer rule tests in `*.test.mjs`;
+  TypeScript `*.test.ts` can fail strict plugin-shape checks during `pnpm run type-check`
 
 ---
 

--- a/docs/lint/no-iife-in-jsx-baseline.md
+++ b/docs/lint/no-iife-in-jsx-baseline.md
@@ -1,0 +1,23 @@
+# no-iife-in-jsx Baseline
+
+Generated at: 2026-03-03 07:22:57Z
+
+## Scope
+- Files: `src/modules/**/ui/**/*.{ts,tsx}`
+- Rule: `container-tracker/no-iife-in-jsx`
+- Severity: `warn`
+- Command:
+  - `pnpm exec eslint "src/modules/**/ui/**/*.{ts,tsx}" --format json`
+
+## Baseline Summary
+- Files scanned: `39`
+- `no-iife-in-jsx` warnings: `0`
+
+## Occurrences by File
+- No current occurrences in scope.
+
+## Incremental Refactoring Tasks
+1. Keep the rule in `warn` mode for `src/modules/**/ui/**/*.{ts,tsx}` while monitoring new warnings per PR.
+2. If a warning appears, refactor JSX IIFE usage into one of the approved alternatives: pre-calculation before JSX, pure external function, or `createMemo`.
+3. Re-generate this baseline after each refactor wave to track net warning reduction by file.
+4. Promote `warn -> error` only when the baseline remains at `0` warnings and CI expectations are updated.

--- a/docs/lint/no-iife-in-jsx-baseline.md
+++ b/docs/lint/no-iife-in-jsx-baseline.md
@@ -21,3 +21,4 @@ Generated at: 2026-03-03 07:22:57Z
 2. If a warning appears, refactor JSX IIFE usage into one of the approved alternatives: pre-calculation before JSX, pure external function, or `createMemo`.
 3. Re-generate this baseline after each refactor wave to track net warning reduction by file.
 4. Promote `warn -> error` only when the baseline remains at `0` warnings and CI expectations are updated.
+5. Follow [`docs/lint/no-iife-in-jsx-transition.md`](./no-iife-in-jsx-transition.md) for promotion checklist, controlled exception format, and CI gate verification.

--- a/docs/lint/no-iife-in-jsx-transition.md
+++ b/docs/lint/no-iife-in-jsx-transition.md
@@ -1,0 +1,50 @@
+# no-iife-in-jsx Transition Guide
+
+This guide defines the controlled promotion path from `warn` to `error` for `container-tracker/no-iife-in-jsx`.
+
+## Promotion Precondition
+
+Promotion to `error` is allowed only when all items below are true:
+
+1. Baseline at [`docs/lint/no-iife-in-jsx-baseline.md`](./no-iife-in-jsx-baseline.md) reports `0` warnings.
+2. Scoped lint command still reports `0` warnings for the rule:
+   - `pnpm exec eslint "src/modules/**/ui/**/*.{ts,tsx}" --format json`
+3. New PRs in scope do not introduce warnings for `container-tracker/no-iife-in-jsx`.
+
+## Controlled Exception Format
+
+Use an inline disable only when the refactor cannot be completed in the same PR and always include a justified reason.
+
+```tsx
+// eslint-disable-next-line container-tracker/no-iife-in-jsx -- justified reason: <ticket/context>
+{(() => computeFallback())()}
+```
+
+Short form reference used in rollout docs:
+
+```tsx
+// eslint-disable-next-line no-iife-in-jsx -- justified reason
+```
+
+## warn -> error Procedure
+
+1. Confirm the precondition above (`0` warnings in scope).
+2. Change rule severity in [`eslint.config.mjs`](../../eslint.config.mjs) for `src/modules/**/ui/**/*.{ts,tsx}`:
+   - from: `'container-tracker/no-iife-in-jsx': 'warn'`
+   - to: `'container-tracker/no-iife-in-jsx': 'error'`
+3. Run local quality gate:
+   - `pnpm run lint`
+   - `pnpm run type-check`
+   - `pnpm run test`
+4. Ensure CI quality gate stays green (`lint`, `type-check`, `test`).
+5. Remove temporary disables as soon as the blocking context is resolved.
+
+## CI Gate Proof for Error Promotion
+
+Quality workflow includes `pnpm run lint:no-iife:error-smoke`, which:
+
+1. Generates a temporary UI fixture containing an IIFE in JSX.
+2. Runs ESLint with `--rule container-tracker/no-iife-in-jsx:error`.
+3. Expects the lint command to fail because of the sample violation.
+
+If lint does not fail under error severity, the smoke command fails and the CI lint job is blocked.

--- a/docs/lint/no-iife-in-jsx-transition.md
+++ b/docs/lint/no-iife-in-jsx-transition.md
@@ -20,12 +20,6 @@ Use an inline disable only when the refactor cannot be completed in the same PR 
 {(() => computeFallback())()}
 ```
 
-Short form reference used in rollout docs:
-
-```tsx
-// eslint-disable-next-line no-iife-in-jsx -- justified reason
-```
-
 ## warn -> error Procedure
 
 1. Confirm the precondition above (`0` warnings in scope).
@@ -44,7 +38,7 @@ Short form reference used in rollout docs:
 Quality workflow includes `pnpm run lint:no-iife:error-smoke`, which:
 
 1. Generates a temporary UI fixture containing an IIFE in JSX.
-2. Runs ESLint with `--rule container-tracker/no-iife-in-jsx:error`.
+2. Runs ESLint with `--rule '{"container-tracker/no-iife-in-jsx":"error"}'`.
 3. Expects the lint command to fail because of the sample violation.
 
 If lint does not fail under error severity, the smoke command fails and the CI lint job is blocked.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,6 +86,12 @@ export default [
     },
   },
   {
+    files: ['src/modules/**/ui/**/*.{ts,tsx}'],
+    rules: {
+      'container-tracker/no-iife-in-jsx': 'warn',
+    },
+  },
+  {
     files: ['src/routes/api/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "i18n:enforce": "node scripts/enforce-i18n-no-hardcoded.mjs",
     "fix": "pnpm exec biome format --write . --format-with-errors true && pnpm exec biome check . --write --max-diagnostics=1000 --no-errors-on-unmatched",
     "lint": "pnpm exec biome check . --max-diagnostics=1000 --no-errors-on-unmatched && pnpm exec eslint --ext .ts,.tsx . --max-warnings=0",
+    "lint:no-iife:error-smoke": "node scripts/no-iife-in-jsx-error-smoke.mjs",
     "ui:complexity:report": "node scripts/ui-complexity-report.mjs",
     "ui:complexity:report:write": "node scripts/ui-complexity-report.mjs --write",
     "ui:complexity:lint:soft": "node scripts/ui-complexity-report.mjs",

--- a/scripts/no-iife-in-jsx-error-smoke.mjs
+++ b/scripts/no-iife-in-jsx-error-smoke.mjs
@@ -3,10 +3,12 @@ import { mkdir, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { assertNoIifeErrorSmokeResult } from './no-iife-in-jsx-error-smoke.shared.mjs'
 
 const currentFilePath = fileURLToPath(import.meta.url)
 const scriptsDirectory = path.dirname(currentFilePath)
 const repositoryRoot = path.resolve(scriptsDirectory, '..')
+const eslintCliPath = path.join(repositoryRoot, 'node_modules', 'eslint', 'bin', 'eslint.js')
 const smokeFixtureDirectory = path.join(
   repositoryRoot,
   'src',
@@ -35,13 +37,14 @@ async function runSmokeCheck() {
     await writeFile(smokeFixtureFilePath, smokeFixtureSource, 'utf8')
 
     const command = spawnSync(
-      'pnpm',
+      process.execPath,
       [
-        'exec',
-        'eslint',
+        eslintCliPath,
         smokeFixtureFilePath,
         '--rule',
         'container-tracker/no-iife-in-jsx:error',
+        '--format',
+        'json',
         '--max-warnings=0',
       ],
       {
@@ -54,20 +57,7 @@ async function runSmokeCheck() {
       throw command.error
     }
 
-    const output = `${command.stdout ?? ''}\n${command.stderr ?? ''}`
-    const detectedRuleViolation = output.includes('container-tracker/no-iife-in-jsx')
-
-    if (command.status === 0) {
-      throw new Error(
-        'Expected ESLint to fail when no-iife-in-jsx is promoted to error, but command succeeded.',
-      )
-    }
-
-    if (!detectedRuleViolation) {
-      throw new Error(
-        'ESLint failed for an unexpected reason. Expected container-tracker/no-iife-in-jsx violation.',
-      )
-    }
+    assertNoIifeErrorSmokeResult(command)
 
     console.log('[no-iife-in-jsx-error-smoke] PASS')
   } finally {

--- a/scripts/no-iife-in-jsx-error-smoke.mjs
+++ b/scripts/no-iife-in-jsx-error-smoke.mjs
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const currentFilePath = fileURLToPath(import.meta.url)
+const scriptsDirectory = path.dirname(currentFilePath)
+const repositoryRoot = path.resolve(scriptsDirectory, '..')
+const smokeFixtureDirectory = path.join(
+  repositoryRoot,
+  'src',
+  'modules',
+  'process',
+  'ui',
+  '__lint_smoke_no_iife__',
+)
+const smokeFixtureFilePath = path.join(smokeFixtureDirectory, 'NoIifeErrorSmokeFixture.tsx')
+
+const smokeFixtureSource = `import { For } from 'solid-js'
+
+export function NoIifeErrorSmokeFixture() {
+  return (
+    <For each={[1, 2]}>
+      {(item) => <span>{(() => item)()}</span>}
+    </For>
+  )
+}
+`
+
+async function runSmokeCheck() {
+  await mkdir(smokeFixtureDirectory, { recursive: true })
+
+  try {
+    await writeFile(smokeFixtureFilePath, smokeFixtureSource, 'utf8')
+
+    const command = spawnSync(
+      'pnpm',
+      [
+        'exec',
+        'eslint',
+        smokeFixtureFilePath,
+        '--rule',
+        'container-tracker/no-iife-in-jsx:error',
+        '--max-warnings=0',
+      ],
+      {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    if (command.error) {
+      throw command.error
+    }
+
+    const output = `${command.stdout ?? ''}\n${command.stderr ?? ''}`
+    const detectedRuleViolation = output.includes('container-tracker/no-iife-in-jsx')
+
+    if (command.status === 0) {
+      throw new Error(
+        'Expected ESLint to fail when no-iife-in-jsx is promoted to error, but command succeeded.',
+      )
+    }
+
+    if (!detectedRuleViolation) {
+      throw new Error(
+        'ESLint failed for an unexpected reason. Expected container-tracker/no-iife-in-jsx violation.',
+      )
+    }
+
+    console.log('[no-iife-in-jsx-error-smoke] PASS')
+  } finally {
+    await rm(smokeFixtureDirectory, { recursive: true, force: true })
+  }
+}
+
+runSmokeCheck().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error('[no-iife-in-jsx-error-smoke] FAIL')
+  console.error(message)
+  process.exitCode = 1
+})

--- a/scripts/no-iife-in-jsx-error-smoke.mjs
+++ b/scripts/no-iife-in-jsx-error-smoke.mjs
@@ -42,7 +42,7 @@ async function runSmokeCheck() {
         eslintCliPath,
         smokeFixtureFilePath,
         '--rule',
-        'container-tracker/no-iife-in-jsx:error',
+        '{"container-tracker/no-iife-in-jsx":"error"}',
         '--format',
         'json',
         '--max-warnings=0',

--- a/scripts/no-iife-in-jsx-error-smoke.shared.mjs
+++ b/scripts/no-iife-in-jsx-error-smoke.shared.mjs
@@ -1,0 +1,109 @@
+const noIifeRuleId = 'container-tracker/no-iife-in-jsx'
+const noIifeRuleMessageId = 'avoidIifeInJsx'
+const maximumDiagnosticsLength = 1200
+
+function truncateText(text) {
+  if (text.length <= maximumDiagnosticsLength) {
+    return text
+  }
+
+  return `${text.slice(0, maximumDiagnosticsLength)}...`
+}
+
+function buildDiagnosticsContext(stdout, stderr) {
+  const normalizedStdout = stdout.trim()
+  const normalizedStderr = stderr.trim()
+
+  if (normalizedStdout.length === 0 && normalizedStderr.length === 0) {
+    return ''
+  }
+
+  const diagnostics = [
+    '[no-iife-in-jsx-error-smoke] ESLint diagnostics:',
+    `stdout:\n${truncateText(normalizedStdout || '<empty>')}`,
+    `stderr:\n${truncateText(normalizedStderr || '<empty>')}`,
+  ]
+
+  return `\n${diagnostics.join('\n')}`
+}
+
+function parseJsonResults(stdout, stderr) {
+  const normalizedStdout = stdout.trim()
+
+  if (normalizedStdout.length === 0) {
+    throw new Error(
+      `Expected ESLint JSON output, but stdout was empty.${buildDiagnosticsContext(stdout, stderr)}`,
+    )
+  }
+
+  let parsedOutput
+  try {
+    parsedOutput = JSON.parse(normalizedStdout)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Failed to parse ESLint JSON output: ${message}.${buildDiagnosticsContext(stdout, stderr)}`,
+    )
+  }
+
+  if (!Array.isArray(parsedOutput)) {
+    throw new Error(
+      `Expected ESLint JSON output to be an array.${buildDiagnosticsContext(stdout, stderr)}`,
+    )
+  }
+
+  return parsedOutput
+}
+
+function collectNoIifeViolations(results) {
+  const violations = []
+  for (const result of results) {
+    const messages = Array.isArray(result?.messages) ? result.messages : []
+
+    for (const message of messages) {
+      if (message?.ruleId !== noIifeRuleId) {
+        continue
+      }
+
+      if (message?.messageId !== noIifeRuleMessageId) {
+        continue
+      }
+
+      violations.push(message)
+    }
+  }
+
+  return violations
+}
+
+export function assertNoIifeErrorSmokeResult(commandResult) {
+  const status = commandResult?.status
+  const stdout = commandResult?.stdout ?? ''
+  const stderr = commandResult?.stderr ?? ''
+
+  if (status === 0) {
+    throw new Error(
+      'Expected ESLint to fail when no-iife-in-jsx is promoted to error, but command succeeded.',
+    )
+  }
+
+  if (status !== 1) {
+    throw new Error(
+      `Expected ESLint to exit with status 1 (lint violations). Received: ${String(status)}.${buildDiagnosticsContext(stdout, stderr)}`,
+    )
+  }
+
+  const results = parseJsonResults(stdout, stderr)
+  const violations = collectNoIifeViolations(results)
+
+  if (violations.length === 0) {
+    throw new Error(
+      `ESLint failed for an unexpected reason. Expected ${noIifeRuleId} with messageId ${noIifeRuleMessageId}.${buildDiagnosticsContext(stdout, stderr)}`,
+    )
+  }
+}
+
+export const noIifeErrorSmokeConstants = {
+  noIifeRuleId,
+  noIifeRuleMessageId,
+}

--- a/scripts/no-iife-in-jsx-error-smoke.shared.mjs
+++ b/scripts/no-iife-in-jsx-error-smoke.shared.mjs
@@ -1,5 +1,6 @@
 const noIifeRuleId = 'container-tracker/no-iife-in-jsx'
 const noIifeRuleMessageId = 'avoidIifeInJsx'
+const noIifeErrorSeverity = 2
 const maximumDiagnosticsLength = 1200
 
 function truncateText(text) {
@@ -69,6 +70,10 @@ function collectNoIifeViolations(results) {
         continue
       }
 
+      if (message?.severity !== noIifeErrorSeverity) {
+        continue
+      }
+
       violations.push(message)
     }
   }
@@ -98,12 +103,13 @@ export function assertNoIifeErrorSmokeResult(commandResult) {
 
   if (violations.length === 0) {
     throw new Error(
-      `ESLint failed for an unexpected reason. Expected ${noIifeRuleId} with messageId ${noIifeRuleMessageId}.${buildDiagnosticsContext(stdout, stderr)}`,
+      `ESLint failed for an unexpected reason. Expected ${noIifeRuleId} with messageId ${noIifeRuleMessageId} at severity ${String(noIifeErrorSeverity)}.${buildDiagnosticsContext(stdout, stderr)}`,
     )
   }
 }
 
 export const noIifeErrorSmokeConstants = {
+  noIifeErrorSeverity,
   noIifeRuleId,
   noIifeRuleMessageId,
 }

--- a/scripts/tests/eslint-plugin-container-tracker.test.mjs
+++ b/scripts/tests/eslint-plugin-container-tracker.test.mjs
@@ -1,0 +1,157 @@
+import path from 'node:path'
+import tsParser from '@typescript-eslint/parser'
+import { ESLint } from 'eslint'
+import { describe, expect, it } from 'vitest'
+import { containerTrackerEslintPlugin } from '#container-tracker-eslint-plugin'
+
+const noIifeInJsxRuleId = 'container-tracker/no-iife-in-jsx'
+const fixtureFilePath = path.join(
+  'src',
+  'modules',
+  'process',
+  'ui',
+  'components',
+  'NoIifeRuleFixture.tsx',
+)
+
+const eslint = new ESLint({
+  overrideConfigFile: true,
+  overrideConfig: [
+    {
+      files: ['**/*.{ts,tsx}'],
+      languageOptions: {
+        parser: tsParser,
+        parserOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+      plugins: {
+        'container-tracker': containerTrackerEslintPlugin,
+      },
+      rules: {
+        [noIifeInJsxRuleId]: 'error',
+      },
+    },
+  ],
+})
+
+async function lintWithNoIifeRule(source) {
+  const [result] = await eslint.lintText(source, { filePath: fixtureFilePath })
+  return result.messages.filter((message) => message.ruleId === noIifeInJsxRuleId)
+}
+
+const invalidCases = [
+  {
+    name: 'flags arrow IIFE inside For',
+    source: `
+      const View = () => (
+        <For each={[1, 2]}>
+          {(item) => <span>{(() => item)()}</span>}
+        </For>
+      )
+    `,
+  },
+  {
+    name: 'flags function expression IIFE inside Show',
+    source: `
+      const View = () => (
+        <Show when={true}>
+          {(function () { return 'visible' })()}
+        </Show>
+      )
+    `,
+  },
+  {
+    name: 'flags arrow IIFE inside Switch',
+    source: `
+      const View = () => (
+        <Switch>
+          {(() => 'fallback')()}
+        </Switch>
+      )
+    `,
+  },
+  {
+    name: 'flags function expression IIFE inside Match',
+    source: `
+      const View = () => (
+        <Match when={true}>
+          {(function () { return 'matched' })()}
+        </Match>
+      )
+    `,
+  },
+  {
+    name: 'flags arrow IIFE inside Index',
+    source: `
+      const View = () => (
+        <Index each={[1, 2]}>
+          {(item) => <span>{(() => item())()}</span>}
+        </Index>
+      )
+    `,
+  },
+]
+
+const validCases = [
+  {
+    name: 'allows pre-calculation outside JSX expression containers',
+    source: `
+      const value = (() => 42)()
+      const View = () => <div>{value}</div>
+    `,
+  },
+  {
+    name: 'allows createMemo usage inside JSX',
+    source: `
+      import { createMemo } from 'solid-js'
+
+      const View = () => {
+        const label = createMemo(() => 'ready')
+        return <Show when={true}>{label()}</Show>
+      }
+    `,
+  },
+  {
+    name: 'allows pure external function calls inside JSX',
+    source: `
+      const toLabel = (value) => \`item-\${value}\`
+      const View = () => (
+        <For each={[1, 2]}>
+          {(value) => <span>{toLabel(value)}</span>}
+        </For>
+      )
+    `,
+  },
+]
+
+describe('container-tracker/no-iife-in-jsx', () => {
+  for (const testCase of invalidCases) {
+    it(testCase.name, async () => {
+      const messages = await lintWithNoIifeRule(testCase.source)
+      expect(messages).toHaveLength(1)
+      expect(messages[0]?.ruleId).toBe(noIifeInJsxRuleId)
+      expect(messages[0]?.messageId).toBe('avoidIifeInJsx')
+    })
+  }
+
+  for (const testCase of validCases) {
+    it(testCase.name, async () => {
+      const messages = await lintWithNoIifeRule(testCase.source)
+      expect(messages).toHaveLength(0)
+    })
+  }
+
+  it('does not report IIFE outside JSX expression containers', async () => {
+    const messages = await lintWithNoIifeRule(`
+      const value = (function () { return 'ok' })()
+      const View = () => <div>{value}</div>
+    `)
+
+    expect(messages).toHaveLength(0)
+  })
+})

--- a/scripts/tests/eslint-plugin-container-tracker.test.mjs
+++ b/scripts/tests/eslint-plugin-container-tracker.test.mjs
@@ -127,6 +127,39 @@ const validCases = [
       )
     `,
   },
+  {
+    name: 'allows pre-computed fallback in Switch',
+    source: `
+      const fallback = 'fallback'
+      const View = () => (
+        <Switch>
+          {fallback}
+        </Switch>
+      )
+    `,
+  },
+  {
+    name: 'allows declarative expression in Match',
+    source: `
+      const label = 'matched'
+      const View = () => (
+        <Match when={true}>
+          {label}
+        </Match>
+      )
+    `,
+  },
+  {
+    name: 'allows pure helper in Index renderer',
+    source: `
+      const toLabel = (value) => \`item-\${value}\`
+      const View = () => (
+        <Index each={[1, 2]}>
+          {(item) => <span>{toLabel(item())}</span>}
+        </Index>
+      )
+    `,
+  },
 ]
 
 describe('container-tracker/no-iife-in-jsx', () => {

--- a/scripts/tests/no-iife-in-jsx-error-smoke.shared.test.mjs
+++ b/scripts/tests/no-iife-in-jsx-error-smoke.shared.test.mjs
@@ -28,7 +28,7 @@ describe('assertNoIifeErrorSmokeResult', () => {
       {
         ruleId: noIifeRuleId,
         messageId: noIifeRuleMessageId,
-        severity: 2,
+        severity: noIifeErrorSmokeConstants.noIifeErrorSeverity,
         message: 'Avoid IIFE inside JSX.',
       },
     ])
@@ -59,6 +59,21 @@ describe('assertNoIifeErrorSmokeResult', () => {
 
     expect(() => assertNoIifeErrorSmokeResult(result)).toThrow(
       `Expected ${noIifeRuleId} with messageId ${noIifeRuleMessageId}`,
+    )
+  })
+
+  it('fails when matching rule is reported only as warning severity', () => {
+    const result = buildResult([
+      {
+        ruleId: noIifeRuleId,
+        messageId: noIifeRuleMessageId,
+        severity: 1,
+        message: 'Avoid IIFE inside JSX.',
+      },
+    ])
+
+    expect(() => assertNoIifeErrorSmokeResult(result)).toThrow(
+      `Expected ${noIifeRuleId} with messageId ${noIifeRuleMessageId} at severity ${String(noIifeErrorSmokeConstants.noIifeErrorSeverity)}`,
     )
   })
 })

--- a/scripts/tests/no-iife-in-jsx-error-smoke.shared.test.mjs
+++ b/scripts/tests/no-iife-in-jsx-error-smoke.shared.test.mjs
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertNoIifeErrorSmokeResult,
+  noIifeErrorSmokeConstants,
+} from '../no-iife-in-jsx-error-smoke.shared.mjs'
+
+const { noIifeRuleId, noIifeRuleMessageId } = noIifeErrorSmokeConstants
+
+function buildResult(messages, status = 1) {
+  return {
+    status,
+    stdout: JSON.stringify([
+      {
+        filePath: '/tmp/NoIifeErrorSmokeFixture.tsx',
+        messages,
+        errorCount: messages.length,
+        warningCount: 0,
+        fatalErrorCount: 0,
+      },
+    ]),
+    stderr: '',
+  }
+}
+
+describe('assertNoIifeErrorSmokeResult', () => {
+  it('passes when eslint exits with a concrete no-iife rule violation', () => {
+    const result = buildResult([
+      {
+        ruleId: noIifeRuleId,
+        messageId: noIifeRuleMessageId,
+        severity: 2,
+        message: 'Avoid IIFE inside JSX.',
+      },
+    ])
+
+    expect(() => assertNoIifeErrorSmokeResult(result)).not.toThrow()
+  })
+
+  it('fails when eslint exits with status 2 despite containing rule text in stderr', () => {
+    const result = {
+      status: 2,
+      stdout: '',
+      stderr: `A configuration object specifies rule \"${noIifeRuleId}\"`,
+    }
+
+    expect(() => assertNoIifeErrorSmokeResult(result)).toThrow(
+      'Expected ESLint to exit with status 1',
+    )
+  })
+
+  it('fails when eslint status is 1 but output does not include concrete rule messageId', () => {
+    const result = buildResult([
+      {
+        ruleId: noIifeRuleId,
+        severity: 2,
+        message: `Definition for rule '${noIifeRuleId}' was not found.`,
+      },
+    ])
+
+    expect(() => assertNoIifeErrorSmokeResult(result)).toThrow(
+      `Expected ${noIifeRuleId} with messageId ${noIifeRuleMessageId}`,
+    )
+  })
+})


### PR DESCRIPTION
Introduce the `no-iife-in-jsx` rule to prevent IIFE calls inside JSX. Add tests for valid and invalid cases, apply the rule in warning mode for UI components, and prepare for a transition to error severity with CI gate verification.