### PR TITLE
Update shipment header warning indicator for missing reference

### DIFF
--- a/src/modules/process/ui/components/ShipmentHeader.tsx
+++ b/src/modules/process/ui/components/ShipmentHeader.tsx
@@ -60,14 +60,14 @@ function InternalIdHint(props: InternalIdHintProps): JSX.Element {
   const [open, setOpen] = createSignal(false)
 
   return (
-    <span class="relative ml-2 inline-block align-middle">
+    <span class="relative inline-block align-middle">
       <button
         type="button"
         aria-label={props.message}
-        class="inline-flex h-4 w-4 items-center justify-center rounded-full bg-surface-muted text-xs-ui font-medium text-primary transition-transform hover:cursor-pointer hover:scale-110 hover:bg-surface-muted"
+        class="inline-flex h-4 w-16 p-2 text-xs align-text-top italic bold text-tone-warning-fg items-center justify-center rounded-full bg-tone-warning-bg text-xs-ui font-medium animate-pulse transition-transform hover:cursor-pointer hover:scale-110 hover:bg-surface-muted"
         onClick={() => setOpen((current) => !current)}
       >
-        i
+        sem ref
       </button>
       <Show when={open()}>
         <div

--- a/src/shared/ui/theme.css
+++ b/src/shared/ui/theme.css
@@ -57,7 +57,7 @@
   --color-tone-info-border: #bfdbfe;
   --color-tone-info-strong: #2563eb;
 
-  --color-tone-warning-bg: #fffbeb;
+  --color-tone-warning-bg: #fff9e0;
   --color-tone-warning-fg: #a16207;
   --color-tone-warning-border: #fde68a;
   --color-tone-warning-strong: #d97706;


### PR DESCRIPTION
This pull request updates the appearance and behavior of the internal ID hint button in the `ShipmentHeader` component, and slightly adjusts the warning background color in the theme. The main focus is on making the button more visually prominent and informative.

UI improvements to the internal ID hint button:

* Increased the button's width, padding, and changed its text from "i" to "sem ref" for clarity, as well as applying italic, bold, and warning-themed styles to make it stand out. The button now also animates with a pulse effect. (`src/modules/process/ui/components/ShipmentHeader.tsx`)

Theme update:

* Changed the warning background color variable `--color-tone-warning-bg` to a slightly different shade for improved visual distinction. (`src/shared/ui/theme.css`)
