### PR TITLE
[Hotfix] Treat 'arrived at POD' as distinct process status

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -584,7 +584,7 @@
       "IN_PROGRESS": "In Progress",
       "LOADED": "Loaded",
       "IN_TRANSIT": "In Transit",
-      "ARRIVED_AT_POD": "Arrived at POD",
+      "ARRIVED_AT_POD": "At POD",
       "DISCHARGED": "Discharged",
       "AVAILABLE_FOR_PICKUP": "Available for Pickup",
       "DELIVERED": "Delivered",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -595,7 +595,7 @@
       "IN_PROGRESS": "Em Andamento",
       "LOADED": "Carregado",
       "IN_TRANSIT": "Em Trânsito",
-      "ARRIVED_AT_POD": "Chegou ao Porto",
+      "ARRIVED_AT_POD": "No Porto",
       "DISCHARGED": "Descarregado",
       "AVAILABLE_FOR_PICKUP": "Disponível para Retirada",
       "DELIVERED": "Entregue",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -595,7 +595,7 @@
       "IN_PROGRESS": "Em Curso",
       "LOADED": "Carregado",
       "IN_TRANSIT": "Em Trânsito",
-      "ARRIVED_AT_POD": "Chegou ao Porto",
+      "ARRIVED_AT_POD": "No Porto",
       "DISCHARGED": "Descarregado",
       "AVAILABLE_FOR_PICKUP": "Disponível para Recolha",
       "DELIVERED": "Entregue",

--- a/src/modules/process/features/operational-projection/application/deriveProcessStatus.ts
+++ b/src/modules/process/features/operational-projection/application/deriveProcessStatus.ts
@@ -63,6 +63,26 @@ const OPERATIONAL_STATUS_ORDER_INDEX: Readonly<Record<OperationalStatus, number>
   EMPTY_RETURNED: 8,
 }
 
