### PR TITLE
Fix initialization order of badge labels in TimelineNode

### DIFF
--- a/src/modules/process/ui/components/TimelineNode.tsx
+++ b/src/modules/process/ui/components/TimelineNode.tsx
@@ -208,16 +208,6 @@ export function TimelineNode(props: {
     const trackUrl = carrierTrackUrl(props.carrier ?? null, props.containerNumber ?? '')
     return typeof trackUrl === 'string' ? trackUrl : undefined
   })
-  const nonMappedBadgeLabel = createMemo(() =>
-    labelPresentation().showNonMappedIndicator
-      ? labelPresentation().nonMappedIndicatorLabel
-      : undefined,
-  )
-  const emptyContainerBadgeLabel = createMemo(() =>
-    props.observation?.isEmpty === true
-      ? t(keys.shipmentView.timeline.emptyContainerBadge)
-      : undefined,
-  )
 
   const labelPresentation = createMemo(() => {
     const indicatorVariant = props.nonMappedIndicatorVariant ?? 'badge'
@@ -237,6 +227,16 @@ export function TimelineNode(props: {
       label: currentLabel,
     }
   })
+  const nonMappedBadgeLabel = createMemo(() =>
+    labelPresentation().showNonMappedIndicator
+      ? labelPresentation().nonMappedIndicatorLabel
+      : undefined,
+  )
+  const emptyContainerBadgeLabel = createMemo(() =>
+    props.observation?.isEmpty === true
+      ? t(keys.shipmentView.timeline.emptyContainerBadge)
+      : undefined,
+  )
 
   const etaChipLabel = createMemo(() => {
     // ETA chip removed: render expected date on the right instead.


### PR DESCRIPTION
## Summary

- What changed: Moved the initialization of `nonMappedBadgeLabel` and `emptyContainerBadgeLabel` before their usage in the `TimelineNode` component.
- Why: Ensures that these labels are properly initialized before being referenced, preventing potential runtime errors.

## Architecture Boundary

- [x] Affected boundary is explicit (`ui`)
- [x] Placement is justified (folder + file role match responsibility)
- [x] No forbidden dependency direction was introduced (`modules -> capabilities`, `domain -> transport/ui`)

## Validation / Parsing Mode (ADR-0021)

- [x] Parsing mode is explicit in the changed code:
  - [x] `UI permissive parsing`
- [x] Domain remains free of transport schema/decode helpers
- [x] `*.validation.ts` files do not perform network/cache/orchestration IO
- [x] Parse/decode failures remain explicit (no silent suppression)

## Hotspot Impact

- [x] This PR does not increase hotspot concentration without rationale
- [ ] If a hotspot grew, rationale and follow-up are documented below
- [ ] Related hotspot (if any):
- [ ] Follow-up action and target sprint:

## ADR Decision Gate

- [x] Existing docs/ADRs were sufficient for this change
- [ ] If proposing new ADR, evidence is attached:
  - [ ] recurrence across multiple points
  - [ ] boundary/layer ownership impact
  - [ ] insufficiency of existing docs
  - [ ] cannot be solved by local refactor/checklist

## Checks

- [x] `pnpm check` is green locally
- [x] Relevant tests for changed behavior were updated

