### PR TITLE
improvement(validation): remove redundant expected validation 

### DIFF
--- a/src/modules/tracking/features/validation/application/tests/trackingValidation.projection.test.ts
+++ b/src/modules/tracking/features/validation/application/tests/trackingValidation.projection.test.ts
@@ -203,7 +203,7 @@ describe('trackingValidation.projection', () => {
     })
   })
 
-  it('suppresses the missing milestone advisory for a plain maritime gap while keeping other advisory detectors', () => {
+  it('does not surface redundant EXPECTED-after-ACTUAL residue as an active validation issue', () => {
     const observations = [
       makeObservation({
         id: 'load-1',
@@ -252,30 +252,13 @@ describe('trackingValidation.projection', () => {
       now: Instant.fromIso('2026-04-12T10:00:00.000Z'),
     })
 
-    expect(summary).toMatchObject({
-      hasIssues: true,
-      findingCount: 1,
-      highestSeverity: 'ADVISORY',
-      topIssue: {
-        code: 'EXPECTED_PLAN_NOT_RECONCILABLE',
-        severity: 'ADVISORY',
-        reasonKey: 'tracking.validation.expectedPlanNotReconcilable',
-        affectedArea: 'series',
-        affectedLocation: 'BRSSZ',
-        affectedBlockLabelKey: null,
-      },
+    expect(summary).toEqual({
+      hasIssues: false,
+      findingCount: 0,
+      highestSeverity: null,
+      topIssue: null,
+      activeIssues: [],
     })
-    expect(summary.activeIssues).toEqual([
-      {
-        code: 'EXPECTED_PLAN_NOT_RECONCILABLE',
-        severity: 'ADVISORY',
-        reasonKey: 'tracking.validation.expectedPlanNotReconcilable',
-        affectedArea: 'series',
-        affectedLocation: 'BRSSZ',
-        affectedBlockLabelKey: null,
-      },
-    ])
-    expect(summary.activeIssues[0]).not.toHaveProperty('debugEvidence')
   })
 
   it('surfaces missing critical milestone only when repeated downstream ACTUAL reinforces the gap', () => {

--- a/src/modules/tracking/features/validation/domain/detectors/expectedPlanNotReconcilable.detector.ts
+++ b/src/modules/tracking/features/validation/domain/detectors/expectedPlanNotReconcilable.detector.ts
@@ -119,7 +119,9 @@ function createFinding(
       seriesKey,
       seriesType: primary.type,
     },
-    isActive: true,
+    // Redundant EXPECTED after ACTUAL is preserved for audit, but should not
+    // promote an operational validation state by itself.
+    isActive: false,
   }
 }
 

--- a/src/modules/tracking/features/validation/domain/tests/expectedPlanNotReconcilable.detector.test.ts
+++ b/src/modules/tracking/features/validation/domain/tests/expectedPlanNotReconcilable.detector.test.ts
@@ -78,7 +78,7 @@ describe('expectedPlanNotReconcilableDetector', () => {
     expect(findings).toEqual([])
   })
 
-  it('emits one ADVISORY finding when an EXPECTED remains redundant after ACTUAL in the same series', () => {
+  it('returns an inactive ADVISORY finding when an EXPECTED remains redundant after ACTUAL in the same series', () => {
     const findings = expectedPlanNotReconcilableDetector.detect(
       makeContext([
         makeObservation({
@@ -105,7 +105,7 @@ describe('expectedPlanNotReconcilableDetector', () => {
       summaryKey: 'tracking.validation.expectedPlanNotReconcilable',
       affectedLocation: 'BRSSZ',
       affectedBlockLabelKey: null,
-      isActive: true,
+      isActive: false,
       debugEvidence: {
         locationCode: 'BRSSZ',
         primaryObservationId: 'arrival-actual',

--- a/tools/agent-control-ui/ipc.ts
+++ b/tools/agent-control-ui/ipc.ts
@@ -1,1 +1,21 @@
-export * from '@tools/agent/electron/ipc'
+import type { AgentControlRendererApi as CanonicalAgentControlRendererApi } from '@tools/agent/electron/ipc'
+import {
+  AgentControlBackendUrlInputSchema as canonicalAgentControlBackendUrlInputSchema,
+  AgentControlBlockedVersionsInputSchema as canonicalAgentControlBlockedVersionsInputSchema,
+  AgentControlChannelInputSchema as canonicalAgentControlChannelInputSchema,
+  AgentControlConfigPatchInputSchema as canonicalAgentControlConfigPatchInputSchema,
+  agentControlIpcChannels as canonicalAgentControlIpcChannels,
+  AgentControlLogsQuerySchema as canonicalAgentControlLogsQuerySchema,
+  AgentControlReleaseVersionInputSchema as canonicalAgentControlReleaseVersionInputSchema,
+} from '@tools/agent/electron/ipc'
+
+export const agentControlIpcChannels = canonicalAgentControlIpcChannels
+export const AgentControlLogsQuerySchema = canonicalAgentControlLogsQuerySchema
+export const AgentControlChannelInputSchema = canonicalAgentControlChannelInputSchema
+export const AgentControlBlockedVersionsInputSchema =
+  canonicalAgentControlBlockedVersionsInputSchema
+export const AgentControlConfigPatchInputSchema = canonicalAgentControlConfigPatchInputSchema
+export const AgentControlBackendUrlInputSchema = canonicalAgentControlBackendUrlInputSchema
+export const AgentControlReleaseVersionInputSchema = canonicalAgentControlReleaseVersionInputSchema
+
+export type AgentControlRendererApi = CanonicalAgentControlRendererApi

--- a/tools/agent-control-ui/linux-installed-service.ts
+++ b/tools/agent-control-ui/linux-installed-service.ts
@@ -1,1 +1,3 @@
-export * from '@tools/agent/electron/main/installed-linux-control-service'
+import { createInstalledLinuxControlService as canonicalCreateInstalledLinuxControlService } from '@tools/agent/electron/main/installed-linux-control-service'
+
+export const createInstalledLinuxControlService = canonicalCreateInstalledLinuxControlService

--- a/tools/agent-control-ui/renderer/AgentControlApp.tsx
+++ b/tools/agent-control-ui/renderer/AgentControlApp.tsx
@@ -1,1 +1,3 @@
-export { AgentControlApp } from '@tools/agent/electron/renderer/AgentControlApp'
+import { AgentControlApp as canonicalAgentControlApp } from '@tools/agent/electron/renderer/AgentControlApp'
+
+export const AgentControlApp = canonicalAgentControlApp

--- a/tools/agent-control-ui/window-controller.ts
+++ b/tools/agent-control-ui/window-controller.ts
@@ -1,1 +1,7 @@
-export * from '@tools/agent/electron/main/window-controller'
+import {
+  createWindowLifecycleController as canonicalCreateWindowLifecycleController,
+  setupSingleInstance as canonicalSetupSingleInstance,
+} from '@tools/agent/electron/main/window-controller'
+
+export const createWindowLifecycleController = canonicalCreateWindowLifecycleController
+export const setupSingleInstance = canonicalSetupSingleInstance

--- a/tools/agent/agent.ts
+++ b/tools/agent/agent.ts
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import './runtime/runtime.entry.ts'
+import '@tools/agent/runtime/runtime.entry'

--- a/tools/agent/bootstrap/create-agent-runtime.ts
+++ b/tools/agent/bootstrap/create-agent-runtime.ts
@@ -1,7 +1,7 @@
 import {
+  type AgentPathLayout,
   ensureAgentPathLayout,
   resolveAgentPathLayout,
-  type AgentPathLayout,
 } from '@tools/agent/runtime-paths'
 
 export function createAgentRuntimeBootstrap(): { readonly layout: AgentPathLayout } {

--- a/tools/agent/bootstrap/create-control-service.ts
+++ b/tools/agent/bootstrap/create-control-service.ts
@@ -1,5 +1,5 @@
-import { createControlService } from '@tools/agent/control/control.service'
 import { createAgentRuntimeBootstrap } from '@tools/agent/bootstrap/create-agent-runtime'
+import { createControlService } from '@tools/agent/control/control.service'
 
 export function createBootstrapControlService() {
   const { layout } = createAgentRuntimeBootstrap()

--- a/tools/agent/build-release.ts
+++ b/tools/agent/build-release.ts
@@ -637,7 +637,9 @@ export function collectInstallerTaskRegistrationErrors(
     line.includes('agent-tray-host.ps1'),
   )
   if (usesLegacyAgentTrayHost) {
-    errors.push('installer.iss agent task must launch run-supervisor.ps1 instead of agent-tray-host.ps1')
+    errors.push(
+      'installer.iss agent task must launch run-supervisor.ps1 instead of agent-tray-host.ps1',
+    )
   }
 
   const launchesRuntimeShimDirectly = taskRegistrationLines.some((line) =>
@@ -782,7 +784,9 @@ async function resolvePackagePathFromTargetPnpmStore(command: {
   readonly targetNodeModulesDir: string
   readonly relativePathFromNodeModules: string
 }): Promise<string | null> {
-  const packagePath = parsePackagePathFromNodeModulesRelativePath(command.relativePathFromNodeModules)
+  const packagePath = parsePackagePathFromNodeModulesRelativePath(
+    command.relativePathFromNodeModules,
+  )
   if (!packagePath) {
     return null
   }
@@ -1310,7 +1314,8 @@ async function normalizeAbsoluteRuntimeSymlinks(command: {
       }
 
       if (!(await pathExists(remappedTargetPath))) {
-        const relativePathFromNodeModules = extractRelativePathFromAnyNodeModules(resolvedRealTargetPath)
+        const relativePathFromNodeModules =
+          extractRelativePathFromAnyNodeModules(resolvedRealTargetPath)
         if (relativePathFromNodeModules) {
           const targetStorePackagePath = await resolvePackagePathFromTargetPnpmStore({
             targetNodeModulesDir: command.targetNodeModulesDir,

--- a/tools/agent/cli/ct-agent-admin.ts
+++ b/tools/agent/cli/ct-agent-admin.ts
@@ -3,7 +3,7 @@
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-
+import { createBootstrapControlService } from '@tools/agent/bootstrap/create-control-service'
 import {
   AgentControlBackendStateSchema,
   AgentControlBackendUpdateResultSchema,
@@ -14,7 +14,6 @@ import {
   AgentOperationalSnapshotSchema,
   AgentReleaseInventorySchema,
 } from '@tools/agent/control-core/contracts'
-import { createBootstrapControlService } from '@tools/agent/bootstrap/create-control-service'
 import { writeAgentControlPublicBackendState } from '@tools/agent/control-core/public-control-files'
 import {
   readAgentControlPublicState,

--- a/tools/agent/config/resolve-agent-public-paths.ts
+++ b/tools/agent/config/resolve-agent-public-paths.ts
@@ -1,14 +1,29 @@
-export {
-  resolveAgentConfigDir,
-  resolveAgentDataDir,
-  resolveAgentDataDirFrom,
-  resolveAgentPublicBackendStatePath,
-  resolveAgentPublicLogsPath,
-  resolveAgentPublicStateDir,
-  resolveAgentPublicStateDirFrom,
-  resolveAgentPublicStatePath,
-  resolveLogsDir,
-  resolveReleaseStatePath,
-  type ResolveAgentDataDirCommand,
-  type ResolveAgentPublicStateDirCommand,
-} from '../runtime/paths.ts'
+import type {
+  ResolveAgentDataDirCommand as CanonicalResolveAgentDataDirCommand,
+  ResolveAgentPublicStateDirCommand as CanonicalResolveAgentPublicStateDirCommand,
+} from '@tools/agent/runtime/paths'
+import {
+  resolveAgentConfigDir as canonicalResolveAgentConfigDir,
+  resolveAgentDataDir as canonicalResolveAgentDataDir,
+  resolveAgentDataDirFrom as canonicalResolveAgentDataDirFrom,
+  resolveAgentPublicBackendStatePath as canonicalResolveAgentPublicBackendStatePath,
+  resolveAgentPublicLogsPath as canonicalResolveAgentPublicLogsPath,
+  resolveAgentPublicStateDir as canonicalResolveAgentPublicStateDir,
+  resolveAgentPublicStateDirFrom as canonicalResolveAgentPublicStateDirFrom,
+  resolveAgentPublicStatePath as canonicalResolveAgentPublicStatePath,
+  resolveLogsDir as canonicalResolveLogsDir,
+  resolveReleaseStatePath as canonicalResolveReleaseStatePath,
+} from '@tools/agent/runtime/paths'
+
+export type ResolveAgentDataDirCommand = CanonicalResolveAgentDataDirCommand
+export type ResolveAgentPublicStateDirCommand = CanonicalResolveAgentPublicStateDirCommand
+export const resolveAgentConfigDir = canonicalResolveAgentConfigDir
+export const resolveAgentDataDir = canonicalResolveAgentDataDir
+export const resolveAgentDataDirFrom = canonicalResolveAgentDataDirFrom
+export const resolveAgentPublicBackendStatePath = canonicalResolveAgentPublicBackendStatePath
+export const resolveAgentPublicLogsPath = canonicalResolveAgentPublicLogsPath
+export const resolveAgentPublicStateDir = canonicalResolveAgentPublicStateDir
+export const resolveAgentPublicStateDirFrom = canonicalResolveAgentPublicStateDirFrom
+export const resolveAgentPublicStatePath = canonicalResolveAgentPublicStatePath
+export const resolveLogsDir = canonicalResolveLogsDir
+export const resolveReleaseStatePath = canonicalResolveReleaseStatePath

--- a/tools/agent/control-core/local-control-service.ts
+++ b/tools/agent/control-core/local-control-service.ts
@@ -27,13 +27,13 @@ import {
   buildAgentReleaseInventory,
   readAgentControlPublicState,
 } from '@tools/agent/control-core/public-control-state'
+import { resolvePlatformAdapter } from '@tools/agent/platform/platform.adapter'
+import type { AgentPlatformControlAdapter } from '@tools/agent/platform/platform.contract'
 import {
   resolveReleaseEntrypoint,
   rollbackRelease as rollbackReleaseState,
 } from '@tools/agent/release-manager'
 import { readReleaseState, writeReleaseState } from '@tools/agent/release-state'
-import { resolvePlatformAdapter } from '@tools/agent/platform/platform.adapter'
-import type { AgentPlatformControlAdapter } from '@tools/agent/platform/platform.contract'
 import { resolveAgentPublicStatePath } from '@tools/agent/runtime/paths'
 import type { AgentPathLayout } from '@tools/agent/runtime-paths'
 import { writeSupervisorControl } from '@tools/agent/supervisor-control'

--- a/tools/agent/control/control.contracts.ts
+++ b/tools/agent/control/control.contracts.ts
@@ -1,12 +1,7 @@
+import { ControlStateSnapshotSchema } from '@tools/agent/control/control.state'
 import { z } from 'zod/v4'
 
-import { ControlStateSnapshotSchema } from './control.state.ts'
-
-export const ControlCommandExecutionStatusSchema = z.enum([
-  'accepted',
-  'completed',
-  'failed',
-])
+export const ControlCommandExecutionStatusSchema = z.enum(['accepted', 'completed', 'failed'])
 
 export const ControlCommandResultSchema = z.object({
   commandId: z.string().uuid(),

--- a/tools/agent/control/control.service.ts
+++ b/tools/agent/control/control.service.ts
@@ -1,22 +1,23 @@
-import {
-  type AgentControlBackendStateSchema,
-  type AgentControlBackendUpdateResultSchema,
-  type AgentControlCommandResultSchema,
-  type AgentControlLogsResponseSchema,
-  type AgentControlPaths,
-  type AgentReleaseInventorySchema,
+import type { ControlCommand } from '@tools/agent/control/control.commands'
+import { ControlCommandResultSchema } from '@tools/agent/control/control.contracts'
+import type {
+  AgentControlBackendStateSchema,
+  AgentControlBackendUpdateResultSchema,
+  AgentControlCommandResultSchema,
+  AgentControlLogsResponseSchema,
+  AgentControlPaths,
+  AgentReleaseInventorySchema,
 } from '@tools/agent/control-core/contracts'
 import { createAgentControlLocalService } from '@tools/agent/control-core/local-control-service'
 import type { AgentPathLayout } from '@tools/agent/runtime-paths'
 import type { z } from 'zod/v4'
 
-import type { ControlCommand } from './control.commands.ts'
-import { ControlCommandResultSchema } from './control.contracts.ts'
-
 type LocalControlService = ReturnType<typeof createAgentControlLocalService>
 
 export type ControlService = LocalControlService & {
-  readonly dispatch: (command: ControlCommand) => Promise<z.infer<typeof ControlCommandResultSchema>>
+  readonly dispatch: (
+    command: ControlCommand,
+  ) => Promise<z.infer<typeof ControlCommandResultSchema>>
 }
 
 type CreateControlServiceDeps = {
@@ -27,7 +28,9 @@ type CreateControlServiceDeps = {
 function toCommandResult(command: {
   readonly commandId: string
   readonly message: string
-  readonly snapshot: Awaited<ReturnType<LocalControlService['getAgentOperationalSnapshot']>>['snapshot']
+  readonly snapshot: Awaited<
+    ReturnType<LocalControlService['getAgentOperationalSnapshot']>
+  >['snapshot']
 }) {
   return ControlCommandResultSchema.parse({
     commandId: command.commandId,

--- a/tools/agent/control/control.state.ts
+++ b/tools/agent/control/control.state.ts
@@ -1,6 +1,6 @@
 import {
-  AgentOperationalSnapshotSchema,
   type AgentOperationalSnapshot,
+  AgentOperationalSnapshotSchema,
 } from '@tools/agent/control-core/contracts'
 
 export const ControlStateSnapshotSchema = AgentOperationalSnapshotSchema

--- a/tools/agent/electron/main/electron-main.ts
+++ b/tools/agent/electron/main/electron-main.ts
@@ -111,7 +111,9 @@ function createMainWindow(): ElectronBrowserWindow {
   if (rendererUrl) {
     void createdWindow.loadURL(rendererUrl)
   } else {
-    void createdWindow.loadFile(path.resolve(currentDir, '../../../agent-control-ui/renderer/index.html'))
+    void createdWindow.loadFile(
+      path.resolve(currentDir, '../../../agent-control-ui/renderer/index.html'),
+    )
   }
 
   return createdWindow

--- a/tools/agent/electron/main/installed-linux-control-service.ts
+++ b/tools/agent/electron/main/installed-linux-control-service.ts
@@ -24,8 +24,6 @@ import {
   buildAgentControlPaths,
   readAgentControlPublicState,
 } from '@tools/agent/control-core/public-control-state'
-import { resolveInstalledLinuxAgentPathLayout } from '@tools/agent/runtime-paths'
-import type { AgentPathLayout } from '@tools/agent/runtime-paths'
 import {
   AgentControlBackendUrlInputSchema,
   type AgentControlBlockedVersionsInputSchema,
@@ -34,6 +32,8 @@ import {
   type AgentControlLogsQuerySchema,
   type AgentControlReleaseVersionInputSchema,
 } from '@tools/agent/electron/ipc'
+import type { AgentPathLayout } from '@tools/agent/runtime-paths'
+import { resolveInstalledLinuxAgentPathLayout } from '@tools/agent/runtime-paths'
 import type { z } from 'zod/v4'
 
 function toErrorMessage(error: unknown): string {

--- a/tools/agent/platform/linux.adapter.ts
+++ b/tools/agent/platform/linux.adapter.ts
@@ -3,11 +3,9 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 
-// biome-ignore lint/style/noRestrictedImports: Platform runtime needs direct relative imports for portable release bundles.
-import { ensureDirectory, runCommand, tryCommand } from './common.ts'
-import { createLinuxLocalControlAdapter } from './local-control.adapter.ts'
-// biome-ignore lint/style/noRestrictedImports: Platform runtime needs direct relative imports for portable release bundles.
-import type { AgentPlatformAdapter } from './platform.types.ts'
+import { ensureDirectory, runCommand, tryCommand } from '@tools/agent/platform/common'
+import { createLinuxLocalControlAdapter } from '@tools/agent/platform/local-control.adapter'
+import type { AgentPlatformAdapter } from '@tools/agent/platform/platform.types'
 
 const DEFAULT_DATA_DIR_NAME = 'ContainerTracker'
 

--- a/tools/agent/platform/local-control.adapter.ts
+++ b/tools/agent/platform/local-control.adapter.ts
@@ -5,7 +5,7 @@ import type {
   AgentPlatformControlAdapter,
   PlatformControlCommand,
   PlatformServiceQueryResult,
-} from './platform.contract.ts'
+} from '@tools/agent/platform/platform.contract'
 
 const DEFAULT_LINUX_SERVICE_NAME = 'container-tracker-agent'
 const DEFAULT_WINDOWS_TASK_NAME = 'ContainerTrackerAgent'
@@ -42,7 +42,11 @@ function runCommand(
 }
 
 function resolveLinuxServiceName(command?: PlatformControlCommand): string {
-  return command?.serviceName?.trim() || process.env.AGENT_SERVICE_NAME?.trim() || DEFAULT_LINUX_SERVICE_NAME
+  return (
+    command?.serviceName?.trim() ||
+    process.env.AGENT_SERVICE_NAME?.trim() ||
+    DEFAULT_LINUX_SERVICE_NAME
+  )
 }
 
 function resolveWindowsTaskName(command?: PlatformControlCommand): string {
@@ -81,7 +85,9 @@ export function parseWindowsTaskQueryOutput(output: string): PlatformServiceQuer
   return { status: 'unknown', detail: output.trim() }
 }
 
-async function queryLinuxService(command?: PlatformControlCommand): Promise<PlatformServiceQueryResult> {
+async function queryLinuxService(
+  command?: PlatformControlCommand,
+): Promise<PlatformServiceQueryResult> {
   const serviceName = resolveLinuxServiceName(command)
 
   try {
@@ -106,7 +112,9 @@ function runWindowsTaskCommand(commandLine: string): Promise<void> {
   return runCommand('cmd.exe', ['/d', '/s', '/c', commandLine]).then(() => undefined)
 }
 
-async function queryWindowsTask(command?: PlatformControlCommand): Promise<PlatformServiceQueryResult> {
+async function queryWindowsTask(
+  command?: PlatformControlCommand,
+): Promise<PlatformServiceQueryResult> {
   const taskName = resolveWindowsTaskName(command)
 
   try {

--- a/tools/agent/platform/platform.types.ts
+++ b/tools/agent/platform/platform.types.ts
@@ -1,15 +1,29 @@
-export type {
-  AgentPlatformAdapter,
-  AgentPlatformControlAdapter,
-  AgentPlatformKey,
-  ExtractBundleArchiveKind,
-  ExtractBundleCommand,
-  PlatformControlCommand,
-  PlatformPathResolution,
-  PlatformServiceQueryResult,
-  PlatformServiceStatus,
-  ResolvePathsCommand,
-  RestartRuntimeCommand,
-  StartRuntimeCommand,
-  StopRuntimeCommand,
-} from './platform.contract.ts'
+import type {
+  AgentPlatformAdapter as CanonicalAgentPlatformAdapter,
+  AgentPlatformControlAdapter as CanonicalAgentPlatformControlAdapter,
+  AgentPlatformKey as CanonicalAgentPlatformKey,
+  ExtractBundleArchiveKind as CanonicalExtractBundleArchiveKind,
+  ExtractBundleCommand as CanonicalExtractBundleCommand,
+  PlatformControlCommand as CanonicalPlatformControlCommand,
+  PlatformPathResolution as CanonicalPlatformPathResolution,
+  PlatformServiceQueryResult as CanonicalPlatformServiceQueryResult,
+  PlatformServiceStatus as CanonicalPlatformServiceStatus,
+  ResolvePathsCommand as CanonicalResolvePathsCommand,
+  RestartRuntimeCommand as CanonicalRestartRuntimeCommand,
+  StartRuntimeCommand as CanonicalStartRuntimeCommand,
+  StopRuntimeCommand as CanonicalStopRuntimeCommand,
+} from '@tools/agent/platform/platform.contract'
+
+export type AgentPlatformAdapter = CanonicalAgentPlatformAdapter
+export type AgentPlatformControlAdapter = CanonicalAgentPlatformControlAdapter
+export type AgentPlatformKey = CanonicalAgentPlatformKey
+export type ExtractBundleArchiveKind = CanonicalExtractBundleArchiveKind
+export type ExtractBundleCommand = CanonicalExtractBundleCommand
+export type PlatformControlCommand = CanonicalPlatformControlCommand
+export type PlatformPathResolution = CanonicalPlatformPathResolution
+export type PlatformServiceQueryResult = CanonicalPlatformServiceQueryResult
+export type PlatformServiceStatus = CanonicalPlatformServiceStatus
+export type ResolvePathsCommand = CanonicalResolvePathsCommand
+export type RestartRuntimeCommand = CanonicalRestartRuntimeCommand
+export type StartRuntimeCommand = CanonicalStartRuntimeCommand
+export type StopRuntimeCommand = CanonicalStopRuntimeCommand

--- a/tools/agent/platform/windows.adapter.ts
+++ b/tools/agent/platform/windows.adapter.ts
@@ -3,11 +3,9 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 
-// biome-ignore lint/style/noRestrictedImports: Platform runtime needs direct relative imports for portable release bundles.
-import { ensureDirectory, runCommand, tryCommand } from './common.ts'
-import { createWindowsLocalControlAdapter } from './local-control.adapter.ts'
-// biome-ignore lint/style/noRestrictedImports: Platform runtime needs direct relative imports for portable release bundles.
-import type { AgentPlatformAdapter } from './platform.types.ts'
+import { ensureDirectory, runCommand, tryCommand } from '@tools/agent/platform/common'
+import { createWindowsLocalControlAdapter } from '@tools/agent/platform/local-control.adapter'
+import type { AgentPlatformAdapter } from '@tools/agent/platform/platform.types'
 
 const DEFAULT_DATA_DIR_NAME = 'ContainerTracker'
 

--- a/tools/agent/runtime-paths.ts
+++ b/tools/agent/runtime-paths.ts
@@ -1,23 +1,45 @@
-export type { AgentPathLayout } from './config/config.contract.ts'
-export {
-  resolveAgentConfigDir,
-  resolveAgentDataDir,
-  resolveAgentDataDirFrom,
-  resolveAgentPublicBackendStatePath,
-  resolveAgentPublicLogsPath,
-  resolveAgentPublicStateDir,
-  resolveAgentPublicStateDirFrom,
-  resolveAgentPublicStatePath,
-  resolveLogsDir,
-  resolveReleaseStatePath,
-  type ResolveAgentDataDirCommand,
-  type ResolveAgentPublicStateDirCommand,
-} from './runtime/paths.ts'
-export {
-  ensureAgentPathLayout,
-  resolveAgentPathLayout,
-  resolveCurrentRelease,
-  resolveDataDir,
-  resolveInstalledLinuxAgentPathLayout,
-  resolveReleasesDir,
-} from './config/resolve-agent-paths.ts'
+import type { AgentPathLayout as CanonicalAgentPathLayout } from '@tools/agent/config/config.contract'
+import {
+  ensureAgentPathLayout as canonicalEnsureAgentPathLayout,
+  resolveAgentPathLayout as canonicalResolveAgentPathLayout,
+  resolveCurrentRelease as canonicalResolveCurrentRelease,
+  resolveDataDir as canonicalResolveDataDir,
+  resolveInstalledLinuxAgentPathLayout as canonicalResolveInstalledLinuxAgentPathLayout,
+  resolveReleasesDir as canonicalResolveReleasesDir,
+} from '@tools/agent/config/resolve-agent-paths'
+import type {
+  ResolveAgentDataDirCommand as CanonicalResolveAgentDataDirCommand,
+  ResolveAgentPublicStateDirCommand as CanonicalResolveAgentPublicStateDirCommand,
+} from '@tools/agent/runtime/paths'
+import {
+  resolveAgentConfigDir as canonicalResolveAgentConfigDir,
+  resolveAgentDataDir as canonicalResolveAgentDataDir,
+  resolveAgentDataDirFrom as canonicalResolveAgentDataDirFrom,
+  resolveAgentPublicBackendStatePath as canonicalResolveAgentPublicBackendStatePath,
+  resolveAgentPublicLogsPath as canonicalResolveAgentPublicLogsPath,
+  resolveAgentPublicStateDir as canonicalResolveAgentPublicStateDir,
+  resolveAgentPublicStateDirFrom as canonicalResolveAgentPublicStateDirFrom,
+  resolveAgentPublicStatePath as canonicalResolveAgentPublicStatePath,
+  resolveLogsDir as canonicalResolveLogsDir,
+  resolveReleaseStatePath as canonicalResolveReleaseStatePath,
+} from '@tools/agent/runtime/paths'
+
+export type AgentPathLayout = CanonicalAgentPathLayout
+export const ensureAgentPathLayout = canonicalEnsureAgentPathLayout
+export const resolveAgentPathLayout = canonicalResolveAgentPathLayout
+export const resolveCurrentRelease = canonicalResolveCurrentRelease
+export const resolveDataDir = canonicalResolveDataDir
+export const resolveInstalledLinuxAgentPathLayout = canonicalResolveInstalledLinuxAgentPathLayout
+export const resolveReleasesDir = canonicalResolveReleasesDir
+export type ResolveAgentDataDirCommand = CanonicalResolveAgentDataDirCommand
+export type ResolveAgentPublicStateDirCommand = CanonicalResolveAgentPublicStateDirCommand
+export const resolveAgentConfigDir = canonicalResolveAgentConfigDir
+export const resolveAgentDataDir = canonicalResolveAgentDataDir
+export const resolveAgentDataDirFrom = canonicalResolveAgentDataDirFrom
+export const resolveAgentPublicBackendStatePath = canonicalResolveAgentPublicBackendStatePath
+export const resolveAgentPublicLogsPath = canonicalResolveAgentPublicLogsPath
+export const resolveAgentPublicStateDir = canonicalResolveAgentPublicStateDir
+export const resolveAgentPublicStateDirFrom = canonicalResolveAgentPublicStateDirFrom
+export const resolveAgentPublicStatePath = canonicalResolveAgentPublicStatePath
+export const resolveLogsDir = canonicalResolveLogsDir
+export const resolveReleaseStatePath = canonicalResolveReleaseStatePath

--- a/tools/agent/runtime/runtime.entry.ts
+++ b/tools/agent/runtime/runtime.entry.ts
@@ -41,10 +41,6 @@ import { resolveAgentPlatformKey } from '../platform/platform.adapter.ts'
 // biome-ignore lint/style/noRestrictedImports: Agent runtime uses Node --experimental-strip-types with direct .ts imports.
 import { readReleaseState, writeReleaseState } from '../release-state.ts'
 // biome-ignore lint/style/noRestrictedImports: Agent runtime uses Node --experimental-strip-types with direct .ts imports.
-import { EXIT_FATAL, EXIT_UPDATE_RESTART } from './lifecycle-exit-codes.ts'
-// biome-ignore lint/style/noRestrictedImports: Agent runtime keeps Linux public-state path resolution local to runtime helpers.
-import { resolveAgentPublicBackendStatePath, resolveAgentPublicStatePath } from './paths.ts'
-// biome-ignore lint/style/noRestrictedImports: Agent runtime uses Node --experimental-strip-types with direct .ts imports.
 import { writeRuntimeHealth } from '../runtime-health.ts'
 // biome-ignore lint/style/noRestrictedImports: Agent runtime uses Node --experimental-strip-types with direct .ts imports.
 import type { AgentPathLayout } from '../runtime-paths.ts'
@@ -58,6 +54,10 @@ import * as supervisorControl from '../supervisor-control.ts'
 import { resolveAutomaticUpdateChecksMode } from '../update-checks.ts'
 // biome-ignore lint/style/noRestrictedImports: Agent runtime uses Node --experimental-strip-types with direct .ts imports.
 import { fetchUpdateManifest, stageReleaseFromManifest } from '../updater.core.ts'
+// biome-ignore lint/style/noRestrictedImports: Agent runtime uses Node --experimental-strip-types with direct .ts imports.
+import { EXIT_FATAL, EXIT_UPDATE_RESTART } from './lifecycle-exit-codes.ts'
+// biome-ignore lint/style/noRestrictedImports: Agent runtime keeps Linux public-state path resolution local to runtime helpers.
+import { resolveAgentPublicBackendStatePath, resolveAgentPublicStatePath } from './paths.ts'
 
 function unquoteValue(value: string): string {
   if (value.length < 2) return value

--- a/tools/agent/supervisor.ts
+++ b/tools/agent/supervisor.ts
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import './supervisor/supervisor.entry.ts'
+import '@tools/agent/supervisor/supervisor.entry'

--- a/tools/agent/supervisor/supervisor.entry.ts
+++ b/tools/agent/supervisor/supervisor.entry.ts
@@ -28,9 +28,9 @@ import {
 } from '../runtime/paths.ts'
 import { readRuntimeHealth } from '../runtime-health.ts'
 import { ensureAgentPathLayout, resolveAgentPathLayout } from '../runtime-paths.ts'
-import { createRotatingChunkWriter } from './runtime-stdio-log-writer.ts'
 import { clearSupervisorControl } from '../supervisor-control.ts'
 import { resolveAutomaticUpdateChecksMode } from '../update-checks.ts'
+import { createRotatingChunkWriter } from './runtime-stdio-log-writer.ts'
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 30_000
 const DEFAULT_HEALTH_GRACE_MS = 120_000

--- a/tools/agent/tests/compatibility-wrappers.test.ts
+++ b/tools/agent/tests/compatibility-wrappers.test.ts
@@ -1,6 +1,4 @@
-import {
-  resolveAgentPathLayout as resolveCanonicalAgentPathLayout,
-} from '@tools/agent/config/resolve-agent-paths'
+import { resolveAgentPathLayout as resolveCanonicalAgentPathLayout } from '@tools/agent/config/resolve-agent-paths'
 import { agentControlIpcChannels as canonicalIpcChannels } from '@tools/agent/electron/ipc'
 import { createInstalledLinuxControlService as createCanonicalInstalledLinuxControlService } from '@tools/agent/electron/main/installed-linux-control-service'
 import { createWindowLifecycleController as createCanonicalWindowLifecycleController } from '@tools/agent/electron/main/window-controller'

--- a/tools/agent/tests/control.service.test.ts
+++ b/tools/agent/tests/control.service.test.ts
@@ -87,18 +87,36 @@ function createMockLocalService(): MockLocalService {
       infraConfigPath: '/tmp/agent/infra-config.json',
       auditLogPath: '/tmp/agent/agent-control-audit.ndjson',
     }),
-    startAgent: vi.fn().mockResolvedValue({ ok: true as const, message: 'started', snapshot: initialSnapshot }),
-    stopAgent: vi.fn().mockResolvedValue({ ok: true as const, message: 'stopped', snapshot: initialSnapshot }),
+    startAgent: vi
+      .fn()
+      .mockResolvedValue({ ok: true as const, message: 'started', snapshot: initialSnapshot }),
+    stopAgent: vi
+      .fn()
+      .mockResolvedValue({ ok: true as const, message: 'stopped', snapshot: initialSnapshot }),
     restartAgent: vi
       .fn()
       .mockResolvedValue({ ok: true as const, message: 'restarted', snapshot: initialSnapshot }),
-    pauseUpdates: vi.fn().mockResolvedValue({ ok: true as const, message: 'paused', snapshot: initialSnapshot }),
-    resumeUpdates: vi.fn().mockResolvedValue({ ok: true as const, message: 'resumed', snapshot: initialSnapshot }),
-    changeChannel: vi.fn().mockResolvedValue({ ok: true as const, message: 'channel updated', snapshot: initialSnapshot }),
-    setBlockedVersions: vi
+    pauseUpdates: vi
       .fn()
-      .mockResolvedValue({ ok: true as const, message: 'blocked versions updated', snapshot: initialSnapshot }),
-    updateConfig: vi.fn().mockResolvedValue({ ok: true as const, message: 'config updated', snapshot: initialSnapshot }),
+      .mockResolvedValue({ ok: true as const, message: 'paused', snapshot: initialSnapshot }),
+    resumeUpdates: vi
+      .fn()
+      .mockResolvedValue({ ok: true as const, message: 'resumed', snapshot: initialSnapshot }),
+    changeChannel: vi.fn().mockResolvedValue({
+      ok: true as const,
+      message: 'channel updated',
+      snapshot: initialSnapshot,
+    }),
+    setBlockedVersions: vi.fn().mockResolvedValue({
+      ok: true as const,
+      message: 'blocked versions updated',
+      snapshot: initialSnapshot,
+    }),
+    updateConfig: vi.fn().mockResolvedValue({
+      ok: true as const,
+      message: 'config updated',
+      snapshot: initialSnapshot,
+    }),
     setBackendUrl: vi.fn().mockResolvedValue({
       ok: true as const,
       message: 'backend updated',
@@ -113,9 +131,21 @@ function createMockLocalService(): MockLocalService {
         warnings: [],
       },
     }),
-    activateRelease: vi.fn().mockResolvedValue({ ok: true as const, message: 'release activated', snapshot: initialSnapshot }),
-    rollbackRelease: vi.fn().mockResolvedValue({ ok: true as const, message: 'rollback executed', snapshot: initialSnapshot }),
-    executeLocalReset: vi.fn().mockResolvedValue({ ok: true as const, message: 'reset executed', snapshot: initialSnapshot }),
+    activateRelease: vi.fn().mockResolvedValue({
+      ok: true as const,
+      message: 'release activated',
+      snapshot: initialSnapshot,
+    }),
+    rollbackRelease: vi.fn().mockResolvedValue({
+      ok: true as const,
+      message: 'rollback executed',
+      snapshot: initialSnapshot,
+    }),
+    executeLocalReset: vi.fn().mockResolvedValue({
+      ok: true as const,
+      message: 'reset executed',
+      snapshot: initialSnapshot,
+    }),
   }
 }
 

--- a/tools/agent/tests/runtime-stdio-log-writer.test.ts
+++ b/tools/agent/tests/runtime-stdio-log-writer.test.ts
@@ -1,13 +1,11 @@
 import { EventEmitter } from 'node:events'
 import os from 'node:os'
 import path from 'node:path'
-
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
 import {
-  createRotatingChunkWriter,
   type ChunkWritable,
+  createRotatingChunkWriter,
 } from '@tools/agent/supervisor/runtime-stdio-log-writer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 class StreamOpenError extends Error {
   readonly code: string

--- a/tools/agent/tests/supervisor-runtime-loader.test.ts
+++ b/tools/agent/tests/supervisor-runtime-loader.test.ts
@@ -16,6 +16,8 @@ describe('supervisor runtime alias loader resolution', () => {
     fs.writeFileSync(scriptPath, '', 'utf8')
     fs.writeFileSync(registerPath, '', 'utf8')
 
-    expect(resolveRuntimeExecArgv(scriptPath)).toEqual([`--import=${pathToFileURL(registerPath).href}`])
+    expect(resolveRuntimeExecArgv(scriptPath)).toEqual([
+      `--import=${pathToFileURL(registerPath).href}`,
+    ])
   })
 })

--- a/tools/agent/tests/windows-launcher.test.ts
+++ b/tools/agent/tests/windows-launcher.test.ts
@@ -29,7 +29,7 @@ describe('windows supervisor launcher', () => {
     const content = fs.readFileSync(agentTrayHostFileUrl, 'utf8')
 
     expect(content).toContain('register-alias-loader.js')
-    expect(content).toContain("\\app\\dist\\tools\\agent\\supervisor.js")
+    expect(content).toContain('\\app\\dist\\tools\\agent\\supervisor.js')
     expect(content).toContain('app\\dist\\tools\\agent\\agent.js')
     expect(content).not.toContain("Join-Path $installRoot 'app\\dist\\agent.js'")
   })

--- a/tools/agent/updater.ts
+++ b/tools/agent/updater.ts
@@ -3,11 +3,11 @@
 import path from 'node:path'
 import process from 'node:process'
 
-import { resolveAgentPathLayout } from './runtime-paths.ts'
+import { resolveAgentPathLayout } from '@tools/agent/runtime-paths'
 import {
   createUpdaterPublicLogsPublisher,
   runUpdaterMain,
-} from './updater/updater.entry.ts'
+} from '@tools/agent/updater/updater.entry'
 
 export { createUpdaterPublicLogsPublisher }
 


### PR DESCRIPTION
This pull request includes two main themes: a behavioral change in the tracking validation logic, and a broad refactor of internal module imports across the agent and agent-control-ui packages. The tracking validation update ensures that redundant EXPECTED-after-ACTUAL residues are not flagged as active validation issues. The refactor standardizes import/export patterns, improves clarity, and aligns files with canonical module entry points, especially for agent runtime, control, and UI modules.

**Behavioral change in tracking validation:**

* Redundant EXPECTED-after-ACTUAL findings are now marked as inactive (`isActive: false`) and are no longer surfaced as active validation issues in the summary. This is reflected in both the detector logic and its associated tests, ensuring that only meaningful issues are reported to users. [[1]](diffhunk://#diff-ad7b82e3fd1927b6c5635341b5ed08dad1fedc2bd77aa4095f3966ba0544dffbL122-R124) [[2]](diffhunk://#diff-f1a3a3c709c9c15ab170d7d1627d1413461c94358ced36d4ba1ea769bcfbf1f7L206-R206) [[3]](diffhunk://#diff-f1a3a3c709c9c15ab170d7d1627d1413461c94358ced36d4ba1ea769bcfbf1f7L255-L278) [[4]](diffhunk://#diff-c88c9e26a76f73bb32816144e514061b6e6a6fe7efbbf54592bdce73155fb88aL81-R81) [[5]](diffhunk://#diff-c88c9e26a76f73bb32816144e514061b6e6a6fe7efbbf54592bdce73155fb88aL108-R108)

**Refactor and standardization of module imports/exports:**

* The agent-control-ui and agent packages now re-export or alias canonical modules from their source locations, rather than using direct exports. This affects files like `ipc.ts`, `linux-installed-service.ts`, `window-controller.ts`, `AgentControlApp.tsx`, and several others, improving maintainability and clarity of module boundaries. [[1]](diffhunk://#diff-86390bce3309a542412e7d3288e0bbd3d35cd77193350d362622d4638d939de7L1-R21) [[2]](diffhunk://#diff-10653676131dd0be662f18598d1904327c9183f40e6bd7ea018d5afddad7133bL1-R3) [[3]](diffhunk://#diff-07ec5f6137d9f6e8fbd287786efeb1d5e72c05a742dbb0c593dbc7719b8c3883L1-R7) [[4]](diffhunk://#diff-12a9861977917e4e35c550ddf761682637a367128d5cf00388ca2dc69e0beec5L1-R3) [[5]](diffhunk://#diff-ce610a42118baf2c677a573145606255c55762297922e621dc5cb9ebd45b509cL1-R29)
* Internal agent runtime and control modules now consistently import types and functions from their canonical locations, with clearer separation between type-only imports and value imports. [[1]](diffhunk://#diff-6ca78464423e72f15cb0b3bec803f37be7d9b4d75cf12b5d47f57feb2e29e9e9R2-L4) [[2]](diffhunk://#diff-ab7e9b9bd327c4727f074496695ff145920f4296a879606563f820db3de2a189L1-R20) [[3]](diffhunk://#diff-ab7e9b9bd327c4727f074496695ff145920f4296a879606563f820db3de2a189L30-R33) [[4]](diffhunk://#diff-2f2618a89504a5060137a987f1d9e4318262a1701363b96069d43fd19fea393aL2-R3) [[5]](diffhunk://#diff-eeea7fdb91e80b626e2904e3a5ab6c4a4a96f4d895d65ad0cc7ab39dfce4cdafR1-R4) [[6]](diffhunk://#diff-53162eb165311c371fd7ba83596cf710a002845dd141ea454c41b1d9ff2ad97fL1-R2) [[7]](diffhunk://#diff-7e8f039349e4addcfe6783d73b369068af3142ec2bded5e60dab6f0cd2e4336aL6-R6) [[8]](diffhunk://#diff-7e8f039349e4addcfe6783d73b369068af3142ec2bded5e60dab6f0cd2e4336aL17)
* The agent entrypoint and bootstrap scripts now use the canonical runtime entry and path modules, further consolidating the runtime structure. [[1]](diffhunk://#diff-74d5a2214679aaf6965a46b7ce31c94f2adf6f046cb5f135f1f17eea50a606bfL3-R3) [[2]](diffhunk://#diff-6f44693b1a0624f52e1ce0dd3985bdca129c914829159b67a56072a56784a3fbR30-L36)
* Platform and electron main modules update their imports to use the canonical agent runtime and platform adapters, ensuring consistent type and value resolution. [[1]](diffhunk://#diff-c00f6959e818f4eac3cb323d20d1d8083e13464f81bba20d4809db6fb5f8b63aL27-L28) [[2]](diffhunk://#diff-c00f6959e818f4eac3cb323d20d1d8083e13464f81bba20d4809db6fb5f8b63aR35-R36) [[3]](diffhunk://#diff-9f34e50dd4a9125772ae27d2f52fb73f18036e4c471f7289d7eef84e9633e8d3L6-R8)
* Minor formatting improvements and line breaks for readability in several files, such as `build-release.ts` and `electron-main.ts`. [[1]](diffhunk://#diff-edf4ae1d411a4289ae944442962fb28d1b3c148cf6ab60644a4e9394a51c2e73L640-R642) [[2]](diffhunk://#diff-edf4ae1d411a4289ae944442962fb28d1b3c148cf6ab60644a4e9394a51c2e73L785-R789) [[3]](diffhunk://#diff-edf4ae1d411a4289ae944442962fb28d1b3c148cf6ab60644a4e9394a51c2e73L1313-R1318) [[4]](diffhunk://#diff-1ae28e50bb79c364d101b680b83520f6868755f3e2b98946bf747f6fd664c6f8L114-R116)