+const PROCESS_STATUS_ORDER = [
+  'UNKNOWN',
+  'BOOKED',
+  'IN_TRANSIT',
+  'ARRIVED_AT_POD',
+  'DISCHARGED',
+  'DELIVERED',
+] as const
+
+type ProcessLifecycleStatus = (typeof PROCESS_STATUS_ORDER)[number]
+
+const PROCESS_STATUS_ORDER_INDEX: Readonly<Record<ProcessLifecycleStatus, number>> = {
+  UNKNOWN: 0,
+  BOOKED: 1,
+  IN_TRANSIT: 2,
+  ARRIVED_AT_POD: 3,
+  DISCHARGED: 4,
+  DELIVERED: 5,
+}
+
 const MICROBADGE_MEANINGFUL_STATUSES: ReadonlySet<OperationalStatus> = new Set([
   'ARRIVED_AT_POD',
   'DISCHARGED',
@@ -71,50 +91,26 @@ const MICROBADGE_MEANINGFUL_STATUSES: ReadonlySet<OperationalStatus> = new Set([
   'EMPTY_RETURNED',
 ])
 
-/**
- * Process pre-shipment phase mapped from container lifecycle.
- */
-const PRE_SHIPMENT_STATUSES: ReadonlySet<OperationalStatus> = new Set(['UNKNOWN', 'IN_PROGRESS'])
-
-/**
- * Transportation + arrival statuses keep the process operationally in transit.
- */
-const TRANSIT_STATUSES: ReadonlySet<OperationalStatus> = new Set([
-  'LOADED',
-  'IN_TRANSIT',
-  'ARRIVED_AT_POD',
-])
-
-/**
- * Arrival/port operation statuses that are not completed yet.
- */
-const ARRIVAL_RISK_STATUSES: ReadonlySet<OperationalStatus> = new Set([
-  'DISCHARGED',
-  'AVAILABLE_FOR_PICKUP',
-])
-
-/**
- * Final completion statuses.
- */
-const FINAL_DELIVERY_STATUSES: ReadonlySet<OperationalStatus> = new Set([
-  'DELIVERED',
-  'EMPTY_RETURNED',
-])
-
-function isPreShipment(status: OperationalStatus): boolean {
-  return PRE_SHIPMENT_STATUSES.has(status)
+function toProcessLifecycleStatus(status: OperationalStatus): ProcessLifecycleStatus {
+  if (status === 'UNKNOWN') return 'UNKNOWN'
+  if (status === 'IN_PROGRESS') return 'BOOKED'
+  if (status === 'LOADED' || status === 'IN_TRANSIT') return 'IN_TRANSIT'
+  if (status === 'ARRIVED_AT_POD') return 'ARRIVED_AT_POD'
+  if (status === 'DISCHARGED' || status === 'AVAILABLE_FOR_PICKUP') return 'DISCHARGED'
+  return 'DELIVERED'
 }
 
-function isTransit(status: OperationalStatus): boolean {
-  return TRANSIT_STATUSES.has(status)
+function isKnownProcessLifecycleStatus(
+  status: ProcessLifecycleStatus,
+): status is Exclude<ProcessLifecycleStatus, 'UNKNOWN'> {
+  return status !== 'UNKNOWN'
 }
 
-function isArrivalRisk(status: OperationalStatus): boolean {
-  return ARRIVAL_RISK_STATUSES.has(status)
-}
-
-function isFinalDelivery(status: OperationalStatus): boolean {
-  return FINAL_DELIVERY_STATUSES.has(status)
+function compareProcessLifecycleProgress(
+  left: ProcessLifecycleStatus,
+  right: ProcessLifecycleStatus,
+): number {
+  return PROCESS_STATUS_ORDER_INDEX[left] - PROCESS_STATUS_ORDER_INDEX[right]
 }
 
 function createEmptyOperationalStatusCounts(): MutableOperationalStatusCounts {
@@ -229,6 +225,10 @@ function toPrimaryStatusOrderIndex(primaryStatus: ProcessAggregatedStatus): numb
     return OPERATIONAL_STATUS_ORDER_INDEX.IN_TRANSIT
   }
 
+  if (primaryStatus === 'ARRIVED_AT_POD') {
+    return OPERATIONAL_STATUS_ORDER_INDEX.ARRIVED_AT_POD
+  }
+
   if (primaryStatus === 'DISCHARGED') {
     return OPERATIONAL_STATUS_ORDER_INDEX.DISCHARGED
   }
@@ -268,7 +268,7 @@ function resolveProcessStatusMicrobadge(command: {
   return null
 }
 
-export function deriveOperationalStatusCounts(
+function deriveOperationalStatusCounts(
   statuses: readonly OperationalStatus[],
 ): OperationalStatusCounts {
   const statusCounts = createEmptyOperationalStatusCounts()
@@ -306,30 +306,26 @@ export function deriveProcessStatusFromContainers(
   statuses: readonly OperationalStatus[],
 ): ProcessAggregatedStatus {
   if (statuses.length === 0) return 'UNKNOWN'
-  if (statuses.every((status) => status === 'UNKNOWN')) return 'UNKNOWN'
 
-  const allFinal = statuses.every(isFinalDelivery)
-  if (allFinal) return 'DELIVERED'
-
-  const allDischargedOrBeyond = statuses.every(
-    (status) => isArrivalRisk(status) || isFinalDelivery(status),
-  )
-  const hasArrivalRisk = statuses.some(isArrivalRisk)
-  if (allDischargedOrBeyond && hasArrivalRisk) {
-    return 'DISCHARGED'
+  const mappedStatuses = statuses.map(toProcessLifecycleStatus)
+  const knownStatuses = mappedStatuses.filter(isKnownProcessLifecycleStatus)
+  if (knownStatuses.length === 0) {
+    return 'UNKNOWN'
   }
 
-  const hasTransit = statuses.some(isTransit)
-  if (hasTransit) {
-    return 'IN_TRANSIT'
+  const firstKnownStatus = knownStatuses[0]
+  if (firstKnownStatus === undefined) {
+    return 'UNKNOWN'
   }
 
-  const allPreShipment = statuses.every(isPreShipment)
-  const hasPreShipmentEvidence = statuses.some((status) => status !== 'UNKNOWN')
-  if (allPreShipment && hasPreShipmentEvidence) {
-    return 'BOOKED'
+  let minimumProgressStatus: ProcessLifecycleStatus = firstKnownStatus
+  for (let index = 1; index < knownStatuses.length; index += 1) {
+    const candidate = knownStatuses[index]
+    if (candidate === undefined) continue
+    if (compareProcessLifecycleProgress(candidate, minimumProgressStatus) < 0) {
+      minimumProgressStatus = candidate
+    }
   }
 
-  // Conservative fallback for mixed/inconsistent groups.
-  return 'IN_TRANSIT'
+  return minimumProgressStatus
 }

--- a/src/modules/process/features/operational-projection/application/operationalSemantics.ts
+++ b/src/modules/process/features/operational-projection/application/operationalSemantics.ts
@@ -13,6 +13,7 @@ export type ProcessAggregatedStatus =
   | 'UNKNOWN'
   | 'BOOKED'
   | 'IN_TRANSIT'
+  | 'ARRIVED_AT_POD'
   | 'DISCHARGED'
   | 'DELIVERED'
   | 'AWAITING_DATA'

--- a/src/modules/process/features/operational-projection/application/tests/aggregateOperationalSummary.test.ts
+++ b/src/modules/process/features/operational-projection/application/tests/aggregateOperationalSummary.test.ts
@@ -97,7 +97,7 @@ describe('aggregateOperationalSummary', () => {
     expect(result.status_counts.UNKNOWN).toBe(2)
   })
 
-  it('returns IN_TRANSIT when observations exist and at least one container is in transit phase', () => {
+  it('returns BOOKED when observations include both pre-shipment and transit statuses', () => {
     const summaries = [
       makeSummary({
         status: 'IN_PROGRESS',
@@ -111,7 +111,7 @@ describe('aggregateOperationalSummary', () => {
 
     const result = aggregateOperationalSummary('p1', null, null, 2, summaries)
 
-    expect(result.process_status).toBe('IN_TRANSIT')
+    expect(result.process_status).toBe('BOOKED')
   })
 
   it('derives ARRIVED_AT_POD microbadge when process primary status is IN_TRANSIT', () => {

--- a/src/modules/process/features/operational-projection/application/tests/deriveProcessStatus.test.ts
+++ b/src/modules/process/features/operational-projection/application/tests/deriveProcessStatus.test.ts
@@ -9,40 +9,58 @@ describe('deriveProcessStatusFromContainers', () => {
     expect(deriveProcessStatusFromContainers([])).toBe('UNKNOWN')
   })
 
+  it('returns UNKNOWN when all containers are UNKNOWN', () => {
+    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'UNKNOWN'])).toBe('UNKNOWN')
+  })
+
+  it('returns BOOKED when all known statuses are pre-shipment', () => {
+    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'IN_PROGRESS'])).toBe('BOOKED')
+  })
+
   it('returns IN_TRANSIT for single transit container', () => {
     expect(deriveProcessStatusFromContainers(['IN_TRANSIT'])).toBe('IN_TRANSIT')
+  })
+
+  it('returns ARRIVED_AT_POD for single arrived-at-pod container', () => {
+    expect(deriveProcessStatusFromContainers(['ARRIVED_AT_POD'])).toBe('ARRIVED_AT_POD')
+  })
+
+  it('ignores UNKNOWN when there are known statuses', () => {
+    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'ARRIVED_AT_POD'])).toBe('ARRIVED_AT_POD')
+  })
+
+  it('returns IN_TRANSIT when IN_TRANSIT and ARRIVED_AT_POD are mixed', () => {
+    expect(deriveProcessStatusFromContainers(['IN_TRANSIT', 'ARRIVED_AT_POD'])).toBe('IN_TRANSIT')
+  })
+
+  it('returns ARRIVED_AT_POD when ARRIVED_AT_POD and DISCHARGED are mixed', () => {
+    expect(deriveProcessStatusFromContainers(['ARRIVED_AT_POD', 'DISCHARGED'])).toBe(
+      'ARRIVED_AT_POD',
+    )
   })
 
   it('returns IN_TRANSIT when transit and discharged are mixed', () => {
     expect(deriveProcessStatusFromContainers(['IN_TRANSIT', 'DISCHARGED'])).toBe('IN_TRANSIT')
   })
 
-  it('returns DISCHARGED when all are discharged', () => {
-    expect(deriveProcessStatusFromContainers(['DISCHARGED', 'DISCHARGED'])).toBe('DISCHARGED')
-  })
-
-  it('returns DISCHARGED when all are discharged or beyond and at least one is not delivered', () => {
-    expect(deriveProcessStatusFromContainers(['DISCHARGED', 'DELIVERED'])).toBe('DISCHARGED')
-  })
-
   it('returns IN_TRANSIT when any container is loaded/on-route/arrived', () => {
     expect(deriveProcessStatusFromContainers(['LOADED', 'ARRIVED_AT_POD'])).toBe('IN_TRANSIT')
   })
 
-  it('returns BOOKED when all are pre-shipment', () => {
-    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'IN_PROGRESS'])).toBe('BOOKED')
+  it('returns DISCHARGED when all are discharged', () => {
+    expect(deriveProcessStatusFromContainers(['DISCHARGED', 'DISCHARGED'])).toBe('DISCHARGED')
   })
 
-  it('returns UNKNOWN when all containers are UNKNOWN', () => {
-    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'UNKNOWN'])).toBe('UNKNOWN')
+  it('returns DISCHARGED when discharged and delivered are mixed', () => {
+    expect(deriveProcessStatusFromContainers(['DISCHARGED', 'DELIVERED'])).toBe('DISCHARGED')
   })
 
   it('returns DELIVERED when all are completed', () => {
     expect(deriveProcessStatusFromContainers(['DELIVERED', 'EMPTY_RETURNED'])).toBe('DELIVERED')
   })
 
-  it('uses IN_TRANSIT fallback for mixed unknown + post-arrival', () => {
-    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'DISCHARGED'])).toBe('IN_TRANSIT')
+  it('ignores UNKNOWN for mixed unknown + post-arrival', () => {
+    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'DISCHARGED'])).toBe('DISCHARGED')
   })
 
   it('keeps IN_TRANSIT when one unknown and one in transit', () => {

--- a/src/modules/process/ui/mappers/processDetail.ui-mapper.ts
+++ b/src/modules/process/ui/mappers/processDetail.ui-mapper.ts
@@ -45,6 +45,7 @@ function toProcessAggregatedStatus(status: string | null | undefined): ProcessAg
     case 'UNKNOWN':
     case 'BOOKED':
     case 'IN_TRANSIT':
+    case 'ARRIVED_AT_POD':
     case 'DISCHARGED':
     case 'DELIVERED':
     case 'AWAITING_DATA':
@@ -53,7 +54,6 @@ function toProcessAggregatedStatus(status: string | null | undefined): ProcessAg
     case 'IN_PROGRESS':
       return 'BOOKED'
     case 'LOADED':
-    case 'ARRIVED_AT_POD':
       return 'IN_TRANSIT'
     case 'AVAILABLE_FOR_PICKUP':
       return 'DISCHARGED'

--- a/src/modules/process/ui/mappers/tests/processDetail.arrived-status.ui-mapper.test.ts
+++ b/src/modules/process/ui/mappers/tests/processDetail.arrived-status.ui-mapper.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { toShipmentDetailVM } from '~/modules/process/ui/mappers/processDetail.ui-mapper'
+import type { ProcessDetailResponse } from '~/shared/api-schemas/processes.schemas'
+
+describe('toShipmentDetailVM ARRIVED_AT_POD mapping', () => {
+  it('keeps ARRIVED_AT_POD as process-level status', () => {
+    const example: ProcessDetailResponse = {
+      id: 'proc-arrived',
+      reference: 'REF-ARRIVED',
+      origin: { display_name: 'Tangier' },
+      destination: { display_name: 'Santos' },
+      carrier: 'maersk',
+      source: 'api',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      containers: [
+        {
+          id: 'c-arrived-1',
+          container_number: 'CAIU1234567',
+          status: 'ARRIVED_AT_POD',
+          observations: [],
+        },
+        {
+          id: 'c-arrived-2',
+          container_number: 'CAIU7654321',
+          status: 'ARRIVED_AT_POD',
+          observations: [],
+        },
+      ],
+      process_operational: {
+        derived_status: 'ARRIVED_AT_POD',
+        status_microbadge: null,
+        eta_max: null,
+        coverage: {
+          total: 2,
+          with_eta: 0,
+        },
+      },
+      containersSync: [],
+      alerts: [],
+    }
+
+    const result = toShipmentDetailVM(example)
+
+    expect(result.statusCode).toBe('ARRIVED_AT_POD')
+    expect(result.status).toBe('amber-500')
+  })
+})


### PR DESCRIPTION
This pull request refactors and clarifies the logic for deriving and mapping process lifecycle statuses in the shipment tracking system, with a particular focus on the handling of the `ARRIVED_AT_POD` status. It introduces a more systematic and ordered approach to process status aggregation, updates translations for consistency, and adds comprehensive tests to ensure correct behavior.

**Key changes:**

### Process Status Derivation and Aggregation

* Introduced a new lifecycle status, `ARRIVED_AT_POD`, into the process status order and aggregation logic, and refactored the mapping to use a clear, ordered array (`PROCESS_STATUS_ORDER`) and index mapping for comparison. The new logic ensures that the most "in-progress" status is always chosen, and that `UNKNOWN` statuses are ignored if there are known statuses present. (`src/modules/process/features/operational-projection/application/deriveProcessStatus.ts`) [[1]](diffhunk://#diff-7f0bffe7d2bdaed134a3b7c710716865acf6f872e402fbfc37227e68e224ba38L66-R113) [[2]](diffhunk://#diff-7f0bffe7d2bdaed134a3b7c710716865acf6f872e402fbfc37227e68e224ba38L309-R330) [[3]](diffhunk://#diff-7f0bffe7d2bdaed134a3b7c710716865acf6f872e402fbfc37227e68e224ba38R228-R231)
* Updated the `ProcessAggregatedStatus` type to include `ARRIVED_AT_POD`, ensuring type safety and consistency throughout the codebase. (`src/modules/process/features/operational-projection/application/operationalSemantics.ts`)

### UI Mapping and Presentation

* Updated the UI mapping logic to correctly handle and display the new `ARRIVED_AT_POD` status at the process level, and added a dedicated test to verify this behavior. (`src/modules/process/ui/mappers/processDetail.ui-mapper.ts`, `src/modules/process/ui/mappers/tests/processDetail.arrived-status.ui-mapper.test.ts`) [[1]](diffhunk://#diff-606c2a0370fcacfb05f1fb0d0903d861e13c121d62ec2104f22ada35337f6e4cR48) [[2]](diffhunk://#diff-606c2a0370fcacfb05f1fb0d0903d861e13c121d62ec2104f22ada35337f6e4cL56) [[3]](diffhunk://#diff-b45c6923fa75cae33ac42948e636a2255be94dcf2693304f99aefc29997271beR1-R48)

### Internationalization

* Shortened and clarified the translation strings for `ARRIVED_AT_POD` in English, Brazilian Portuguese, and European Portuguese to ensure consistency and accuracy in status labeling. (`src/locales/en-US.json`, `src/locales/pt-BR.json`, `src/locales/pt-PT.json`) [[1]](diffhunk://#diff-536a4668fb27a29187f589d8b586399b8f6ccd287f1e906c70bede98689baa87L587-R587) [[2]](diffhunk://#diff-8f3a0cf8394e26b3755643fc71adc9d48caffe815b748da3cc521976bb524f7cL598-R598) [[3]](diffhunk://#diff-c791c52513cb74ead2488a0d46893ff64917f06c4bcc9adedd89944f6c16a687L598-R598)

### Testing

* Added and updated comprehensive tests for process status aggregation, including new scenarios for `ARRIVED_AT_POD` and mixed status cases, ensuring the new logic is robust and correct. (`src/modules/process/features/operational-projection/application/tests/deriveProcessStatus.test.ts`, `src/modules/process/features/operational-projection/application/tests/aggregateOperationalSummary.test.ts`) [[1]](diffhunk://#diff-8c2c6a82d1a3d0f6fc40ae6a7f1e17beba342dae5bb392e7aaf6f467adaf2430R12-R63) [[2]](diffhunk://#diff-5b562d1103db0fabcac4ade5dc0895baf2e0e452a9e8cbba006aae12d5b60347L100-R100) [[3]](diffhunk://#diff-5b562d1103db0fabcac4ade5dc0895baf2e0e452a9e8cbba006aae12d5b60347L114-R114)
* 

### Summary
Treat "arrived at POD" as a distinct process status in the operational/status derivation and UI mapping; update semantics, tests and locale strings so the timeline and alerts represent this fact separately.

### What changed
- Derive an explicit "arrived at POD" process status in `src/modules/process/.../deriveProcessStatus.ts`
- Adjust operational semantics used for status/timeline derivation
- Add UI mapper and test for arrived-status (`src/modules/process/ui/mappers/tests/processDetail.arrived-status.ui-mapper.test.ts`)
- Update unit tests (`deriveProcessStatus.test.ts`, `aggregateOperationalSummary.test.ts`) to cover the new status handling
- Update localization files (`src/locales/en-US.json`, `src/locales/pt-BR.json`, `src/locales/pt-PT.json`)
- Bump canary manifest entries (agent-manifests/canary.json) as part of the release artifacts

### Why
Previously arrival-at-POD facts could be conflated with other statuses, hiding an important actual event in the timeline. Representing "arrived at POD" as a distinct status preserves facts, reduces ambiguity, and aligns with tracking invariants (append-only observations, derived status).

### How to test / QA steps
1. Run linters and tests:
   - pnpm flint
   - pnpm test
2. Run the deriveProcessStatus unit tests:
   - Verify `deriveProcessStatus` tests pass and cover arrived-at-POD scenarios
3. Run the UI mapper tests:
   - Confirm `processDetail.arrived-status.ui-mapper.test.ts` passes
4. Manual QA:
   - Start the app or story fixture and load a process with an "arrived at POD" observation
   - Confirm timeline shows a distinct "Arrived at POD" entry and the process detail renders the new status
5. Verify locale strings:
   - Check English, pt-BR and pt-PT translations render correctly for the new status

### Related issues / references
Branch: `hotfix/in-progrees-but-already-pod` (compare `develop` -> branch; includes refactor commit: treat arrived at POD as distinct process status)

### Suggested reviewers and labels
Reviewers: @tracking-team, @backend-team  
Labels: `bug`, `needs-review`, `i18n`