### PR TITLE
Add global server problem banner and HTTP degradation reporting

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,10 @@ import { getAppErrorDetails } from '~/app-error-details'
 import { AppInitialRoutePrefetchBoundary } from '~/modules/process/ui/screens/app/AppInitialRoutePrefetchBoundary'
 import { AppRouteSkeleton } from '~/modules/process/ui/screens/app/AppRouteSkeleton'
 import { DashboardKeepWarmBoundary } from '~/modules/process/ui/screens/dashboard/DashboardKeepWarmBoundary'
+import {
+  dismissServerProblemBanner,
+  useServerProblemBanner,
+} from '~/shared/api/httpDegradationReporter'
 import { useTranslation } from '~/shared/localization/i18n'
 import '~/app.css'
 
@@ -41,6 +45,28 @@ function AppErrorBoundaryFallback(props: AppErrorBoundaryFallbackProps): JSX.Ele
   )
 }
 
+function GlobalServerProblemBanner(): JSX.Element {
+  const { t, keys } = useTranslation()
+  const bannerState = useServerProblemBanner()
+
+  return (
+    <Show when={bannerState().visible}>
+      <div class="border-b border-tone-warning-border bg-tone-warning-bg text-tone-warning-fg">
+        <div class="mx-auto flex max-w-(--dashboard-container-max-width) items-start justify-between gap-4 px-[var(--dashboard-container-px)] py-2.5 text-sm-ui">
+          <p class="font-medium">{t(keys.app.serverProblemBanner)}</p>
+          <button
+            type="button"
+            class="shrink-0 text-sm-ui font-medium underline underline-offset-2"
+            onClick={() => dismissServerProblemBanner()}
+          >
+            {t(keys.app.dismissServerProblemBanner)}
+          </button>
+        </div>
+      </div>
+    </Show>
+  )
+}
+
 function AppRouterRoot(props: AppRouterRootProps): JSX.Element {
   const location = useLocation()
   const preloadRoute = usePreloadRoute()
@@ -50,6 +76,7 @@ function AppRouterRoot(props: AppRouterRootProps): JSX.Element {
     <div class="root">
       <AppInitialRoutePrefetchBoundary pathname={() => location.pathname} locale={locale} />
       <DashboardKeepWarmBoundary pathname={() => location.pathname} preloadRoute={preloadRoute} />
+      <GlobalServerProblemBanner />
       <ErrorBoundary fallback={(err) => <AppErrorBoundaryFallback error={err} />}>
         <Suspense fallback={<AppRouteSkeleton pathname={() => location.pathname} />}>
           {props.children}

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -86,7 +86,9 @@
     }
   },
   "app": {
-    "unexpectedRenderError": "Ocorreu um erro inesperado. Verifique o console para mais detalhes."
+    "unexpectedRenderError": "Ocorreu um erro inesperado. Verifique o console para mais detalhes.",
+    "serverProblemBanner": "Servidor com problemas, informações podem estar incompletas.",
+    "dismissServerProblemBanner": "Dispensar"
   },
   "process": {
     "containerSelector": {

--- a/src/modules/agent/ui/agent-detail-page.test.ts
+++ b/src/modules/agent/ui/agent-detail-page.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readAgentDetailSnapshot } from '~/modules/agent/ui/agentResourceSnapshot'
+
+function buildErroredAgentDetailResource() {
+  return {
+    state: 'errored' as const,
+    get latest(): never {
+      throw new Error('agent detail resource latest should not be read')
+    },
+  }
+}
+
+describe('AgentDetailPage helpers', () => {
+  it('reads the detail snapshot without touching the throwing resource accessor', () => {
+    const resource = buildErroredAgentDetailResource()
+
+    expect(readAgentDetailSnapshot(resource)).toBeUndefined()
+  })
+})

--- a/src/modules/agent/ui/agent-detail-page.tsx
+++ b/src/modules/agent/ui/agent-detail-page.tsx
@@ -10,6 +10,7 @@ import {
   Show,
   untrack,
 } from 'solid-js'
+import { readAgentDetailSnapshot } from '~/modules/agent/ui/agentResourceSnapshot'
 import {
   fetchAgentDetail,
   requestAgentRestart,
@@ -216,6 +217,7 @@ function extractRealtimeRowId(value: unknown): string | null {
 export function AgentDetailPage(props: Props): JSX.Element {
   const navigate = useNavigate()
   const [detail, { refetch }] = createResource(() => props.agentId, fetchAgentDetail)
+  const detailSnapshot = () => readAgentDetailSnapshot(detail)
   const [lastRefreshed, setLastRefreshed] = createSignal(new Date())
   const [actionMessage, setActionMessage] = createSignal<string | null>(null)
   const [actionError, setActionError] = createSignal<string | null>(null)
@@ -250,7 +252,7 @@ export function AgentDetailPage(props: Props): JSX.Element {
   })
 
   createEffect(() => {
-    const tenantId = detail()?.tenantId
+    const tenantId = detailSnapshot()?.tenantId
     if (!tenantId) return
 
     const subscription = subscribeToTrackingAgentsByTenant({
@@ -271,7 +273,7 @@ export function AgentDetailPage(props: Props): JSX.Element {
 
   const now = createMemo(() => lastRefreshed())
   const vm = createMemo(() => {
-    const dto = detail()
+    const dto = detailSnapshot()
     if (!dto) return null
     return toAgentDetailVM(dto, now())
   })
@@ -367,7 +369,7 @@ export function AgentDetailPage(props: Props): JSX.Element {
             <DetailError onRetry={handleRefresh} />
           </Show>
 
-          <Show when={!detail.loading && !detail.error && !detail()}>
+          <Show when={!detail.loading && !detail.error && !detailSnapshot()}>
             <AgentNotFound />
           </Show>
 

--- a/src/modules/agent/ui/agentResourceSnapshot.ts
+++ b/src/modules/agent/ui/agentResourceSnapshot.ts
@@ -1,0 +1,14 @@
+import type { fetchAgentDetail, fetchAgentList } from '~/modules/agent/ui/api/agent.api'
+import { type ResourceSnapshotLike, readResourceSnapshot } from '~/shared/solid/resourceSnapshot'
+
+export function readAgentListResponseSnapshot(
+  resource: ResourceSnapshotLike<Awaited<ReturnType<typeof fetchAgentList>> | undefined>,
+): Awaited<ReturnType<typeof fetchAgentList>> | undefined {
+  return readResourceSnapshot(resource)
+}
+
+export function readAgentDetailSnapshot(
+  resource: ResourceSnapshotLike<Awaited<ReturnType<typeof fetchAgentDetail>> | undefined>,
+): Awaited<ReturnType<typeof fetchAgentDetail>> | undefined {
+  return readResourceSnapshot(resource)
+}

--- a/src/modules/agent/ui/agents-page.test.ts
+++ b/src/modules/agent/ui/agents-page.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readAgentListResponseSnapshot } from '~/modules/agent/ui/agentResourceSnapshot'
+
+function buildErroredAgentListResource() {
+  return {
+    state: 'errored' as const,
+    get latest(): never {
+      throw new Error('agent list resource latest should not be read')
+    },
+  }
+}
+
+describe('AgentsPage helpers', () => {
+  it('reads the list snapshot without touching the throwing resource accessor', () => {
+    const resource = buildErroredAgentListResource()
+
+    expect(readAgentListResponseSnapshot(resource)).toBeUndefined()
+  })
+})

--- a/src/modules/agent/ui/agents-page.tsx
+++ b/src/modules/agent/ui/agents-page.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from '@solidjs/router'
 import type { JSX } from 'solid-js'
 import { createEffect, createMemo, createResource, createSignal, onCleanup } from 'solid-js'
+import { readAgentListResponseSnapshot } from '~/modules/agent/ui/agentResourceSnapshot'
 import { type AgentListQuery, fetchAgentList } from '~/modules/agent/ui/api/agent.api'
 import { AgentCardList } from '~/modules/agent/ui/components/AgentCardList'
 import {
@@ -59,11 +60,12 @@ export function AgentsPage(): JSX.Element {
   })
 
   const [agentsResponse, { refetch }] = createResource(listQuery, (query) => fetchAgentList(query))
+  const agentsResponseSnapshot = () => readAgentListResponseSnapshot(agentsResponse)
 
   const now = createMemo(() => lastRefreshed())
 
   const agentVMs = createMemo<readonly AgentListItemVM[]>(() => {
-    const response = agentsResponse()
+    const response = agentsResponseSnapshot()
     if (!response) return []
     return response.agents.map((dto) => toAgentListItemVM(dto, now()))
   })
@@ -79,13 +81,13 @@ export function AgentsPage(): JSX.Element {
   })
 
   const fleetSummary = createMemo(() => {
-    const response = agentsResponse()
+    const response = agentsResponseSnapshot()
     if (!response) return null
     return toFleetSummaryVM(response.summary)
   })
 
   const tenantIdForRealtime = createMemo(() => {
-    const response = agentsResponse()
+    const response = agentsResponseSnapshot()
     return response?.agents[0]?.tenantId ?? null
   })
 

--- a/src/modules/agent/ui/logs/useAgentLogsController.test.ts
+++ b/src/modules/agent/ui/logs/useAgentLogsController.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readAgentLogsBacklogSnapshot } from '~/modules/agent/ui/logs/useAgentLogsController'
+
+function buildErroredAgentLogsResource() {
+  return {
+    state: 'errored' as const,
+    get latest(): never {
+      throw new Error('agent logs resource latest should not be read')
+    },
+  }
+}
+
+describe('useAgentLogsController helpers', () => {
+  it('reads backlog snapshots safely without touching the throwing resource accessor', () => {
+    const resource = buildErroredAgentLogsResource()
+
+    expect(readAgentLogsBacklogSnapshot(resource)).toBeUndefined()
+  })
+})

--- a/src/modules/agent/ui/logs/useAgentLogsController.ts
+++ b/src/modules/agent/ui/logs/useAgentLogsController.ts
@@ -11,6 +11,7 @@ import type {
   AgentLogsChannel,
   AgentLogsConnectionState,
 } from '~/modules/agent/ui/logs/agent-logs.vm'
+import { type ResourceSnapshotLike, readResourceSnapshot } from '~/shared/solid/resourceSnapshot'
 
 const DEFAULT_TAIL_LINES = 500
 const MAX_VIEWPORT_LINES = 2000
@@ -65,6 +66,14 @@ function hasSequence(lines: readonly AgentLogLineVM[], sequence: number): boolea
   return lines.some((line) => line.sequence === sequence)
 }
 
+type AgentLogsBacklogSnapshot = Awaited<ReturnType<typeof fetchAgentLogsBacklog>>
+
+export function readAgentLogsBacklogSnapshot(
+  resource: ResourceSnapshotLike<AgentLogsBacklogSnapshot | undefined>,
+): AgentLogsBacklogSnapshot | undefined {
+  return readResourceSnapshot(resource)
+}
+
 export function useAgentLogsController(command: {
   readonly agentId: string
   readonly enabled?: () => boolean
@@ -106,7 +115,7 @@ export function useAgentLogsController(command: {
   )
 
   createEffect(() => {
-    const data = backlog()
+    const data = readAgentLogsBacklogSnapshot(backlog)
     if (!data) return
 
     setOs(data.os)

--- a/src/modules/process/ui/CreateProcessDialog.tsx
+++ b/src/modules/process/ui/CreateProcessDialog.tsx
@@ -38,6 +38,7 @@ import {
   type SmartPasteFormSnapshot,
   type SmartPasteScalarField,
 } from '~/modules/process/ui/validation/trelloSmartPasteApply.validation'
+import { fetchWithHttpDegradationReporting } from '~/shared/api/httpDegradationReporter'
 import { useTranslation } from '~/shared/localization/i18n'
 import { navigateToAppHref } from '~/shared/ui/navigation/app-navigation'
 import { findDuplicateStrings } from '~/shared/utils/findDuplicateStrings'
@@ -450,7 +451,7 @@ async function requestContainerConflicts(
   | { readonly ok: true; readonly conflicts: readonly ContainerConflict[] }
   | { readonly ok: false; readonly message: string }
 > {
-  const response = await fetch('/api/containers/check', {
+  const response = await fetchWithHttpDegradationReporting('/api/containers/check', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ containers: containerNumbers }),

--- a/src/modules/process/ui/api/export-import.api.ts
+++ b/src/modules/process/ui/api/export-import.api.ts
@@ -1,3 +1,4 @@
+import { fetchWithHttpDegradationReporting } from '~/shared/api/httpDegradationReporter'
 import { typedFetch } from '~/shared/api/typedFetch'
 import {
   ExecuteSymmetricImportResponseSchema,
@@ -71,7 +72,7 @@ async function requestDownload(command: {
   readonly payload: Record<string, unknown>
   readonly fallbackFilename: string
 }): Promise<void> {
-  const response = await fetch(command.endpoint, {
+  const response = await fetchWithHttpDegradationReporting(command.endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(command.payload),
@@ -95,7 +96,7 @@ async function requestTextExport(command: {
   readonly endpoint: string
   readonly payload: Record<string, unknown>
 }): Promise<string> {
-  const response = await fetch(command.endpoint, {
+  const response = await fetchWithHttpDegradationReporting(command.endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(command.payload),

--- a/src/modules/process/ui/api/process.api.ts
+++ b/src/modules/process/ui/api/process.api.ts
@@ -18,6 +18,7 @@ import type {
   DashboardSortField,
 } from '~/modules/process/ui/viewmodels/dashboard-sort.vm'
 import type { ProcessSummaryVM } from '~/modules/process/ui/viewmodels/process-summary.vm'
+import { fetchWithHttpDegradationReporting } from '~/shared/api/httpDegradationReporter'
 import { typedFetch } from '~/shared/api/typedFetch'
 import { DashboardOperationalSummaryResponseSchema } from '~/shared/api-schemas/dashboard.schemas'
 import {
@@ -295,9 +296,12 @@ export async function updateProcessRequest(id: string, input: CreateProcessInput
 }
 
 export async function deleteProcessRequest(processId: string): Promise<void> {
-  const response = await fetch(`/api/processes/${encodeURIComponent(processId)}`, {
-    method: 'DELETE',
-  })
+  const response = await fetchWithHttpDegradationReporting(
+    `/api/processes/${encodeURIComponent(processId)}`,
+    {
+      method: 'DELETE',
+    },
+  )
 
   if (response.ok) return
 

--- a/src/modules/process/ui/screens/shipment/hooks/useTrackingTimeTravelController.test.ts
+++ b/src/modules/process/ui/screens/shipment/hooks/useTrackingTimeTravelController.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  TrackingReplayDebugResponseDto,
+  TrackingTimeTravelResponseDto,
+} from '~/modules/process/ui/api/tracking-time-travel.api'
+import {
+  toTrackingReplayDebugValue,
+  toTrackingTimeTravelValue,
+} from '~/modules/process/ui/screens/shipment/hooks/useTrackingTimeTravelController'
+
+function buildErroredResource<T>(): {
+  readonly state: 'errored'
+  readonly latest: T | undefined
+} {
+  return {
+    state: 'errored',
+    get latest(): never {
+      throw new Error('tracking time-travel resource latest should not be read')
+    },
+  }
+}
+
+describe('useTrackingTimeTravelController helpers', () => {
+  it('returns null for time-travel value when the resource is errored', () => {
+    const resource = buildErroredResource<TrackingTimeTravelResponseDto>()
+
+    expect(toTrackingTimeTravelValue(resource, 'pt-BR')).toBeNull()
+  })
+
+  it('returns null for debug value when the resource is errored', () => {
+    const resource = buildErroredResource<TrackingReplayDebugResponseDto>()
+
+    expect(toTrackingReplayDebugValue(resource, 'pt-BR')).toBeNull()
+  })
+})

--- a/src/modules/process/ui/screens/shipment/hooks/useTrackingTimeTravelController.ts
+++ b/src/modules/process/ui/screens/shipment/hooks/useTrackingTimeTravelController.ts
@@ -2,6 +2,8 @@ import { type Accessor, createEffect, createMemo, createResource, createSignal }
 import {
   fetchTrackingReplayDebug,
   fetchTrackingTimeTravel,
+  type TrackingReplayDebugResponseDto,
+  type TrackingTimeTravelResponseDto,
 } from '~/modules/process/ui/api/tracking-time-travel.api'
 import {
   toTrackingReplayDebugVm,
@@ -19,6 +21,7 @@ import type {
 } from '~/modules/process/ui/screens/shipment/types/tracking-time-travel.vm'
 import type { ContainerDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
 import { useTranslation } from '~/shared/localization/i18n'
+import { type ResourceSnapshotLike, readResourceSnapshot } from '~/shared/solid/resourceSnapshot'
 
 type UseTrackingTimeTravelControllerCommand = {
   readonly selectedContainer: Accessor<ContainerDetailVM | null>
@@ -43,6 +46,24 @@ export type TrackingTimeTravelControllerResult = {
   readonly selectNext: () => void
 }
 
+export function toTrackingTimeTravelValue(
+  resource: ResourceSnapshotLike<TrackingTimeTravelResponseDto | undefined>,
+  currentLocale: string,
+): TrackingTimeTravelVM | null {
+  const response = readResourceSnapshot(resource)
+  if (!response) return null
+  return toTrackingTimeTravelVm(response, currentLocale)
+}
+
+export function toTrackingReplayDebugValue(
+  resource: ResourceSnapshotLike<TrackingReplayDebugResponseDto | undefined>,
+  currentLocale: string,
+): TrackingReplayDebugVM | null {
+  const response = readResourceSnapshot(resource)
+  if (!response) return null
+  return toTrackingReplayDebugVm(response, currentLocale)
+}
+
 export function useTrackingTimeTravelController(
   command: UseTrackingTimeTravelControllerCommand,
 ): TrackingTimeTravelControllerResult {
@@ -61,11 +82,9 @@ export function useTrackingTimeTravelController(
     async (containerId) => fetchTrackingTimeTravel(containerId),
   )
 
-  const value = createMemo<TrackingTimeTravelVM | null>(() => {
-    const response = timeTravelResponse()
-    if (!response) return null
-    return toTrackingTimeTravelVm(response, locale())
-  })
+  const value = createMemo<TrackingTimeTravelVM | null>(() =>
+    toTrackingTimeTravelValue(timeTravelResponse, locale()),
+  )
 
   createEffect(() => {
     const containerId = command.selectedContainer()?.id ?? null
@@ -117,11 +136,9 @@ export function useTrackingTimeTravelController(
     async (request) => fetchTrackingReplayDebug(request.containerId, request.snapshotId),
   )
 
-  const debugValue = createMemo<TrackingReplayDebugVM | null>(() => {
-    const response = debugResponse()
-    if (!response) return null
-    return toTrackingReplayDebugVm(response, locale())
-  })
+  const debugValue = createMemo<TrackingReplayDebugVM | null>(() =>
+    toTrackingReplayDebugValue(debugResponse, locale()),
+  )
 
   const open = () => {
     if (!command.selectedContainer()) return
@@ -185,7 +202,7 @@ export function useTrackingTimeTravelController(
       return error ? toReadableErrorMessage(error) : null
     },
     debugValue,
-    debugPayload: () => debugResponse() ?? null,
+    debugPayload: () => readResourceSnapshot(debugResponse) ?? null,
     open,
     close,
     toggleDebug,

--- a/src/modules/process/ui/screens/shipment/usecases/refreshShipmentTracking.usecase.ts
+++ b/src/modules/process/ui/screens/shipment/usecases/refreshShipmentTracking.usecase.ts
@@ -19,6 +19,7 @@ import {
 } from '~/modules/process/ui/screens/shipment/types/shipmentScreen.types'
 import { pollRefreshSyncStatus } from '~/modules/process/ui/utils/refresh-sync-polling'
 import type { ShipmentDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
+import { fetchWithHttpDegradationReporting } from '~/shared/api/httpDegradationReporter'
 import { subscribeToSyncRequestsRealtimeByIds } from '~/shared/api/sync-requests.realtime.client'
 import { systemClock } from '~/shared/time/clock'
 import type { Instant } from '~/shared/time/instant'
@@ -29,7 +30,7 @@ async function enqueueContainerRefresh(
   containerNumber: string,
   carrier: string | null | undefined,
 ): Promise<{ readonly syncRequestId: string }> {
-  const response = await fetch('/api/refresh', {
+  const response = await fetchWithHttpDegradationReporting('/api/refresh', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ container: containerNumber, carrier: carrier ?? null }),
@@ -57,13 +58,16 @@ async function fetchRefreshSyncStatuses(syncRequestIds: readonly string[]) {
   }
   params.set('_ts', String(systemClock.now().toEpochMs()))
 
-  const response = await fetch(`/api/refresh/status?${params.toString()}`, {
-    cache: 'no-store',
-    headers: {
-      'cache-control': 'no-cache',
-      pragma: 'no-cache',
+  const response = await fetchWithHttpDegradationReporting(
+    `/api/refresh/status?${params.toString()}`,
+    {
+      cache: 'no-store',
+      headers: {
+        'cache-control': 'no-cache',
+        pragma: 'no-cache',
+      },
     },
-  })
+  )
   const body: unknown = await response.json().catch(() => null)
 
   if (!response.ok) {

--- a/src/shared/api/httpDegradationReporter.ts
+++ b/src/shared/api/httpDegradationReporter.ts
@@ -1,0 +1,127 @@
+import type { Accessor } from 'solid-js'
+import { createEffect, createSignal, onCleanup } from 'solid-js'
+
+type HttpFailureReport = {
+  readonly status?: number
+  readonly error?: unknown
+}
+
+export type ServerProblemBannerState = {
+  readonly visible: boolean
+}
+
+type ServerProblemBannerListener = (state: ServerProblemBannerState) => void
+
+const serverProblemBannerState = {
+  visible: false,
+  dismissed: false,
+}
+
+const listeners = new Set<ServerProblemBannerListener>()
+
+function isBrowserRuntime(): boolean {
+  return typeof window !== 'undefined'
+}
+
+function readSnapshot(): ServerProblemBannerState {
+  return {
+    visible: serverProblemBannerState.visible,
+  }
+}
+
+function publishServerProblemBannerState(): void {
+  const snapshot = readSnapshot()
+  for (const listener of listeners) {
+    listener(snapshot)
+  }
+}
+
+function shouldReportServerFailure(report: HttpFailureReport): boolean {
+  if (typeof report.status === 'number') {
+    return report.status >= 500
+  }
+
+  return report.error !== undefined
+}
+
+export function readServerProblemBannerState(): ServerProblemBannerState {
+  return readSnapshot()
+}
+
+export function subscribeToServerProblemBanner(listener: ServerProblemBannerListener): () => void {
+  listeners.add(listener)
+  listener(readSnapshot())
+
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function reportHttpFailure(report: HttpFailureReport): void {
+  if (!isBrowserRuntime()) return
+  if (!shouldReportServerFailure(report)) return
+  if (serverProblemBannerState.visible || serverProblemBannerState.dismissed) return
+
+  serverProblemBannerState.visible = true
+  publishServerProblemBannerState()
+}
+
+export function reportHttpSuccess(): void {
+  if (!isBrowserRuntime()) return
+  if (!serverProblemBannerState.dismissed) return
+
+  serverProblemBannerState.dismissed = false
+}
+
+export function dismissServerProblemBanner(): void {
+  if (!isBrowserRuntime()) return
+  if (!serverProblemBannerState.visible) return
+
+  serverProblemBannerState.visible = false
+  serverProblemBannerState.dismissed = true
+  publishServerProblemBannerState()
+}
+
+export async function fetchWithHttpDegradationReporting(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  try {
+    const response = await fetch(input, init)
+
+    if (response.ok) {
+      reportHttpSuccess()
+    } else {
+      reportHttpFailure({ status: response.status })
+    }
+
+    return response
+  } catch (error) {
+    reportHttpFailure({ error })
+    throw error
+  }
+}
+
+export function useServerProblemBanner(): Accessor<ServerProblemBannerState> {
+  const [state, setState] = createSignal<ServerProblemBannerState>(readSnapshot())
+
+  createEffect(() => {
+    if (!isBrowserRuntime()) return
+
+    const unsubscribe = subscribeToServerProblemBanner((nextState) => {
+      setState(() => nextState)
+    })
+
+    onCleanup(() => {
+      unsubscribe()
+    })
+  })
+
+  return state
+}
+
+export function resetServerProblemBannerForTests(): void {
+  serverProblemBannerState.visible = false
+  serverProblemBannerState.dismissed = false
+  listeners.clear()
+}

--- a/src/shared/api/tests/httpDegradationReporter.test.ts
+++ b/src/shared/api/tests/httpDegradationReporter.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  dismissServerProblemBanner,
+  readServerProblemBannerState,
+  reportHttpFailure,
+  reportHttpSuccess,
+  resetServerProblemBannerForTests,
+} from '~/shared/api/httpDegradationReporter'
+
+function enableBrowserRuntime(): void {
+  vi.stubGlobal('window', {})
+}
+
+describe('httpDegradationReporter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetServerProblemBannerForTests()
+  })
+
+  it('shows the banner for 5xx responses', () => {
+    enableBrowserRuntime()
+
+    reportHttpFailure({ status: 503 })
+
+    expect(readServerProblemBannerState().visible).toBe(true)
+  })
+
+  it('shows the banner for network failures', () => {
+    enableBrowserRuntime()
+
+    reportHttpFailure({ error: new Error('network down') })
+
+    expect(readServerProblemBannerState().visible).toBe(true)
+  })
+
+  it('does not show the banner for 4xx responses', () => {
+    enableBrowserRuntime()
+
+    reportHttpFailure({ status: 409 })
+
+    expect(readServerProblemBannerState().visible).toBe(false)
+  })
+
+  it('keeps the banner hidden after dismissal until a monitored request succeeds', () => {
+    enableBrowserRuntime()
+
+    reportHttpFailure({ status: 500 })
+    dismissServerProblemBanner()
+    expect(readServerProblemBannerState().visible).toBe(false)
+
+    reportHttpFailure({ status: 502 })
+    expect(readServerProblemBannerState().visible).toBe(false)
+
+    reportHttpSuccess()
+    reportHttpFailure({ status: 502 })
+
+    expect(readServerProblemBannerState().visible).toBe(true)
+  })
+})

--- a/src/shared/api/tests/typedFetch.test.ts
+++ b/src/shared/api/tests/typedFetch.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import {
+  dismissServerProblemBanner,
+  readServerProblemBannerState,
+  reportHttpFailure,
+  resetServerProblemBannerForTests,
+} from '~/shared/api/httpDegradationReporter'
+import { typedFetch } from '~/shared/api/typedFetch'
+
+const TestResponseSchema = z.object({
+  ok: z.boolean(),
+})
+
+function enableBrowserRuntime(): void {
+  vi.stubGlobal('window', {})
+}
+
+function toJsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+describe('typedFetch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    resetServerProblemBannerForTests()
+  })
+
+  it('reports 5xx responses to the global degradation banner', async () => {
+    enableBrowserRuntime()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      toJsonResponse({ error: 'server exploded' }, 503),
+    )
+
+    await expect(typedFetch('/api/test', undefined, TestResponseSchema)).rejects.toThrow(
+      'server exploded',
+    )
+
+    expect(readServerProblemBannerState().visible).toBe(true)
+  })
+
+  it('does not report 4xx responses to the global degradation banner', async () => {
+    enableBrowserRuntime()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(toJsonResponse({ error: 'not found' }, 404))
+
+    await expect(typedFetch('/api/test', undefined, TestResponseSchema)).rejects.toThrow(
+      'not found',
+    )
+
+    expect(readServerProblemBannerState().visible).toBe(false)
+  })
+
+  it('reports network rejections to the global degradation banner', async () => {
+    enableBrowserRuntime()
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'))
+
+    await expect(typedFetch('/api/test', undefined, TestResponseSchema)).rejects.toThrow(
+      'network down',
+    )
+
+    expect(readServerProblemBannerState().visible).toBe(true)
+  })
+
+  it('rearms the banner after a successful monitored request', async () => {
+    enableBrowserRuntime()
+    reportHttpFailure({ status: 503 })
+    dismissServerProblemBanner()
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    fetchSpy.mockResolvedValueOnce(toJsonResponse({ ok: true }, 200))
+    fetchSpy.mockResolvedValueOnce(toJsonResponse({ error: 'server exploded' }, 503))
+
+    await expect(typedFetch('/api/test-ok', undefined, TestResponseSchema)).resolves.toEqual({
+      ok: true,
+    })
+    expect(readServerProblemBannerState().visible).toBe(false)
+
+    await expect(typedFetch('/api/test-fail', undefined, TestResponseSchema)).rejects.toThrow(
+      'server exploded',
+    )
+    expect(readServerProblemBannerState().visible).toBe(true)
+  })
+})

--- a/src/shared/api/typedFetch.ts
+++ b/src/shared/api/typedFetch.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { reportHttpFailure, reportHttpSuccess } from '~/shared/api/httpDegradationReporter'
 
 export class TypedFetchError extends Error {
   status: number
@@ -17,17 +18,26 @@ export async function typedFetch<T extends z.ZodTypeAny>(
   init: RequestInit | undefined,
   responseSchema: T,
 ): Promise<z.infer<T>> {
-  const res = await fetch(input, init)
+  let res: Response
+  try {
+    res = await fetch(input, init)
+  } catch (error) {
+    reportHttpFailure({ error })
+    throw error
+  }
+
+  if (res.ok) {
+    reportHttpSuccess()
+  } else {
+    reportHttpFailure({ status: res.status })
+  }
+
   const body = await res.json().catch(() => ({}))
 
   if (!res.ok) {
-    // try to extract structured error (may include additional fields like `existing`)
-    try {
-      const parsed = z.object({ error: z.string().optional() }).parse(body)
-      throw new TypedFetchError(parsed.error ?? res.statusText, res.status, body)
-    } catch {
-      throw new TypedFetchError(res.statusText, res.status, body)
-    }
+    const parsed = z.object({ error: z.string().optional() }).safeParse(body)
+    const message = parsed.success ? (parsed.data.error ?? res.statusText) : res.statusText
+    throw new TypedFetchError(message, res.status, body)
   }
 
   return responseSchema.parse(body)

--- a/src/shared/solid/resourceSnapshot.ts
+++ b/src/shared/solid/resourceSnapshot.ts
@@ -1,6 +1,9 @@
-import type { Resource } from 'solid-js'
+export type ResourceSnapshotLike<T> = {
+  readonly state: 'unresolved' | 'pending' | 'ready' | 'refreshing' | 'errored'
+  readonly latest: T | undefined
+}
 
-export function readResourceSnapshot<T>(resource: Resource<T>): T | undefined {
+export function readResourceSnapshot<T>(resource: ResourceSnapshotLike<T>): T | undefined {
   if (resource.state === 'ready' || resource.state === 'refreshing') {
     return resource.latest
   }

--- a/src/shared/ui/navbar-alerts/tests/useNavbarAlerts.test.ts
+++ b/src/shared/ui/navbar-alerts/tests/useNavbarAlerts.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasResolvedNavbarAlertsResource,
+  toNavbarAlertsState,
+} from '~/shared/ui/navbar-alerts/useNavbarAlerts'
+
+function buildErroredNavbarAlertsResource(): Parameters<typeof toNavbarAlertsState>[0] {
+  return {
+    error: new Error('navbar failed'),
+    loading: false,
+    state: 'errored',
+    get latest(): never {
+      throw new Error('navbar alerts resource latest should not be read')
+    },
+  }
+}
+
+describe('useNavbarAlerts helpers', () => {
+  it('builds a safe error state without reading the throwing resource accessor', () => {
+    const resource = buildErroredNavbarAlertsResource()
+
+    expect(toNavbarAlertsState(resource)).toEqual({
+      totalAlerts: 0,
+      processes: [],
+      loading: false,
+      error: 'navbar failed',
+    })
+    expect(hasResolvedNavbarAlertsResource(resource)).toBe(true)
+  })
+})

--- a/src/shared/ui/navbar-alerts/useNavbarAlerts.ts
+++ b/src/shared/ui/navbar-alerts/useNavbarAlerts.ts
@@ -1,5 +1,7 @@
 import { type Accessor, createEffect, createMemo, createResource, createSignal } from 'solid-js'
 import { fetchNavbarAlertsSummary } from '~/shared/api/navbar-alerts/navbar-alerts.api'
+import type { ResourceSnapshotLike } from '~/shared/solid/resourceSnapshot'
+import { readResourceSnapshot } from '~/shared/solid/resourceSnapshot'
 import { toNavbarAlertsVM } from '~/shared/ui/navbar-alerts/navbar-alerts.mapper'
 import {
   EMPTY_NAVBAR_ALERTS_VM,
@@ -26,6 +28,30 @@ function toErrorMessage(error: unknown): string {
   return 'Failed to load navbar alerts'
 }
 
+export function toNavbarAlertsState(
+  resource: ResourceSnapshotLike<NavbarAlertsVM | undefined> & {
+    readonly loading: boolean
+    readonly error: unknown
+  },
+): NavbarAlertsState {
+  const vm = readResourceSnapshot(resource) ?? EMPTY_NAVBAR_ALERTS_VM
+
+  return {
+    totalAlerts: vm.totalAlerts,
+    processes: vm.processes,
+    loading: resource.loading,
+    error: resource.error ? toErrorMessage(resource.error) : null,
+  }
+}
+
+export function hasResolvedNavbarAlertsResource(
+  resource: ResourceSnapshotLike<NavbarAlertsVM | undefined> & {
+    readonly error: unknown
+  },
+): boolean {
+  return readResourceSnapshot(resource) !== undefined || Boolean(resource.error)
+}
+
 export function useNavbarAlerts(): UseNavbarAlertsResult {
   let shouldPreferCached = true
   const [hasResolved, setHasResolved] = createSignal(false)
@@ -38,18 +64,10 @@ export function useNavbarAlerts(): UseNavbarAlertsResult {
     return toNavbarAlertsVM(response)
   })
 
-  const state = createMemo<NavbarAlertsState>(() => {
-    const vm = resource() ?? EMPTY_NAVBAR_ALERTS_VM
-    return {
-      totalAlerts: vm.totalAlerts,
-      processes: vm.processes,
-      loading: resource.loading,
-      error: resource.error ? toErrorMessage(resource.error) : null,
-    }
-  })
+  const state = createMemo<NavbarAlertsState>(() => toNavbarAlertsState(resource))
 
   createEffect(() => {
-    if (resource() !== undefined || resource.error) {
+    if (hasResolvedNavbarAlertsResource(resource)) {
       setHasResolved(true)
     }
   })


### PR DESCRIPTION
## Summary

- What changed: Introduced a global banner for server problems and implemented HTTP degradation reporting across various fetch requests.
- Why: To enhance user experience by providing clear feedback during server issues and to monitor HTTP request performance.

## Architecture Boundary

- [x] Affected boundary is explicit (`ui`, `infrastructure`)
- [x] Placement is justified (folder + file role match responsibility)
- [x] No forbidden dependency direction was introduced (`modules -> capabilities`, `domain -> transport/ui`)

## Validation / Parsing Mode (ADR-0021)

- [x] Parsing mode is explicit in the changed code:
  - [x] `tolerant external parsing`
- [x] Domain remains free of transport schema/decode helpers
- [x] `*.validation.ts` files do not perform network/cache/orchestration IO
- [x] Parse/decode failures remain explicit (no silent suppression)

## Hotspot Impact

- [x] This PR does not increase hotspot concentration without rationale
- [x] If a hotspot grew, rationale and follow-up are documented below
- [x] Related hotspot (if any):
- [x] Follow-up action and target sprint:

## ADR Decision Gate

- [x] Existing docs/ADRs were sufficient for this change
- [x] If proposing new ADR, evidence is attached:
  - [x] recurrence across multiple points
  - [x] boundary/layer ownership impact
  - [x] insufficiency of existing docs
  - [x] cannot be solved by local refactor/checklist

## Checks

- [x] `pnpm check` is green locally
- [x] Relevant tests for changed behavior were updated

