### PR TITLE
Parse inline vessel from product field in Trello smart paste

### DIFF
--- a/src/modules/process/ui/validation/tests/trelloSmartPaste.validation.test.ts
+++ b/src/modules/process/ui/validation/tests/trelloSmartPaste.validation.test.ts
@@ -62,6 +62,24 @@ Reserva alternativa CAAU7648798`)
     expect(parsed.fields.containers).toEqual(['MRSU8798130', 'CAAU7648798'])
   })
 
+  it('splits product and vessel when NAVIO is pasted without a line break after product', () => {
+    const parsed = parseTrelloSmartPaste(`Título:
+REF. CASTRO: CA075-25 - IMP: FLUSH - EXP: AL-HAMDOLILLAH - SAL
+
+Descrição:
+PRODUTO: SALNAVIO: GSL VIOLETTA
+BL: MEDUP6124762
+CTNR: MSCU1234567`)
+
+    expect(parsed.fields.reference).toBe('CA075-25')
+    expect(parsed.fields.importerName).toBe('FLUSH')
+    expect(parsed.fields.exporterName).toBe('AL-HAMDOLILLAH')
+    expect(parsed.fields.product).toBe('SAL')
+    expect(parsed.fields.billOfLading).toBe('MEDUP6124762')
+    expect(parsed.fields.containers).toEqual(['MSCU1234567'])
+    expect(parsed.unmappedFields).toContainEqual({ label: 'NAVIO', value: 'GSL VIOLETTA' })
+  })
+
   it('returns warning when no valid container can be found', () => {
     const parsed = parseTrelloSmartPaste(`REF: ABC-001
 IMP: Empresa A

