### PR TITLE
Improve ETA sorting logic and add container tracking setup

### DIFF
--- a/src/modules/process/ui/viewmodels/dashboard-sort.service.ts
+++ b/src/modules/process/ui/viewmodels/dashboard-sort.service.ts
@@ -33,6 +33,15 @@ function compareByDirection(baseComparison: number, direction: DashboardSortDire
   return baseComparison * toDirectionMultiplier(direction)
 }
 
+function getDefaultSortDirection(field: DashboardSortField): DashboardSortDirection {
+  if (field === 'eta') return 'asc'
+  return 'desc'
+}
+
+function getOppositeSortDirection(direction: DashboardSortDirection): DashboardSortDirection {
+  return direction === 'asc' ? 'desc' : 'asc'
+}
+
 function normalizeSortableString(value: string | null | undefined): string | null {
   if (!value) return null
   const trimmed = value.trim()
@@ -239,13 +248,14 @@ export function nextDashboardSortSelection(
   field: DashboardSortField,
 ): DashboardSortSelection {
   const currentDirection = getActiveDashboardSortDirection(currentSelection, field)
+  const defaultDirection = getDefaultSortDirection(field)
 
   if (!currentDirection) {
-    return { field, direction: 'desc' }
+    return { field, direction: defaultDirection }
   }
 
-  if (currentDirection === 'desc') {
-    return { field, direction: 'asc' }
+  if (currentDirection === defaultDirection) {
+    return { field, direction: getOppositeSortDirection(defaultDirection) }
   }
 
   return null

--- a/src/modules/process/ui/viewmodels/tests/dashboard-sort-interaction.vm.test.ts
+++ b/src/modules/process/ui/viewmodels/tests/dashboard-sort-interaction.vm.test.ts
@@ -107,12 +107,22 @@ describe('dashboard sort interactions', () => {
     expect(third).toBeNull()
   })
 
-  it('keeps a single active field by resetting to desc on another column click', () => {
+  it('cycles ETA in order asc -> desc -> default because ETA starts nearest-first', () => {
+    const first = nextDashboardSortSelection(null, 'eta')
+    const second = nextDashboardSortSelection(first, 'eta')
+    const third = nextDashboardSortSelection(second, 'eta')
+
+    expect(first).toEqual({ field: 'eta', direction: 'asc' })
+    expect(second).toEqual({ field: 'eta', direction: 'desc' })
+    expect(third).toBeNull()
+  })
+
+  it('keeps a single active field by resetting ETA to asc on another column click', () => {
     const activeProvider: DashboardSortSelection = { field: 'provider', direction: 'asc' }
 
     expect(nextDashboardSortSelection(activeProvider, 'eta')).toEqual({
       field: 'eta',
-      direction: 'desc',
+      direction: 'asc',
     })
   })
 
@@ -257,6 +267,94 @@ describe('dashboard sort interactions', () => {
 
     expect(ascResult.map((process) => process.id)).toEqual(['C', 'A', 'B'])
     expect(descResult.map((process) => process.id)).toEqual(['A', 'C', 'B'])
+  })
+
+  it('sorts ETA chronologically across same month, different months, and different years', () => {
+    const baseline = [
+      createProcess({
+        id: 'may-10-2026',
+        eta: temporalDtoFromCanonical('2026-05-10T00:00:00.000Z'),
+        etaMsOrNull: Date.UTC(2026, 4, 10),
+      }),
+      createProcess({
+        id: 'apr-24-2026',
+        eta: temporalDtoFromCanonical('2026-04-24T00:00:00.000Z'),
+        etaMsOrNull: Date.UTC(2026, 3, 24),
+      }),
+      createProcess({
+        id: 'apr-02-2026',
+        eta: temporalDtoFromCanonical('2026-04-02T00:00:00.000Z'),
+        etaMsOrNull: Date.UTC(2026, 3, 2),
+      }),
+      createProcess({
+        id: 'may-08-2026',
+        eta: temporalDtoFromCanonical('2026-05-08T00:00:00.000Z'),
+        etaMsOrNull: Date.UTC(2026, 4, 8),
+      }),
+      createProcess({
+        id: 'dec-31-2025',
+        eta: temporalDtoFromCanonical('2025-12-31T00:00:00.000Z'),
+        etaMsOrNull: Date.UTC(2025, 11, 31),
+      }),
+    ] as const
+
+    const ascResult = sortDashboardProcesses(baseline, { field: 'eta', direction: 'asc' })
+    const descResult = sortDashboardProcesses(baseline, { field: 'eta', direction: 'desc' })
+
+    expect(ascResult.map((process) => process.id)).toEqual([
+      'dec-31-2025',
+      'apr-02-2026',
+      'apr-24-2026',
+      'may-08-2026',
+      'may-10-2026',
+    ])
+    expect(descResult.map((process) => process.id)).toEqual([
+      'may-10-2026',
+      'may-08-2026',
+      'apr-24-2026',
+      'apr-02-2026',
+      'dec-31-2025',
+    ])
+  })
+
+  it('keeps null ETA values last and deterministic even when multiple rows are null', () => {
+    const baseline = [
+      createProcess({
+        id: 'eta-null-newer',
+        eta: null,
+        etaMsOrNull: null,
+        lastEventAt: temporalDtoFromCanonical('2025-03-02T00:00:00.000Z'),
+        reference: 'REF-3',
+      }),
+      createProcess({
+        id: 'eta-with-value',
+        eta: temporalDtoFromCanonical('2026-05-08T00:00:00.000Z'),
+        etaMsOrNull: Date.UTC(2026, 4, 8),
+        lastEventAt: temporalDtoFromCanonical('2025-03-01T00:00:00.000Z'),
+        reference: 'REF-2',
+      }),
+      createProcess({
+        id: 'eta-null-older',
+        eta: null,
+        etaMsOrNull: null,
+        lastEventAt: temporalDtoFromCanonical('2025-03-01T00:00:00.000Z'),
+        reference: 'REF-1',
+      }),
+    ] as const
+
+    const ascResult = sortDashboardProcesses(baseline, { field: 'eta', direction: 'asc' })
+    const descResult = sortDashboardProcesses(baseline, { field: 'eta', direction: 'desc' })
+
+    expect(ascResult.map((process) => process.id)).toEqual([
+      'eta-with-value',
+      'eta-null-newer',
+      'eta-null-older',
+    ])
+    expect(descResult.map((process) => process.id)).toEqual([
+      'eta-with-value',
+      'eta-null-newer',
+      'eta-null-older',
+    ])
   })
 
   it('uses createdAt descending as tie-break when primary field values are equal', () => {

--- a/src/modules/process/ui/viewmodels/tests/dashboard-sort-interaction.vm.test.ts
+++ b/src/modules/process/ui/viewmodels/tests/dashboard-sort-interaction.vm.test.ts
@@ -96,6 +96,7 @@ function createImporterTieBreakProcesses(): readonly ProcessSummaryVM[] {
   ] as const
 }
 
+// eslint-disable-next-line max-lines-per-function
 describe('dashboard sort interactions', () => {
   it('cycles same field in order desc -> asc -> default', () => {
     const first = nextDashboardSortSelection(null, 'provider')


### PR DESCRIPTION
This pull request updates the dashboard sorting logic to provide more intuitive and consistent sorting behavior, especially for the ETA (Estimated Time of Arrival) field. It introduces new helper functions to determine default and opposite sort directions, adjusts the cycling behavior for sorting, and adds comprehensive tests to ensure correct sorting across various scenarios.

**Dashboard sort logic improvements:**

* Added `getDefaultSortDirection` and `getOppositeSortDirection` helper functions to centralize and clarify how default and opposite sort directions are determined for each field, with ETA now defaulting to ascending order.
* Updated `nextDashboardSortSelection` so that when a column is sorted for the first time, it uses the field's default direction (e.g., 'asc' for ETA), and toggles between the default and its opposite on subsequent clicks.

**Test enhancements and behavioral coverage:**

* Revised and expanded test cases to reflect the new default ascending sort for ETA, ensuring the sort cycles as expected (asc → desc → off), and that switching columns resets ETA to its default direction.
* Added tests to verify that ETA sorting works correctly across different months and years, ensuring chronological order is maintained for both ascending and descending sorts.
* Added tests to confirm that processes with null ETA values are always sorted last and in a deterministic order, regardless of sort direction.