### PR TITLE
Fix crash on unknown carriers/providers (e.g. DB has new provider)

### DIFF
--- a/src/modules/tracking/domain/model/provider.ts
+++ b/src/modules/tracking/domain/model/provider.ts
@@ -3,3 +3,15 @@
  * Extensible — add new carriers here as they are integrated.
  */
 export type Provider = 'msc' | 'maersk' | 'cmacgm'
+
+/**
+ * Provider values that may appear in persisted legacy/external data.
+ *
+ * Read-side mappers should degrade unsupported providers to `unknown`
+ * instead of taking hot endpoints down.
+ */
+export type PersistedProvider = Provider | 'unknown'
+
+export function isKnownProvider(value: string): value is Provider {
+  return value === 'msc' || value === 'maersk' || value === 'cmacgm'
+}

--- a/src/modules/tracking/domain/model/snapshot.ts
+++ b/src/modules/tracking/domain/model/snapshot.ts
@@ -1,4 +1,4 @@
-import type { Provider } from '~/modules/tracking/domain/model/provider'
+import type { PersistedProvider, Provider } from '~/modules/tracking/domain/model/provider'
 
 /**
  * Snapshot — immutable record of what a carrier API returned at a given moment.
@@ -16,7 +16,7 @@ export type Snapshot = {
   container_id: string
 
   /** Provider that returned this data */
-  provider: Provider
+  provider: PersistedProvider
 
   /** When the API call was made (UTC ISO string) */
   fetched_at: string