--- a/src/modules/process/ui/validation/trelloSmartPaste.validation.ts
+++ b/src/modules/process/ui/validation/trelloSmartPaste.validation.ts
@@ -36,6 +36,7 @@ type ParsedTitleFields = {
   readonly importerName?: string
   readonly exporterName?: string
   readonly product?: string
+  readonly unmappedFields: readonly ParsedUnmappedField[]
 }
 
 type ParsedLineFields = {
@@ -96,6 +97,24 @@ function extractContainerNumbers(rawText: string): readonly string[] {
   return dedupeStrings(
     matches.map((value) => normalizeContainerNumber(value)).filter((value) => value.length > 0),
   )
+}
+
+function splitProductValueFromInlineVessel(rawValue: string): {
+  readonly productValue: string
+  readonly vesselValue?: string
+} {
+  const productWithInlineVesselMatch = rawValue.match(
+    /^(?<productValue>.+?)\s*NAVIO\s*:\s*(?<vesselValue>.+)$/i,
+  )
+  const productValue = normalizeWhitespace(
+    productWithInlineVesselMatch?.groups?.productValue ?? rawValue,
+  )
+  const vesselValue = normalizeWhitespace(productWithInlineVesselMatch?.groups?.vesselValue ?? '')
+
+  return {
+    productValue,
+    ...(vesselValue.length === 0 ? {} : { vesselValue }),
+  }
 }
 
 function toLabelClassification(rawLabel: string): LabelClassification {
@@ -167,7 +186,7 @@ function toLabelClassification(rawLabel: string): LabelClassification {
 function parseTitleFields(rawTitle: string): ParsedTitleFields {
   const title = normalizeWhitespace(rawTitle)
   if (title.length === 0) {
-    return {}
+    return { unmappedFields: [] }
   }
 
   const segments = title
@@ -175,13 +194,14 @@ function parseTitleFields(rawTitle: string): ParsedTitleFields {
     .map((segment) => normalizeWhitespace(segment))
     .filter((segment) => segment.length > 0)
 
-  if (segments.length === 0) return {}
+  if (segments.length === 0) return { unmappedFields: [] }
 
   let reference: string | undefined
   let importerName: string | undefined
   let exporterName: string | undefined
   let product: string | undefined
   const leftovers: string[] = []
+  const unmappedFields: ParsedUnmappedField[] = []
 
   for (const segment of segments) {
     const referenceMatch = segment.match(/^REF\.?(?:\s+[^:]+)?\s*:\s*(.+)$/i)
@@ -204,7 +224,13 @@ function parseTitleFields(rawTitle: string): ParsedTitleFields {
 
     const productMatch = segment.match(/^PRODUTO\s*:\s*(.+)$/i)
     if (productMatch?.[1]) {
-      product = normalizeWhitespace(productMatch[1])
+      const productField = splitProductValueFromInlineVessel(productMatch[1])
+      product = productField.productValue
+
+      if (productField.vesselValue !== undefined) {
+        unmappedFields.push({ label: 'NAVIO', value: productField.vesselValue })
+      }
+
       continue
     }
 
@@ -212,7 +238,12 @@ function parseTitleFields(rawTitle: string): ParsedTitleFields {
   }
 
   if (!product && leftovers.length > 0) {
-    product = leftovers[leftovers.length - 1]
+    const fallbackProduct = splitProductValueFromInlineVessel(leftovers[leftovers.length - 1] ?? '')
+    product = fallbackProduct.productValue
+
+    if (fallbackProduct.vesselValue !== undefined) {
+      unmappedFields.push({ label: 'NAVIO', value: fallbackProduct.vesselValue })
+    }
   }
 
   return {
@@ -220,6 +251,7 @@ function parseTitleFields(rawTitle: string): ParsedTitleFields {
     ...(importerName === undefined ? {} : { importerName }),
     ...(exporterName === undefined ? {} : { exporterName }),
     ...(product === undefined ? {} : { product }),
+    unmappedFields,
   }
 }
 
@@ -299,6 +331,18 @@ function parseLineFields(lines: readonly string[]): ParsedLineFields {
 
     if (rawValue.length === 0) continue
     if (scalar[classification.key] !== undefined) continue
+
+    if (classification.key === 'product') {
+      const productField = splitProductValueFromInlineVessel(rawValue)
+      scalar.product = productField.productValue
+
+      if (productField.vesselValue !== undefined) {
+        unmappedFields.push({ label: 'NAVIO', value: productField.vesselValue })
+      }
+
+      continue
+    }
+
     scalar[classification.key] = rawValue
   }
 
@@ -367,7 +411,7 @@ export function parseTrelloSmartPaste(rawInput: string): ParsedProcessDraft {
 
   return {
     fields,
-    unmappedFields: lineFields.unmappedFields,
+    unmappedFields: [...titleFields.unmappedFields, ...lineFields.unmappedFields],
     warnings: buildWarnings({
       hasCarrier: Boolean(fields.carrier && fields.carrier.trim().length > 0),
       containers: mergedContainers,


### PR DESCRIPTION
This pull request enhances the parsing logic for Trello smart paste inputs, specifically improving how product and vessel information are extracted when they appear on the same line. It introduces logic to split inline vessel data from the product field and ensures that unmapped fields (such as vessel names) are captured and returned for further processing. Additionally, the test suite has been updated to cover these new parsing scenarios.

### Parsing improvements

* Added a `splitProductValueFromInlineVessel` function to detect and separate vessel names when they are included inline with the product (e.g., `PRODUTO: SALNAVIO: GSL VIOLETTA`), assigning the vessel name to an unmapped field labeled `NAVIO`.
* Updated both the title and line parsing logic to use the new split function, ensuring vessel names are always extracted from inline product fields and added to the `unmappedFields` array. [[1]](diffhunk://#diff-31c01aff31c999f0f6ec487cb2ac47761a279acbe0929e209b4a2be6de9d2130L207-R254) [[2]](diffhunk://#diff-31c01aff31c999f0f6ec487cb2ac47761a279acbe0929e209b4a2be6de9d2130R334-R345)
* Ensured that unmapped fields from both title and line parsing are combined and returned in the final parsed result.

### Type and structure changes

* Updated the `ParsedTitleFields` type to always include an `unmappedFields` property, improving type safety and consistency.
* Modified the title parsing function to always return an object with an `unmappedFields` array, even when the input is empty or contains no segments.

### Test coverage

* Added a test case to verify that the parser correctly splits product and vessel fields when `NAVIO` appears inline without a line break after the product.