### PR TITLE
Persist scroll position and highlight last opened process in dashboard

### DIFF
--- a/src/modules/process/ui/components/DashboardProcessTable.tsx
+++ b/src/modules/process/ui/components/DashboardProcessTable.tsx
@@ -24,6 +24,7 @@ import {
   SyncCell as SyncCellComponent,
   type SyncCellState,
 } from '~/modules/process/ui/components/SyncCell'
+import { toDashboardProcessRowClass } from '~/modules/process/ui/utils/dashboard-process-row-style'
 import {
   hasDashboardRowSelectedText,
   isInteractiveDashboardRowTarget,
@@ -51,6 +52,7 @@ type DashboardProcessSeverity = 'danger' | 'warning' | 'info' | 'success' | 'non
 
 type Props = {
   readonly processes: readonly ProcessSummaryVM[]
+  readonly highlightedProcessId: string | null
   readonly initialLoading: boolean
   readonly refreshing: boolean
   readonly hasError: boolean
@@ -66,6 +68,7 @@ type Props = {
 
 type RowProps = {
   readonly process: ProcessSummaryVM
+  readonly isHighlighted: boolean
   readonly columnOrder: readonly DashboardColumnId[]
   readonly gridStyle: string
   readonly onProcessSync: (processId: string) => Promise<void>
@@ -75,6 +78,7 @@ type RowProps = {
 
 type TableRowsProps = {
   readonly processes: readonly ProcessSummaryVM[]
+  readonly highlightedProcessId: string | null
   readonly sortSelection: DashboardSortSelection
   readonly onSortToggle: (field: DashboardSortField) => void
   readonly onProcessSync: (processId: string) => Promise<void>
@@ -141,13 +145,6 @@ function toSeverityBadgeClasses(severity: DashboardProcessSeverity): string {
   if (severity === 'success')
     return 'border-tone-success-border bg-tone-success-bg text-tone-success-fg'
   return 'border-border bg-surface-muted text-text-muted'
-}
-
-function getSeverityBorderClass(severity: DashboardProcessSeverity): string {
-  if (severity === 'danger') return '[box-shadow:inset_4px_0_0_0_var(--color-tone-danger-strong)]'
-  if (severity === 'warning') return '[box-shadow:inset_4px_0_0_0_var(--color-tone-warning-strong)]'
-  if (severity === 'info') return '[box-shadow:inset_4px_0_0_0_var(--color-tone-info-strong)]'
-  return ''
 }
 
 function toUnifiedAlertIcon(severity: DashboardProcessSeverity): JSX.Element {
@@ -603,7 +600,11 @@ function DashboardProcessRow(props: RowProps): JSX.Element {
       role="button"
       tabIndex={0}
       data-dashboard-process-id={props.process.id}
-      class={`grid min-h-(--dashboard-table-row-height) cursor-pointer items-center border-b border-border/50 bg-surface transition-colors hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 last:border-b-0 ${getSeverityBorderClass(dominantSeverity())}`}
+      data-dashboard-last-opened={props.isHighlighted ? 'true' : undefined}
+      class={toDashboardProcessRowClass({
+        severity: dominantSeverity(),
+        isHighlighted: props.isHighlighted,
+      })}
       style={{ 'grid-template-columns': props.gridStyle }}
       onClick={handleRowClick}
       onKeyDown={handleRowKeydown}
@@ -771,6 +772,7 @@ function DashboardProcessRows(props: TableRowsProps): JSX.Element {
           {(process) => (
             <DashboardProcessRow
               process={process}
+              isHighlighted={process.id === props.highlightedProcessId}
               columnOrder={props.columnOrder}
               gridStyle={gridStyle()}
               onProcessSync={props.onProcessSync}
@@ -906,6 +908,7 @@ export function DashboardProcessTable(props: Props): JSX.Element {
     return (
       <DashboardProcessRows
         processes={props.processes}
+        highlightedProcessId={props.highlightedProcessId}
         sortSelection={props.sortSelection}
         onSortToggle={props.onSortToggle}
         onProcessSync={props.onProcessSync}

--- a/src/modules/process/ui/components/tests/DashboardProcessTable.test.ts
+++ b/src/modules/process/ui/components/tests/DashboardProcessTable.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { toDashboardProcessRowClass } from '~/modules/process/ui/utils/dashboard-process-row-style'
+
+describe('toDashboardProcessRowClass', () => {
+  it('keeps the severity bar class while adding highlighted row treatment', () => {
+    const className = toDashboardProcessRowClass({
+      severity: 'danger',
+      isHighlighted: true,
+    })
+
+    expect(className).toContain('bg-primary/5')
+    expect(className).toContain('outline-primary/25')
+    expect(className).toContain('[box-shadow:inset_4px_0_0_0_var(--color-tone-danger-strong)]')
+  })
+
+  it('returns the default row background when the process is not highlighted', () => {
+    const className = toDashboardProcessRowClass({
+      severity: 'none',
+      isHighlighted: false,
+    })
+
+    expect(className).toContain('bg-surface')
+    expect(className).toContain('hover:bg-surface-muted')
+    expect(className).not.toContain('outline-primary/25')
+  })
+})

--- a/src/modules/process/ui/screens/DashboardScreen.tsx
+++ b/src/modules/process/ui/screens/DashboardScreen.tsx
@@ -34,6 +34,13 @@ import { toDashboardMonthlyBarDatumVMs } from '~/modules/process/ui/mappers/dash
 import { useDashboardFilterSortController } from '~/modules/process/ui/screens/dashboard/hooks/useDashboardFilterSortController'
 import { useDashboardSyncController } from '~/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController'
 import { resolveDashboardChartWindowSize } from '~/modules/process/ui/utils/dashboard-chart-window-size'
+import {
+  clearDashboardNavigationState,
+  readDashboardNavigationState,
+  resolveHighlightedDashboardProcessId,
+  restoreDashboardScrollPosition,
+  saveDashboardNavigationState,
+} from '~/modules/process/ui/utils/dashboard-navigation-state'
 import { toCreateProcessInput } from '~/modules/process/ui/validation/processApi.validation'
 import {
   type ExistingProcessConflict,
@@ -100,10 +107,12 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
   const { t, keys, locale } = useTranslation()
   const navigate = useNavigate()
   const preloadRoute = usePreloadRoute()
+  const dashboardNavigationState = readDashboardNavigationState()
   let shouldPreferPrefetchedProcesses = true
   let shouldPreferPrefetchedGlobalAlerts = true
   let shouldPreferPrefetchedDashboardKpis = true
   let shouldPreferPrefetchedDashboardActivity = true
+  let shouldRestoreDashboardScroll = dashboardNavigationState !== null
   const [processes, { refetch: refetchProcesses }] = createResource(() => {
     const preferPrefetched = shouldPreferPrefetchedProcesses
     shouldPreferPrefetchedProcesses = false
@@ -149,6 +158,7 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
   const {
     sortSelection,
     filterSelection,
+    isHydrated: isDashboardFilterSortHydrated,
     handleSortToggle,
     handleProviderFilterToggle,
     handleStatusFilterToggle,
@@ -158,6 +168,11 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
   } = useDashboardFilterSortController()
   const [isCreateDialogOpen, setIsCreateDialogOpen] = createSignal(false)
   const [createError, setCreateError] = createSignal<string | ExistingProcessConflict | null>(null)
+  const [lastOpenedProcessId] = createSignal<string | null>(
+    dashboardNavigationState?.lastOpenedProcessId ?? null,
+  )
+
+  clearDashboardNavigationState()
 
   const providerFilterOptions = createMemo(() =>
     deriveDashboardProviderFilterOptions(processesState.data() ?? []),
@@ -214,6 +229,12 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
       refetchDashboardKpis,
       refetchDashboardProcessesCreatedByMonth,
     })
+  const highlightedProcessId = createMemo(() =>
+    resolveHighlightedDashboardProcessId({
+      processes: processesWithSyncFeedback(),
+      lastOpenedProcessId: lastOpenedProcessId(),
+    }),
+  )
 
   onMount(() => {
     const updateChartWindowSize = (): void => {
@@ -227,12 +248,29 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
     })
   })
 
+  createEffect(() => {
+    if (!shouldRestoreDashboardScroll) return
+    if (!isDashboardFilterSortHydrated()) return
+    if (processesState.initialLoading()) return
+    if (dashboardKpisState.initialLoading()) return
+    if (dashboardActivityState.initialLoading()) return
+
+    shouldRestoreDashboardScroll = false
+    restoreDashboardScrollPosition({
+      state: dashboardNavigationState,
+    })
+  })
+
   const handleCreateProcess = () => {
     setCreateError(null)
     setIsCreateDialogOpen(true)
   }
 
   const handleOpenProcess = (processId: string) => {
+    saveDashboardNavigationState({
+      lastOpenedProcessId: processId,
+    })
+
     navigateToProcess({
       navigate,
       processId,
@@ -338,6 +376,7 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
           />
           <DashboardProcessTable
             processes={processesWithSyncFeedback()}
+            highlightedProcessId={highlightedProcessId()}
             initialLoading={processesState.initialLoading()}
             refreshing={processesState.refreshing()}
             hasError={processesState.hasBlockingError()}

--- a/src/modules/process/ui/screens/app/AppRouteSkeleton.tsx
+++ b/src/modules/process/ui/screens/app/AppRouteSkeleton.tsx
@@ -88,6 +88,7 @@ function DashboardRouteSkeleton(): JSX.Element {
         <DashboardFiltersSkeleton />
         <DashboardProcessTable
           processes={[]}
+          highlightedProcessId={null}
           initialLoading
           refreshing={false}
           hasError={false}

--- a/src/modules/process/ui/screens/dashboard/hooks/useDashboardFilterSortController.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/useDashboardFilterSortController.ts
@@ -30,6 +30,7 @@ import { DASHBOARD_DEFAULT_SORT_SELECTION } from '~/modules/process/ui/viewmodel
 type DashboardFilterSortControllerResult = {
   readonly sortSelection: Accessor<DashboardSortSelection>
   readonly filterSelection: Accessor<DashboardFilterSelection>
+  readonly isHydrated: Accessor<boolean>
   readonly handleSortToggle: (field: DashboardSortField) => void
   readonly handleProviderFilterToggle: (provider: string) => void
   readonly handleStatusFilterToggle: (status: ProcessStatusCode) => void
@@ -45,10 +46,12 @@ export function useDashboardFilterSortController(): DashboardFilterSortControlle
   const [filterSelection, setFilterSelection] = createSignal<DashboardFilterSelection>(
     DASHBOARD_DEFAULT_FILTER_SELECTION,
   )
+  const [isHydrated, setIsHydrated] = createSignal(false)
 
   onMount(() => {
     setSortSelection(readDashboardSortFromLocalStorage())
     setFilterSelection(readDashboardFiltersFromLocalStorage())
+    setIsHydrated(true)
   })
 
   const persistDashboardFilters = (nextFilterSelection: DashboardFilterSelection) => {
@@ -86,6 +89,7 @@ export function useDashboardFilterSortController(): DashboardFilterSortControlle
   return {
     sortSelection,
     filterSelection,
+    isHydrated,
     handleSortToggle,
     handleProviderFilterToggle,
     handleStatusFilterToggle,

--- a/src/modules/process/ui/screens/shipment/ShipmentScreen.tsx
+++ b/src/modules/process/ui/screens/shipment/ShipmentScreen.tsx
@@ -18,6 +18,7 @@ import { useTrackingTimeTravelController } from '~/modules/process/ui/screens/sh
 import { toSortedActiveAlerts } from '~/modules/process/ui/screens/shipment/lib/shipmentAlerts.sorting'
 import { normalizeSelectedContainerNumber } from '~/modules/process/ui/screens/shipment/lib/shipmentContainerSelection'
 import { resolveDashboardChartWindowSize } from '~/modules/process/ui/utils/dashboard-chart-window-size'
+import { hasDashboardNavigationState } from '~/modules/process/ui/utils/dashboard-navigation-state'
 import type { AlertDisplayVM } from '~/modules/process/ui/viewmodels/alert.vm'
 import { useTranslation } from '~/shared/localization/i18n'
 import {
@@ -36,6 +37,7 @@ export function ShipmentScreen(props: ShipmentScreenProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const preloadRoute = usePreloadRoute()
+  const preserveDashboardScroll = hasDashboardNavigationState()
 
   // props.processId is already an Accessor<string>; no extra createMemo indirection required
   const processId = () => props.processId()
@@ -147,6 +149,7 @@ export function ShipmentScreen(props: ShipmentScreenProps) {
       shipmentError={resource.error}
       onOpenCreateProcess={dialogs.openCreateDialog}
       onDashboardIntent={handleDashboardIntent}
+      preserveDashboardScroll={preserveDashboardScroll}
       searchSlot={props.searchSlot}
       actionsSlot={<ExportImportActions processId={processId()} showImport={false} />}
       banners={

--- a/src/modules/process/ui/screens/shipment/components/ShipmentScreenLayout.tsx
+++ b/src/modules/process/ui/screens/shipment/components/ShipmentScreenLayout.tsx
@@ -58,6 +58,7 @@ export function ShipmentScreenLayout(props: ShipmentScreenLayoutProps) {
         <main class="relative mx-auto max-w-(--dashboard-container-max-width) px-[var(--dashboard-container-px)] pb-[var(--dashboard-container-py)] pt-6">
           <A
             href="/"
+            noScroll
             class="mb-3 inline-flex items-center gap-1.5 text-sm-ui text-text-muted transition-colors hover:text-foreground"
             onPointerEnter={triggerDashboardIntent}
             onFocusIn={triggerDashboardIntent}
@@ -76,6 +77,7 @@ export function ShipmentScreenLayout(props: ShipmentScreenLayoutProps) {
               <p class="text-tone-danger-fg">{t(keys.shipmentView.loadError)}</p>
               <A
                 href="/"
+                noScroll
                 class="mt-4 inline-block text-sm-ui text-text-muted hover:text-foreground"
                 onPointerEnter={triggerDashboardIntent}
                 onFocusIn={triggerDashboardIntent}
@@ -91,6 +93,7 @@ export function ShipmentScreenLayout(props: ShipmentScreenLayoutProps) {
               <p class="text-tone-danger-fg">{t(keys.shipmentView.notFound)}</p>
               <A
                 href="/"
+                noScroll
                 class="mt-4 inline-block text-sm-ui text-text-muted hover:text-foreground"
                 onPointerEnter={triggerDashboardIntent}
                 onFocusIn={triggerDashboardIntent}

--- a/src/modules/process/ui/screens/shipment/components/ShipmentScreenLayout.tsx
+++ b/src/modules/process/ui/screens/shipment/components/ShipmentScreenLayout.tsx
@@ -14,6 +14,7 @@ type ShipmentScreenLayoutProps = {
   readonly shipmentError: Accessor<unknown>
   readonly onOpenCreateProcess: () => void
   readonly onDashboardIntent: () => void
+  readonly preserveDashboardScroll: boolean
   readonly searchSlot?: JSX.Element
   readonly actionsSlot?: JSX.Element
   readonly banners: JSX.Element
@@ -48,6 +49,7 @@ export function ShipmentScreenLayout(props: ShipmentScreenLayoutProps) {
         <AppHeader
           onCreateProcess={props.onOpenCreateProcess}
           onDashboardIntent={props.onDashboardIntent}
+          preserveDashboardScroll={props.preserveDashboardScroll}
           searchSlot={props.searchSlot}
           actionsSlot={props.actionsSlot}
         />
@@ -58,7 +60,7 @@ export function ShipmentScreenLayout(props: ShipmentScreenLayoutProps) {
         <main class="relative mx-auto max-w-(--dashboard-container-max-width) px-[var(--dashboard-container-px)] pb-[var(--dashboard-container-py)] pt-6">
           <A
             href="/"
-            noScroll
+            noScroll={props.preserveDashboardScroll}
             class="mb-3 inline-flex items-center gap-1.5 text-sm-ui text-text-muted transition-colors hover:text-foreground"
             onPointerEnter={triggerDashboardIntent}
             onFocusIn={triggerDashboardIntent}
@@ -77,7 +79,7 @@ export function ShipmentScreenLayout(props: ShipmentScreenLayoutProps) {
               <p class="text-tone-danger-fg">{t(keys.shipmentView.loadError)}</p>
               <A
                 href="/"
-                noScroll
+                noScroll={props.preserveDashboardScroll}
                 class="mt-4 inline-block text-sm-ui text-text-muted hover:text-foreground"
                 onPointerEnter={triggerDashboardIntent}
                 onFocusIn={triggerDashboardIntent}
@@ -93,7 +95,7 @@ export function ShipmentScreenLayout(props: ShipmentScreenLayoutProps) {
               <p class="text-tone-danger-fg">{t(keys.shipmentView.notFound)}</p>
               <A
                 href="/"
-                noScroll
+                noScroll={props.preserveDashboardScroll}
                 class="mt-4 inline-block text-sm-ui text-text-muted hover:text-foreground"
                 onPointerEnter={triggerDashboardIntent}
                 onFocusIn={triggerDashboardIntent}

--- a/src/modules/process/ui/utils/dashboard-navigation-state.ts
+++ b/src/modules/process/ui/utils/dashboard-navigation-state.ts
@@ -1,0 +1,73 @@
+type DashboardNavigationWindow = {
+  readonly scrollY: number
+  readonly scrollTo: (x: number, y: number) => void
+}
+
+export type DashboardNavigationState = {
+  readonly lastOpenedProcessId: string
+  readonly scrollY: number
+}
+
+export type DashboardNavigationStateEnvironment = {
+  readonly window?: DashboardNavigationWindow | undefined
+}
+
+let dashboardNavigationState: DashboardNavigationState | null = null
+
+function resolveDashboardNavigationWindow(
+  environment?: DashboardNavigationStateEnvironment,
+): DashboardNavigationWindow | undefined {
+  return environment?.window ?? (typeof window === 'undefined' ? undefined : window)
+}
+
+export function clearDashboardNavigationState(): void {
+  dashboardNavigationState = null
+}
+
+export function readDashboardNavigationState(): DashboardNavigationState | null {
+  return dashboardNavigationState
+}
+
+export function saveDashboardNavigationState(command: {
+  readonly lastOpenedProcessId: string
+  readonly environment?: DashboardNavigationStateEnvironment
+}): void {
+  const processId = command.lastOpenedProcessId.trim()
+  if (processId.length === 0) {
+    clearDashboardNavigationState()
+    return
+  }
+
+  dashboardNavigationState = {
+    lastOpenedProcessId: processId,
+    scrollY: Math.max(0, resolveDashboardNavigationWindow(command.environment)?.scrollY ?? 0),
+  }
+}
+
+export function restoreDashboardScrollPosition(command: {
+  readonly state: DashboardNavigationState | null
+  readonly environment?: DashboardNavigationStateEnvironment
+}): boolean {
+  if (command.state === null) return false
+
+  const currentWindow = resolveDashboardNavigationWindow(command.environment)
+  if (!currentWindow) return false
+
+  currentWindow.scrollTo(0, command.state.scrollY)
+  return true
+}
+
+export function resolveHighlightedDashboardProcessId(command: {
+  readonly processes: readonly { readonly id: string }[]
+  readonly lastOpenedProcessId: string | null
+}): string | null {
+  if (command.lastOpenedProcessId === null) return null
+
+  for (const process of command.processes) {
+    if (process.id === command.lastOpenedProcessId) {
+      return command.lastOpenedProcessId
+    }
+  }
+
+  return null
+}

--- a/src/modules/process/ui/utils/dashboard-navigation-state.ts
+++ b/src/modules/process/ui/utils/dashboard-navigation-state.ts
@@ -28,6 +28,10 @@ export function readDashboardNavigationState(): DashboardNavigationState | null 
   return dashboardNavigationState
 }
 
+export function hasDashboardNavigationState(): boolean {
+  return dashboardNavigationState !== null
+}
+
 export function saveDashboardNavigationState(command: {
   readonly lastOpenedProcessId: string
   readonly environment?: DashboardNavigationStateEnvironment

--- a/src/modules/process/ui/utils/dashboard-process-row-style.ts
+++ b/src/modules/process/ui/utils/dashboard-process-row-style.ts
@@ -1,0 +1,20 @@
+export type DashboardProcessRowSeverity = 'danger' | 'warning' | 'info' | 'success' | 'none'
+
+function getSeverityBorderClass(severity: DashboardProcessRowSeverity): string {
+  if (severity === 'danger') return '[box-shadow:inset_4px_0_0_0_var(--color-tone-danger-strong)]'
+  if (severity === 'warning') return '[box-shadow:inset_4px_0_0_0_var(--color-tone-warning-strong)]'
+  if (severity === 'info') return '[box-shadow:inset_4px_0_0_0_var(--color-tone-info-strong)]'
+  return ''
+}
+
+export function toDashboardProcessRowClass(command: {
+  readonly severity: DashboardProcessRowSeverity
+  readonly isHighlighted: boolean
+}): string {
+  const stateClass = command.isHighlighted
+    ? 'bg-primary/5 outline outline-2 -outline-offset-2 outline-primary/25 hover:bg-primary/10'
+    : 'bg-surface hover:bg-surface-muted'
+  const severityClass = getSeverityBorderClass(command.severity)
+
+  return `grid min-h-(--dashboard-table-row-height) cursor-pointer items-center border-b border-border/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 last:border-b-0 ${stateClass} ${severityClass}`.trim()
+}

--- a/src/modules/process/ui/utils/tests/dashboard-navigation-state.test.ts
+++ b/src/modules/process/ui/utils/tests/dashboard-navigation-state.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearDashboardNavigationState,
+  readDashboardNavigationState,
+  resolveHighlightedDashboardProcessId,
+  restoreDashboardScrollPosition,
+  saveDashboardNavigationState,
+} from '~/modules/process/ui/utils/dashboard-navigation-state'
+
+class MockDashboardNavigationWindow {
+  scrollY: number
+  readonly scrollTo = vi.fn()
+
+  constructor(scrollY: number) {
+    this.scrollY = scrollY
+  }
+}
+
+afterEach(() => {
+  clearDashboardNavigationState()
+})
+
+describe('dashboard-navigation-state', () => {
+  it('saves and reads the current dashboard scroll position and last opened process', () => {
+    const dashboardWindow = new MockDashboardNavigationWindow(420)
+
+    saveDashboardNavigationState({
+      lastOpenedProcessId: ' process-42 ',
+      environment: {
+        window: dashboardWindow,
+      },
+    })
+
+    expect(readDashboardNavigationState()).toEqual({
+      lastOpenedProcessId: 'process-42',
+      scrollY: 420,
+    })
+  })
+
+  it('clamps negative scroll values and clears previous state when process id is blank', () => {
+    saveDashboardNavigationState({
+      lastOpenedProcessId: 'process-42',
+      environment: {
+        window: new MockDashboardNavigationWindow(-10),
+      },
+    })
+
+    expect(readDashboardNavigationState()).toEqual({
+      lastOpenedProcessId: 'process-42',
+      scrollY: 0,
+    })
+
+    saveDashboardNavigationState({
+      lastOpenedProcessId: '   ',
+    })
+
+    expect(readDashboardNavigationState()).toBeNull()
+  })
+
+  it('restores scroll from saved dashboard state and reports no-op when state or window is missing', () => {
+    const dashboardWindow = new MockDashboardNavigationWindow(0)
+
+    expect(
+      restoreDashboardScrollPosition({
+        state: {
+          lastOpenedProcessId: 'process-42',
+          scrollY: 640,
+        },
+        environment: {
+          window: dashboardWindow,
+        },
+      }),
+    ).toBe(true)
+    expect(dashboardWindow.scrollTo).toHaveBeenCalledWith(0, 640)
+
+    expect(
+      restoreDashboardScrollPosition({
+        state: null,
+        environment: {
+          window: dashboardWindow,
+        },
+      }),
+    ).toBe(false)
+
+    expect(
+      restoreDashboardScrollPosition({
+        state: {
+          lastOpenedProcessId: 'process-42',
+          scrollY: 640,
+        },
+        environment: {},
+      }),
+    ).toBe(false)
+  })
+
+  it('highlights only the last opened process when it still exists in the visible rows', () => {
+    expect(
+      resolveHighlightedDashboardProcessId({
+        processes: [{ id: 'process-1' }, { id: 'process-2' }],
+        lastOpenedProcessId: 'process-2',
+      }),
+    ).toBe('process-2')
+
+    expect(
+      resolveHighlightedDashboardProcessId({
+        processes: [{ id: 'process-1' }],
+        lastOpenedProcessId: 'process-2',
+      }),
+    ).toBeNull()
+
+    expect(
+      resolveHighlightedDashboardProcessId({
+        processes: [{ id: 'process-1' }],
+        lastOpenedProcessId: null,
+      }),
+    ).toBeNull()
+  })
+})

--- a/src/modules/process/ui/utils/tests/dashboard-navigation-state.test.ts
+++ b/src/modules/process/ui/utils/tests/dashboard-navigation-state.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   clearDashboardNavigationState,
+  hasDashboardNavigationState,
   readDashboardNavigationState,
   resolveHighlightedDashboardProcessId,
   restoreDashboardScrollPosition,
@@ -35,6 +36,7 @@ describe('dashboard-navigation-state', () => {
       lastOpenedProcessId: 'process-42',
       scrollY: 420,
     })
+    expect(hasDashboardNavigationState()).toBe(true)
   })
 
   it('clamps negative scroll values and clears previous state when process id is blank', () => {
@@ -55,6 +57,7 @@ describe('dashboard-navigation-state', () => {
     })
 
     expect(readDashboardNavigationState()).toBeNull()
+    expect(hasDashboardNavigationState()).toBe(false)
   })
 
   it('restores scroll from saved dashboard state and reports no-op when state or window is missing', () => {

--- a/src/routes/dev/tracking-scenarios.tsx
+++ b/src/routes/dev/tracking-scenarios.tsx
@@ -324,6 +324,7 @@ function DashboardPreview(props: {
         <div class="mt-3">
           <DashboardProcessTable
             processes={rows()}
+            highlightedProcessId={null}
             initialLoading={props.rowLoading && rows().length === 0}
             refreshing={props.rowLoading && rows().length > 0}
             hasError={Boolean(props.rowError) && rows().length === 0}

--- a/src/shared/ui/AppHeader.tsx
+++ b/src/shared/ui/AppHeader.tsx
@@ -11,6 +11,7 @@ import { NavbarAlertsButton } from '~/shared/ui/navbar-alerts/NavbarAlertsButton
 type Props = {
   readonly onCreateProcess?: () => void
   readonly onDashboardIntent?: () => void
+  readonly preserveDashboardScroll?: boolean
   readonly searchSlot?: JSX.Element
   readonly syncSlot?: JSX.Element
   readonly actionsSlot?: JSX.Element
@@ -23,6 +24,7 @@ function NavLink(props: {
   readonly href: string
   readonly children: JSX.Element
   readonly end?: boolean
+  readonly preserveScroll?: boolean
   readonly onIntent?: () => void
 }): JSX.Element {
   const location = useLocation()
@@ -40,7 +42,7 @@ function NavLink(props: {
     <A
       href={props.href}
       end={props.end}
-      noScroll={props.href === '/' && props.onIntent !== undefined}
+      noScroll={props.preserveScroll === true}
       onPointerEnter={() => props.onIntent?.()}
       onFocusIn={() => props.onIntent?.()}
       onPointerDown={() => props.onIntent?.()}
@@ -57,13 +59,16 @@ function NavLink(props: {
   )
 }
 
-function HeaderBrand(props: { readonly onDashboardIntent?: () => void }): JSX.Element {
+function HeaderBrand(props: {
+  readonly onDashboardIntent?: () => void
+  readonly preserveDashboardScroll?: boolean
+}): JSX.Element {
   const isDark = () => getTheme() === 'dark'
 
   return (
     <A
       href="/"
-      noScroll={props.onDashboardIntent !== undefined}
+      noScroll={props.preserveDashboardScroll === true}
       onPointerEnter={() => props.onDashboardIntent?.()}
       onFocusIn={() => props.onDashboardIntent?.()}
       onPointerDown={() => props.onDashboardIntent?.()}
@@ -111,12 +116,14 @@ function HeaderNavigation(props: {
   readonly dashboardLabel: string
   readonly agentsLabel: string
   readonly onDashboardIntent?: () => void
+  readonly preserveDashboardScroll?: boolean
 }): JSX.Element {
   return (
     <nav class="hidden shrink-0 items-center gap-6 md:flex" aria-label="Primary">
       <NavLink
         href="/"
         end
+        {...(props.preserveDashboardScroll ? { preserveScroll: true } : {})}
         {...(props.onDashboardIntent ? { onIntent: props.onDashboardIntent } : {})}
       >
         {props.dashboardLabel}
@@ -241,11 +248,13 @@ export function AppHeader(props: Props): JSX.Element {
         <div class="navbar-left flex min-w-0 items-center gap-3 max-[1279px]:gap-4 lg:gap-6">
           <HeaderBrand
             {...(props.onDashboardIntent ? { onDashboardIntent: props.onDashboardIntent } : {})}
+            {...(props.preserveDashboardScroll ? { preserveDashboardScroll: true } : {})}
           />
           <HeaderNavigation
             dashboardLabel={t(keys.header.nav.dashboard)}
             agentsLabel={t(keys.header.nav.agents)}
             {...(props.onDashboardIntent ? { onDashboardIntent: props.onDashboardIntent } : {})}
+            {...(props.preserveDashboardScroll ? { preserveDashboardScroll: true } : {})}
           />
         </div>
 

--- a/src/shared/ui/AppHeader.tsx
+++ b/src/shared/ui/AppHeader.tsx
@@ -40,6 +40,7 @@ function NavLink(props: {
     <A
       href={props.href}
       end={props.end}
+      noScroll={props.href === '/' && props.onIntent !== undefined}
       onPointerEnter={() => props.onIntent?.()}
       onFocusIn={() => props.onIntent?.()}
       onPointerDown={() => props.onIntent?.()}
@@ -62,6 +63,7 @@ function HeaderBrand(props: { readonly onDashboardIntent?: () => void }): JSX.El
   return (
     <A
       href="/"
+      noScroll={props.onDashboardIntent !== undefined}
       onPointerEnter={() => props.onDashboardIntent?.()}
       onFocusIn={() => props.onDashboardIntent?.()}
       onPointerDown={() => props.onDashboardIntent?.()}


### PR DESCRIPTION
This pull request introduces a new mechanism to remember and visually highlight the last opened process row in the dashboard, and to restore the user's scroll position when navigating back to the dashboard. It also refactors row styling logic for maintainability and adds related tests. The changes are grouped below by theme.

**Dashboard navigation state and highlighting:**

* Added a new utility module (`dashboard-navigation-state.ts`) to track the last opened process and scroll position, with functions to save, read, clear, and restore navigation state. This enables the dashboard to remember which process was last opened and restore the scroll position upon return.
* Updated the dashboard screen (`DashboardScreen.tsx`) to use the navigation state: it now highlights the last opened process row and restores the scroll position after navigation, waiting for filters and data to hydrate before restoring. [[1]](diffhunk://#diff-57a27d17e205673009a70dabfa4cbd1f341187dfa4026dc6879241e6ef3d02b1R37-R43) [[2]](diffhunk://#diff-57a27d17e205673009a70dabfa4cbd1f341187dfa4026dc6879241e6ef3d02b1R110-R115) [[3]](diffhunk://#diff-57a27d17e205673009a70dabfa4cbd1f341187dfa4026dc6879241e6ef3d02b1R161) [[4]](diffhunk://#diff-57a27d17e205673009a70dabfa4cbd1f341187dfa4026dc6879241e6ef3d02b1R171-R175) [[5]](diffhunk://#diff-57a27d17e205673009a70dabfa4cbd1f341187dfa4026dc6879241e6ef3d02b1R232-R237) [[6]](diffhunk://#diff-57a27d17e205673009a70dabfa4cbd1f341187dfa4026dc6879241e6ef3d02b1R251-R273) [[7]](diffhunk://#diff-57a27d17e205673009a70dabfa4cbd1f341187dfa4026dc6879241e6ef3d02b1R379)
* Modified the dashboard table and row components to accept and use a `highlightedProcessId` prop, passing it down to individual rows to apply the highlight. [[1]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeR55) [[2]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeR71) [[3]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeR81) [[4]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeR775) [[5]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeR911) [[6]](diffhunk://#diff-ee4b8b67907604e7414d100ff9069f2fd3309ac32ceca343c18d45227a301063R91)

**Row styling refactor and test:**

* Extracted row styling logic into a new utility (`dashboard-process-row-style.ts`), centralizing severity and highlight class calculation, and removed the old inline severity border logic from the table component. [[1]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeL146-L152) [[2]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeL606-R607) [[3]](diffhunk://#diff-2ecd38a3dd09462de553961490a87c7bc7649b00f7d53f8b2e18d5a268d1efdeR27) [[4]](diffhunk://#diff-56d16a4f908c33dc6be948ff52a113da56736f51d1c46c2f2f7c721a2384ee78R1-R20)
* Added tests for the new row styling utility to ensure correct class application for highlighted and non-highlighted rows.

**Dashboard filter/sort hydration:**

* Enhanced the dashboard filter/sort controller to expose an `isHydrated` signal, ensuring that scroll restoration only happens after filters and sorts are loaded from storage. [[1]](diffhunk://#diff-324db3f1564bd4aa26e37de52157488a1362c4d35c553bdd3d6e0c9cdbb60c53R33) [[2]](diffhunk://#diff-324db3f1564bd4aa26e37de52157488a1362c4d35c553bdd3d6e0c9cdbb60c53R49-R54) [[3]](diffhunk://#diff-324db3f1564bd4aa26e37de52157488a1362c4d35c553bdd3d6e0c9cdbb60c53R92)

**Minor improvements:**

* Updated shipment screen layout links to use the `noScroll` prop, preventing scroll reset when navigating back to the dashboard. [[1]](diffhunk://#diff-2dabcfd73bef110da20c815bc064d4f77cb5537a2f5c0d9ce41b4ac68b851cd9R61) [[2]](diffhunk://#diff-2dabcfd73bef110da20c815bc064d4f77cb5537a2f5c0d9ce41b4ac68b851cd9R80) [[3]](diffhunk://#diff-2dabcfd73bef110da20c815bc064d4f77cb5537a2f5c0d9ce41b4ac68b851cd9R96)