@@ -31,4 +31,6 @@ export type Snapshot = {
 /**
  * Shape for inserting a new snapshot (id auto-generated on DB side).
  */
-export type NewSnapshot = Omit<Snapshot, 'id'>
+export type NewSnapshot = Omit<Snapshot, 'id' | 'provider'> & {
+  provider: Provider
+}

--- a/src/modules/tracking/features/alerts/domain/model/trackingAlert.ts
+++ b/src/modules/tracking/features/alerts/domain/model/trackingAlert.ts
@@ -1,4 +1,4 @@
-import type { Provider } from '~/modules/tracking/domain/model/provider'
+import type { PersistedProvider, Provider } from '~/modules/tracking/domain/model/provider'
 
 /**
  * Tracking Alert — derived signal from timeline/status analysis.
@@ -116,7 +116,7 @@ type TrackingAlertBase = {
   retroactive: boolean
 
   /** Provider, if attributable */
-  provider: Provider | null
+  provider: PersistedProvider | null
 
   /** When acknowledged by user (UTC ISO) */
   acked_at: string | null
@@ -160,7 +160,9 @@ export type TrackingAlertDerivationState = Pick<
 /**
  * Shape for inserting a new tracking alert.
  */
-type NewTrackingAlertBase = Omit<TrackingAlertBase, 'id'>
+type NewTrackingAlertBase = Omit<TrackingAlertBase, 'id' | 'provider'> & {
+  provider: Provider | null
+}
 export type NewTrackingAlert = NewTrackingAlertBase & TrackingAlertMessageContract
 
 export function resolveAlertLifecycleState(alert: {

--- a/src/modules/tracking/features/observation/application/orchestration/normalizeSnapshot.ts
+++ b/src/modules/tracking/features/observation/application/orchestration/normalizeSnapshot.ts
@@ -1,4 +1,4 @@
-import type { Provider } from '~/modules/tracking/domain/model/provider'
+import { isKnownProvider, type Provider } from '~/modules/tracking/domain/model/provider'
 import type { Snapshot } from '~/modules/tracking/domain/model/snapshot'
 import type { ObservationDraft } from '~/modules/tracking/features/observation/domain/model/observationDraft'
 import { normalizeCmaCgmSnapshot } from '~/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer'
@@ -29,6 +29,12 @@ const NORMALIZERS: Record<Provider, (snapshot: Snapshot) => ObservationDraft[]> 
  * @see docs/master-consolidated-0209.md §4.1
  */
 export function normalizeSnapshot(snapshot: Snapshot): ObservationDraft[] {
+  if (!isKnownProvider(snapshot.provider)) {
+    throw new Error(
+      `normalizeSnapshot: provider ${snapshot.provider} is not supported for normalization`,
+    )
+  }
+
   const normalizer = NORMALIZERS[snapshot.provider]
   return normalizer(snapshot)
 }

--- a/src/modules/tracking/features/observation/domain/model/observation.ts
+++ b/src/modules/tracking/features/observation/domain/model/observation.ts
@@ -1,4 +1,4 @@
-import type { Provider } from '~/modules/tracking/domain/model/provider'
+import type { PersistedProvider, Provider } from '~/modules/tracking/domain/model/provider'
 import type { Confidence } from '~/modules/tracking/features/observation/domain/model/observationDraft'
 import type { ObservationType } from '~/modules/tracking/features/observation/domain/model/observationType'
 import type { TemporalValue } from '~/shared/time/temporal-value'
@@ -79,7 +79,7 @@ export type Observation = {
   confidence: Confidence
 
   /** Provider that produced this data */
-  provider: Provider
+  provider: PersistedProvider
 
   /** Snapshot that first introduced this observation */
   created_from_snapshot_id: string
@@ -97,4 +97,6 @@ export type Observation = {
 /**
  * Shape for inserting — omits server-generated fields.
  */
-export type NewObservation = Omit<Observation, 'id' | 'created_at'>
+export type NewObservation = Omit<Observation, 'id' | 'created_at' | 'provider'> & {
+  provider: Provider
+}

--- a/src/modules/tracking/infrastructure/carriers/tests/tracking.persistence.mappers.test.ts
+++ b/src/modules/tracking/infrastructure/carriers/tests/tracking.persistence.mappers.test.ts
@@ -58,10 +58,9 @@ describe('observationRowToDomain', () => {
     expect(result.type).toBe('TERMINAL_MOVE')
   })
 
-  it('should throw for invalid provider', () => {
-    expect(() => observationRowToDomain({ ...validRow, provider: 'invalid' })).toThrow(
-      'not a valid provider',
-    )
+  it('should degrade unknown persisted provider to unknown', () => {
+    const result = observationRowToDomain({ ...validRow, provider: 'invalid' })
+    expect(result.provider).toBe('unknown')
   })
 
   it('should throw for invalid observation type', () => {
@@ -144,10 +143,9 @@ describe('snapshotRowToDomain', () => {
     expect(result.payload).toEqual({ test: 'data' })
   })
 
-  it('should throw for invalid provider', () => {
-    expect(() => snapshotRowToDomain({ ...validRow, provider: 'unknown_carrier' })).toThrow(
-      'not a valid provider',
-    )
+  it('should degrade unknown persisted provider to unknown', () => {
+    const result = snapshotRowToDomain({ ...validRow, provider: 'unknown_carrier' })
+    expect(result.provider).toBe('unknown')
   })
 
   it('should throw for invalid timestamp', () => {
@@ -242,6 +240,11 @@ describe('alertRowToDomain', () => {
   it('should handle null provider', () => {
     const result = alertRowToDomain({ ...validRow, provider: null })
     expect(result.provider).toBeNull()
+  })
+
+  it('should degrade unknown persisted alert provider to unknown', () => {
+    const result = alertRowToDomain({ ...validRow, provider: 'pil' })
+    expect(result.provider).toBe('unknown')
   })
 
   it('should normalize space-separated timestamps', () => {

--- a/src/modules/tracking/infrastructure/carriers/tests/tracking.persistence.mappers.test.ts
+++ b/src/modules/tracking/infrastructure/carriers/tests/tracking.persistence.mappers.test.ts
@@ -258,7 +258,7 @@ describe('alertRowToDomain', () => {
   })
 
   it('should degrade unknown persisted alert provider to unknown', () => {
-    const result = alertRowToDomain({ ...validRow, provider: 'pil' })
+    const result = alertRowToDomain({ ...validRow, provider: 'thisproviderwillneverexist' })
     expect(result.provider).toBe('unknown')
   })
 

--- a/src/modules/tracking/infrastructure/persistence/tracking.alert.persistence.mappers.ts
+++ b/src/modules/tracking/infrastructure/persistence/tracking.alert.persistence.mappers.ts
@@ -13,7 +13,7 @@ import {
   isRecord,
   normalizeAlertIso,
   optionalFiniteNumber,
-  optionalProvider,
+  optionalReadProvider,
   requireFiniteNumber,
   requireString,
 } from '~/modules/tracking/infrastructure/persistence/tracking.persistence.mapper-primitives'
@@ -261,7 +261,7 @@ export function alertRowToDomain(row: TrackingAlertRow): TrackingAlert {
     source_observation_fingerprints: fingerprints,
     alert_fingerprint: row.alert_fingerprint ?? null,
     retroactive: row.retroactive,
-    provider: optionalProvider(row.provider, 'alert.provider'),
+    provider: optionalReadProvider(row.provider, 'alert.provider'),
     acked_at: ackedAtIso,
     acked_by: row.acked_by ?? null,
     acked_source: optionalAlertAckSource(row.acked_source, 'alert.acked_source'),

--- a/src/modules/tracking/infrastructure/persistence/tracking.persistence.mapper-primitives.ts
+++ b/src/modules/tracking/infrastructure/persistence/tracking.persistence.mapper-primitives.ts
@@ -1,11 +1,9 @@
-import type { Provider } from '~/modules/tracking/domain/model/provider'
+import {
+  isKnownProvider,
+  type PersistedProvider,
+  type Provider,
+} from '~/modules/tracking/domain/model/provider'
 import { normalizeTimestamptz } from '~/shared/utils/normalizeTimestamptz'
-
-const PROVIDER_MAP: Record<string, Provider> = {
-  msc: 'msc',
-  maersk: 'maersk',
-  cmacgm: 'cmacgm',
-}
 
 export function requireString(value: unknown, field: string): string {
   if (typeof value !== 'string' || value.length === 0) {
@@ -15,17 +13,22 @@ export function requireString(value: unknown, field: string): string {
 }
 
 export function requireProvider(value: unknown, field: string): Provider {
-  const s = requireString(value, field)
-  const mapped = PROVIDER_MAP[s]
-  if (mapped === undefined) {
-    throw new Error(`tracking persistence mapper: ${field} is not a valid provider: ${s}`)
+  const provider = requireString(value, field)
+  if (!isKnownProvider(provider)) {
+    throw new Error(`tracking persistence mapper: ${field} is not a valid provider: ${provider}`)
   }
-  return mapped
+  return provider
 }
 
-export function optionalProvider(value: unknown, field: string): Provider | null {
+export function readProvider(value: unknown, field: string): PersistedProvider {
+  const provider = requireString(value, field)
+  if (isKnownProvider(provider)) return provider
+  return 'unknown'
+}
+
+export function optionalReadProvider(value: unknown, field: string): PersistedProvider | null {
   if (value === null || value === undefined) return null
-  return requireProvider(value, field)
+  return readProvider(value, field)
 }
 
 export function requireFiniteNumber(value: unknown, field: string): number {

--- a/src/modules/tracking/infrastructure/persistence/tracking.persistence.mappers.ts
+++ b/src/modules/tracking/infrastructure/persistence/tracking.persistence.mappers.ts
@@ -26,7 +26,7 @@ import {
   alertToInsertRow as mapAlertToInsertRow,
 } from '~/modules/tracking/infrastructure/persistence/tracking.alert.persistence.mappers'
 import {
-  requireProvider,
+  readProvider,
   requireString,
   requireTimestamp,
 } from '~/modules/tracking/infrastructure/persistence/tracking.persistence.mapper-primitives'
@@ -200,7 +200,7 @@ export function observationRowToDomain(row: TrackingObservationRow): Observation
     voyage: row.voyage,
     is_empty: row.is_empty,
     confidence: requireConfidence(row.confidence, 'observation.confidence'),
-    provider: requireProvider(row.provider, 'observation.provider'),
+    provider: readProvider(row.provider, 'observation.provider'),
     created_from_snapshot_id: requireString(
       row.created_from_snapshot_id,
       'observation.created_from_snapshot_id',
@@ -244,7 +244,7 @@ export function snapshotRowToDomain(row: TrackingSnapshotRow): Snapshot {
   return {
     id: requireString(row.id, 'snapshot.id'),
     container_id: requireString(row.container_id, 'snapshot.container_id'),
-    provider: requireProvider(row.provider, 'snapshot.provider'),
+    provider: readProvider(row.provider, 'snapshot.provider'),
     fetched_at: requireTimestamp(row.fetched_at, 'snapshot.fetched_at'),
     payload: row.payload,
     parse_error: row.parse_error,


### PR DESCRIPTION
This pull request introduces a new approach for handling provider values in persisted tracking data, allowing the system to gracefully degrade unsupported or unknown providers to 'unknown' instead of failing. This improves robustness when dealing with legacy or external data sources. The changes span domain models, persistence mappers, and test cases to ensure consistent handling of both known and unknown providers throughout the tracking module.

Key changes include:

**Provider Model & Type Handling:**
- Added a `PersistedProvider` type that extends the existing `Provider` type with an `'unknown'` value, and an `isKnownProvider` type guard function. This allows the system to distinguish between supported and unsupported providers in persisted data.
- Updated domain models (`Snapshot`, `Observation`, `TrackingAlert`) to use `PersistedProvider` for persisted/read-side types, while ensuring that new/inserted records still require a known `Provider`. [[1]](diffhunk://#diff-1a6a119d01328490f90e929c47e7db22c9bbdc70ba34438e6b014b0f6aa2b850L1-R1) [[2]](diffhunk://#diff-1a6a119d01328490f90e929c47e7db22c9bbdc70ba34438e6b014b0f6aa2b850L19-R19) [[3]](diffhunk://#diff-1a6a119d01328490f90e929c47e7db22c9bbdc70ba34438e6b014b0f6aa2b850L34-R36) [[4]](diffhunk://#diff-45402ba731c4800b57e71f745206495260151a77aea4c2c0482529715b5332d3L1-R1) [[5]](diffhunk://#diff-45402ba731c4800b57e71f745206495260151a77aea4c2c0482529715b5332d3L119-R119) [[6]](diffhunk://#diff-45402ba731c4800b57e71f745206495260151a77aea4c2c0482529715b5332d3L163-R165) [[7]](diffhunk://#diff-c0b155bbfe6a59f5fc1a83b45e804242cd2596285471f1672063df95b39bfc1bL1-R1) [[8]](diffhunk://#diff-c0b155bbfe6a59f5fc1a83b45e804242cd2596285471f1672063df95b39bfc1bL82-R82) [[9]](diffhunk://#diff-c0b155bbfe6a59f5fc1a83b45e804242cd2596285471f1672063df95b39bfc1bL100-R102)

**Persistence Mapper Improvements:**
- Replaced strict provider validation in read mappers with new `readProvider` and `optionalReadProvider` functions, which degrade unknown providers to `'unknown'` instead of throwing errors. [[1]](diffhunk://#diff-a661b73ac54430ffde6daaff0ea8a5a2408d5b1335470bf4f4289d5200055d88L1-L9) [[2]](diffhunk://#diff-a661b73ac54430ffde6daaff0ea8a5a2408d5b1335470bf4f4289d5200055d88L18-R31) [[3]](diffhunk://#diff-c8841f497d7294a921d570414e50a1cd499493a926a162a4a2a05c65f5618458L16-R16) [[4]](diffhunk://#diff-c8841f497d7294a921d570414e50a1cd499493a926a162a4a2a05c65f5618458L264-R264) [[5]](diffhunk://#diff-956fee6db08326dbf8ca65aaef2165f82dda571aef7211d0c8fc25c98ff69c20L29-R29) [[6]](diffhunk://#diff-956fee6db08326dbf8ca65aaef2165f82dda571aef7211d0c8fc25c98ff69c20L203-R203) [[7]](diffhunk://#diff-956fee6db08326dbf8ca65aaef2165f82dda571aef7211d0c8fc25c98ff69c20L247-R247)

**Normalization Logic:**
- Updated the snapshot normalization logic to explicitly throw an error if an attempt is made to normalize a snapshot from an unknown provider, ensuring only supported providers are processed. [[1]](diffhunk://#diff-252418d8e8799b28fff7fc75a499c64720633a5fcf2393bd8f8f4c20ba00bb29L1-R1) [[2]](diffhunk://#diff-252418d8e8799b28fff7fc75a499c64720633a5fcf2393bd8f8f4c20ba00bb29R32-R37)

**Test Coverage:**
- Adjusted and expanded tests to verify that unknown providers in persisted data are correctly degraded to `'unknown'` rather than causing errors, increasing system resilience. [[1]](diffhunk://#diff-dcb57d24ae227562de89f16efc54fb24375ca401b4bb2c34edc8d591f0607fd3L61-R63) [[2]](diffhunk://#diff-dcb57d24ae227562de89f16efc54fb24375ca401b4bb2c34edc8d591f0607fd3L147-R148) [[3]](diffhunk://#diff-dcb57d24ae227562de89f16efc54fb24375ca401b4bb2c34edc8d591f0607fd3R245-R249)