### PR TITLE
fix(agent): agent:run not working on linux

### DIFF
--- a/tools/agent/supervisor.ts
+++ b/tools/agent/supervisor.ts
@@ -1,3 +1,22 @@
 #!/usr/bin/env node
 
-import '@tools/agent/supervisor/supervisor.entry'
+import path from 'node:path'
+
+import { runSupervisorMain } from '@tools/agent/supervisor/supervisor.entry'
+
+export function isSupervisorEntrypoint(entrypoint = process.argv[1]): boolean {
+  if (!entrypoint) {
+    return false
+  }
+
+  const entrypointName = path.basename(entrypoint).toLowerCase()
+  return entrypointName === 'supervisor.js' || entrypointName === 'supervisor.ts'
+}
+
+if (isSupervisorEntrypoint()) {
+  void runSupervisorMain().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[supervisor] fatal error: ${message}`)
+    process.exitCode = 1
+  })
+}

--- a/tools/agent/supervisor/supervisor.entry.ts
+++ b/tools/agent/supervisor/supervisor.entry.ts
@@ -459,7 +459,7 @@ async function runChildWithoutHealthGate(command: {
   }
 }
 
-async function main(): Promise<void> {
+export async function runSupervisorMain(): Promise<void> {
   const scriptPath = fileURLToPath(import.meta.url)
   const scriptDir = path.dirname(scriptPath)
   const fallbackEntrypoint = resolveFallbackRuntimeEntrypoint(scriptDir)
@@ -905,7 +905,7 @@ function isDirectExecution(moduleUrl: string): boolean {
 }
 
 if (isDirectExecution(import.meta.url)) {
-  void main().catch((error) => {
+  void runSupervisorMain().catch((error) => {
     console.error(`[supervisor] fatal error: ${toErrorMessage(error)}`)
     process.exitCode = EXIT_FATAL
   })

--- a/tools/agent/tests/supervisor-wrapper.test.ts
+++ b/tools/agent/tests/supervisor-wrapper.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from 'vitest'
-
 import { isSupervisorEntrypoint } from '@tools/agent/supervisor'
+import { describe, expect, it } from 'vitest'
 
 describe('supervisor entry wrapper', () => {
   it('recognizes the compiled supervisor entrypoint', () => {

--- a/tools/agent/tests/supervisor-wrapper.test.ts
+++ b/tools/agent/tests/supervisor-wrapper.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSupervisorEntrypoint } from '@tools/agent/supervisor'
+
+describe('supervisor entry wrapper', () => {
+  it('recognizes the compiled supervisor entrypoint', () => {
+    expect(isSupervisorEntrypoint('/tmp/container-tracker/tools/agent/supervisor.js')).toBe(true)
+  })
+
+  it('recognizes the TypeScript supervisor entrypoint', () => {
+    expect(isSupervisorEntrypoint('/tmp/container-tracker/tools/agent/supervisor.ts')).toBe(true)
+  })
+
+  it('does not run for unrelated entrypoints', () => {
+    expect(isSupervisorEntrypoint('/tmp/container-tracker/tools/agent/agent.js')).toBe(false)
+  })
+})


### PR DESCRIPTION
This pull request refactors the supervisor entrypoint logic to make it more robust and testable. It introduces a new `isSupervisorEntrypoint` function to detect when the supervisor entry should run and exports the main supervisor function for improved clarity. Unit tests are also added to verify the new entrypoint detection logic.

**Entrypoint detection and execution:**
* Added `isSupervisorEntrypoint` function in `supervisor.ts` to determine if the current process should launch the supervisor, and refactored the entrypoint logic to use this function.
* Exported `runSupervisorMain` from `supervisor.entry.ts` and updated direct execution logic to use the new function name for clarity. [[1]](diffhunk://#diff-5243e88c323ab2a33880abc9150a8d81328b380d6ba0c7b19bbcb85c9448e24eL462-R462) [[2]](diffhunk://#diff-5243e88c323ab2a33880abc9150a8d81328b380d6ba0c7b19bbcb85c9448e24eL908-R908)

**Testing:**
* Added unit tests in `supervisor-wrapper.test.ts` to verify that `isSupervisorEntrypoint` correctly recognizes supervisor entrypoints and excludes unrelated files.