### PR TITLE
Stabilize same-day event ordering for block derivation

### DIFF
--- a/src/modules/process/ui/timeline/tests/timelineBlockModel.test.ts
+++ b/src/modules/process/ui/timeline/tests/timelineBlockModel.test.ts
@@ -32,6 +32,109 @@ function requireDefined<T>(value: T | undefined): T {
   return value
 }
 
+type SameDayTieEventKey = 'load' | 'positionedIn' | 'positionedOut' | 'other'
+
+function makeMscSameDayTransshipmentFixture(
+  sameDayOrder: readonly SameDayTieEventKey[],
+): readonly TrackingTimelineItem[] {
+  const sameDayEventTime = temporalDtoFromCanonical('2026-02-28')
+  const sameDayEvents: Record<SameDayTieEventKey, TrackingTimelineItem> = {
+    load: makeEvent({
+      id: 'same-day-load',
+      type: 'LOAD',
+      eventTime: sameDayEventTime,
+      vesselName: 'MSC BIANCA SILVIA',
+      voyage: 'UX605A',
+      location: 'BUSAN, KR',
+    }),
+    positionedIn: makeEvent({
+      id: 'same-day-positioned-in',
+      type: 'TRANSSHIPMENT_POSITIONED_IN',
+      eventTime: sameDayEventTime,
+      location: 'BUSAN, KR',
+    }),
+    positionedOut: makeEvent({
+      id: 'same-day-positioned-out',
+      type: 'TRANSSHIPMENT_POSITIONED_OUT',
+      eventTime: sameDayEventTime,
+      location: 'BUSAN, KR',
+    }),
+    other: makeEvent({
+      id: 'same-day-other',
+      type: 'OTHER',
+      eventTime: sameDayEventTime,
+      location: 'BUSAN, KR',
+    }),
+  }
+
+  return [
+    makeEvent({
+      id: 'pre-gate-out',
+      type: 'GATE_OUT',
+      eventTime: temporalDtoFromCanonical('2025-11-30'),
+      location: 'FAISALABAD, PK',
+    }),
+    makeEvent({
+      id: 'pre-gate-in',
+      type: 'GATE_IN',
+      eventTime: temporalDtoFromCanonical('2025-12-30'),
+      location: 'KARACHI, PK',
+    }),
+    makeEvent({
+      id: 'voyage-a-load',
+      type: 'LOAD',
+      eventTime: temporalDtoFromCanonical('2026-01-02'),
+      vesselName: 'MSC IRIS',
+      voyage: 'QS551R',
+      location: 'KARACHI, PK',
+    }),
+    makeEvent({
+      id: 'voyage-a-discharge',
+      type: 'DISCHARGE',
+      eventTime: temporalDtoFromCanonical('2026-02-10'),
+      vesselName: 'MSC IRIS',
+      voyage: 'UX604A',
+      location: 'BUSAN, KR',
+    }),
+    ...sameDayOrder.map((key) => sameDayEvents[key]),
+    makeEvent({
+      id: 'voyage-b-arrival-expected',
+      type: 'ARRIVAL',
+      eventTime: temporalDtoFromCanonical('2026-05-08'),
+      eventTimeType: 'EXPECTED',
+      derivedState: 'ACTIVE_EXPECTED',
+      vesselName: 'MSC BIANCA SILVIA',
+      voyage: 'UX614R',
+      location: 'SANTOS, BR',
+    }),
+  ]
+}
+
+function renderListSignature(
+  renderList: ReturnType<typeof buildTimelineRenderList>,
+): readonly string[] {
+  return renderList.map((item) => {
+    switch (item.type) {
+      case 'voyage-block':
+        return `voyage-block:${item.block.vessel ?? ''}:${item.block.voyage ?? ''}:${item.block.origin ?? ''}:${item.block.destination ?? ''}`
+      case 'terminal-block':
+        return `terminal-block:${item.block.kind}:${item.block.events.map((event) => event.type).join(',')}`
+      case 'transshipment-block':
+        return `transshipment-block:${item.block.fromVessel ?? ''}:${item.block.toVessel ?? ''}:${item.block.port ?? ''}`
+      case 'event':
+        return `event:${item.event.id}:${item.event.type}:${item.isLast ? 'last' : 'mid'}`
+      case 'gap-marker':
+        return `gap-marker:${item.marker.kind}:${item.marker.fromEventType}:${item.marker.toEventType}:${item.marker.durationDays}`
+      case 'port-risk-marker':
+        return `port-risk-marker:${item.marker.severity}:${item.marker.durationDays}:${item.marker.ongoing ? 'ongoing' : 'closed'}`
+      case 'block-end':
+        return 'block-end'
+      default:
+        return 'unreachable'
+    }
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Phase 4-5 — buildTimelineRenderList (block assembly + transshipment)
 // ---------------------------------------------------------------------------
@@ -42,10 +145,31 @@ describe('buildTimelineRenderList voyage grouping', () => {
 
   it('creates a voyage block for a single voyage', () => {
     const events = [
-      makeEvent({ id: 'e1', type: 'LOAD', vesselName: 'V1', location: 'A' }),
-      makeEvent({ id: 'e2', type: 'DEPARTURE', location: 'A' }),
-      makeEvent({ id: 'e3', type: 'ARRIVAL', location: 'B' }),
-      makeEvent({ id: 'e4', type: 'DISCHARGE', location: 'B' }),
+      makeEvent({
+        id: 'e1',
+        type: 'LOAD',
+        vesselName: 'V1',
+        location: 'A',
+        eventTime: temporalDtoFromCanonical('2026-03-01T00:00:00Z'),
+      }),
+      makeEvent({
+        id: 'e2',
+        type: 'DEPARTURE',
+        location: 'A',
+        eventTime: temporalDtoFromCanonical('2026-03-02T00:00:00Z'),
+      }),
+      makeEvent({
+        id: 'e3',
+        type: 'ARRIVAL',
+        location: 'B',
+        eventTime: temporalDtoFromCanonical('2026-03-03T00:00:00Z'),
+      }),
+      makeEvent({
+        id: 'e4',
+        type: 'DISCHARGE',
+        location: 'B',
+        eventTime: temporalDtoFromCanonical('2026-03-04T00:00:00Z'),
+      }),
     ]
     const renderList = buildTimelineRenderList(
       events,
@@ -68,6 +192,7 @@ describe('buildTimelineRenderList voyage grouping', () => {
       makeEvent({
         id: 'e1',
         type: 'DEPARTURE',
+        eventTime: temporalDtoFromCanonical('2026-04-01T00:00:00Z'),
         eventTimeType: 'EXPECTED',
         derivedState: 'ACTIVE_EXPECTED',
         vesselName: 'MSC MIRAYA V',
@@ -77,6 +202,7 @@ describe('buildTimelineRenderList voyage grouping', () => {
       makeEvent({
         id: 'e2',
         type: 'ARRIVAL',
+        eventTime: temporalDtoFromCanonical('2026-04-04T00:00:00Z'),
         eventTimeType: 'EXPECTED',
         derivedState: 'ACTIVE_EXPECTED',
         vesselName: 'MSC MIRAYA V',
@@ -236,11 +362,24 @@ describe('buildTimelineRenderList terminal grouping', () => {
 
   it('renders transshipment helper events as transshipment-terminal between maritime legs', () => {
     const events = [
-      makeEvent({ id: 'e1', type: 'LOAD', vesselName: 'V1', voyage: 'VY1', location: 'A' }),
-      makeEvent({ id: 'e2', type: 'DISCHARGE', location: 'B' }),
+      makeEvent({
+        id: 'e1',
+        type: 'LOAD',
+        vesselName: 'V1',
+        voyage: 'VY1',
+        location: 'A',
+        eventTime: temporalDtoFromCanonical('2026-03-01T00:00:00Z'),
+      }),
+      makeEvent({
+        id: 'e2',
+        type: 'DISCHARGE',
+        location: 'B',
+        eventTime: temporalDtoFromCanonical('2026-03-04T00:00:00Z'),
+      }),
       makeEvent({
         id: 'e3',
         type: 'TRANSSHIPMENT_INTENDED',
+        eventTime: temporalDtoFromCanonical('2026-03-05T00:00:00Z'),
         eventTimeType: 'EXPECTED',
         derivedState: 'ACTIVE_EXPECTED',
         location: 'B',
@@ -248,11 +387,13 @@ describe('buildTimelineRenderList terminal grouping', () => {
       makeEvent({
         id: 'e4',
         type: 'TRANSSHIPMENT_POSITIONED_IN',
+        eventTime: temporalDtoFromCanonical('2026-03-06T00:00:00Z'),
         location: 'B',
       }),
       makeEvent({
         id: 'e5',
         type: 'DEPARTURE',
+        eventTime: temporalDtoFromCanonical('2026-03-07T00:00:00Z'),
         eventTimeType: 'EXPECTED',
         derivedState: 'ACTIVE_EXPECTED',
         vesselName: 'V2',
@@ -262,6 +403,7 @@ describe('buildTimelineRenderList terminal grouping', () => {
       makeEvent({
         id: 'e6',
         type: 'ARRIVAL',
+        eventTime: temporalDtoFromCanonical('2026-03-10T00:00:00Z'),
         eventTimeType: 'EXPECTED',
         derivedState: 'ACTIVE_EXPECTED',
         vesselName: 'V2',
@@ -285,6 +427,77 @@ describe('buildTimelineRenderList terminal grouping', () => {
       expect(terminalBlock.block.events.map((event) => event.type)).toEqual([
         'TRANSSHIPMENT_INTENDED',
         'TRANSSHIPMENT_POSITIONED_IN',
+      ])
+    }
+  })
+})
+
+describe('buildTimelineRenderList same-day tie-break ordering', () => {
+  it('keeps MSC date-only transshipment helpers inside transshipment-terminal blocks', () => {
+    const renderList = buildTimelineRenderList(
+      makeMscSameDayTransshipmentFixture(['load', 'positionedOut', 'positionedIn']),
+      instantFromIsoText('2026-04-02T00:00:00.000Z'),
+    )
+
+    const transshipmentTerminalBlocks = renderList.filter(
+      (item) => item.type === 'terminal-block' && item.block.kind === 'transshipment-terminal',
+    )
+    const postCarriageBlocks = renderList.filter(
+      (item) => item.type === 'terminal-block' && item.block.kind === 'post-carriage',
+    )
+
+    expect(transshipmentTerminalBlocks).toHaveLength(1)
+    expect(postCarriageBlocks).toHaveLength(0)
+
+    const terminalBlock = requireDefined(transshipmentTerminalBlocks[0])
+    if (terminalBlock.type === 'terminal-block') {
+      expect(terminalBlock.block.events.map((event) => event.type)).toEqual([
+        'TRANSSHIPMENT_POSITIONED_IN',
+        'TRANSSHIPMENT_POSITIONED_OUT',
+      ])
+    }
+  })
+
+  it('produces identical block output across same-day tie permutations', () => {
+    const sameDayOrders: readonly (readonly SameDayTieEventKey[])[] = [
+      ['load', 'positionedIn', 'positionedOut'],
+      ['positionedOut', 'load', 'positionedIn'],
+      ['positionedIn', 'positionedOut', 'load'],
+      ['positionedOut', 'positionedIn', 'load'],
+    ]
+
+    const signatures = sameDayOrders.map((sameDayOrder) =>
+      renderListSignature(
+        buildTimelineRenderList(
+          makeMscSameDayTransshipmentFixture(sameDayOrder),
+          instantFromIsoText('2026-04-02T00:00:00.000Z'),
+        ),
+      ),
+    )
+
+    const baselineSignature = requireDefined(signatures[0])
+    for (const signature of signatures.slice(1)) {
+      expect(signature).toEqual(baselineSignature)
+    }
+  })
+
+  it('keeps transshipment grouping stable when an unknown same-day event is present', () => {
+    const renderList = buildTimelineRenderList(
+      makeMscSameDayTransshipmentFixture(['load', 'other', 'positionedOut', 'positionedIn']),
+      instantFromIsoText('2026-04-02T00:00:00.000Z'),
+    )
+
+    const transshipmentTerminalBlocks = renderList.filter(
+      (item) => item.type === 'terminal-block' && item.block.kind === 'transshipment-terminal',
+    )
+
+    expect(transshipmentTerminalBlocks).toHaveLength(1)
+
+    const terminalBlock = requireDefined(transshipmentTerminalBlocks[0])
+    if (terminalBlock.type === 'terminal-block') {
+      expect(terminalBlock.block.events.map((event) => event.type)).toEqual([
+        'TRANSSHIPMENT_POSITIONED_IN',
+        'TRANSSHIPMENT_POSITIONED_OUT',
       ])
     }
   })

--- a/src/modules/tracking/features/timeline/application/projection/tracking.timeline.blocks.readmodel.ts
+++ b/src/modules/tracking/features/timeline/application/projection/tracking.timeline.blocks.readmodel.ts
@@ -60,6 +60,89 @@ function dominantLocation(events: readonly TrackingTimelineItem[]): string | nul
   return best
 }
 
+const EVENT_TIE_BREAK_PRIORITY = new Map<string, number>([
+  ['GATE_OUT', 10],
+  ['GATE_IN', 20],
+  ['ARRIVAL', 30],
+  ['DISCHARGE', 40],
+  ['TRANSSHIPMENT_INTENDED', 50],
+  ['TRANSSHIPMENT_POSITIONED_IN', 60],
+  ['TERMINAL_MOVE', 70],
+  ['TRANSSHIPMENT_POSITIONED_OUT', 80],
+  ['LOAD', 90],
+  ['DEPARTURE', 100],
+  ['DELIVERY', 110],
+  ['EMPTY_RETURN', 120],
+])
+
+const DEFAULT_EVENT_TIE_BREAK_PRIORITY = 500
+
+function compareTextValue(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): number {
+  const normalizedLeft = left ?? ''
+  const normalizedRight = right ?? ''
+
+  if (normalizedLeft < normalizedRight) return -1
+  if (normalizedLeft > normalizedRight) return 1
+  return 0
+}
+
+function eventTieBreakPriority(type: string): number {
+  return EVENT_TIE_BREAK_PRIORITY.get(type) ?? DEFAULT_EVENT_TIE_BREAK_PRIORITY
+}
+
+function compareTimelineItemsForBlockDerivation(
+  left: TrackingTimelineItem,
+  right: TrackingTimelineItem,
+): number {
+  const leftInstant = toTimelineInstant(left.eventTime)
+  const rightInstant = toTimelineInstant(right.eventTime)
+
+  if (leftInstant === null && rightInstant !== null) return 1
+  if (leftInstant !== null && rightInstant === null) return -1
+
+  if (leftInstant !== null && rightInstant !== null) {
+    const timeCompare = leftInstant.compare(rightInstant)
+    if (timeCompare !== 0) return timeCompare
+  }
+
+  if (left.eventTimeType === 'ACTUAL' && right.eventTimeType === 'EXPECTED') return -1
+  if (left.eventTimeType === 'EXPECTED' && right.eventTimeType === 'ACTUAL') return 1
+
+  const priorityCompare = eventTieBreakPriority(left.type) - eventTieBreakPriority(right.type)
+  if (priorityCompare !== 0) return priorityCompare
+
+  const typeCompare = compareTextValue(left.type, right.type)
+  if (typeCompare !== 0) return typeCompare
+
+  const locationCompare = compareTextValue(left.location, right.location)
+  if (locationCompare !== 0) return locationCompare
+
+  const vesselCompare = compareTextValue(left.vesselName, right.vesselName)
+  if (vesselCompare !== 0) return vesselCompare
+
+  const voyageCompare = compareTextValue(left.voyage, right.voyage)
+  if (voyageCompare !== 0) return voyageCompare
+
+  return compareTextValue(left.id, right.id)
+}
+
+/**
+ * Timeline block classification depends on the relative order of timeline items.
+ * Providers that emit date-only milestones can collapse multiple transshipment
+ * steps onto the same comparable instant, so we apply a semantic tie-break here
+ * to keep those helper events stable and prevent them from drifting into
+ * post-carriage because of incidental array order.
+ */
+function sortTimelineItemsForBlockDerivation(
+  events: readonly TrackingTimelineItem[],
+): readonly TrackingTimelineItem[] {
+  if (events.length < 2) return events
+  return [...events].sort(compareTimelineItemsForBlockDerivation)
+}
+
 /**
  * Group events that do NOT belong to any voyage segment into terminal segments.
  *
@@ -420,11 +503,12 @@ export function buildTimelineRenderList(
 ): readonly TimelineRenderItem[] {
   if (events.length === 0) return []
 
-  const voyageSegments = groupVoyageSegments(events)
-  const terminalSegments = groupTerminalSegments(events, voyageSegments)
+  const orderedEvents = sortTimelineItemsForBlockDerivation(events)
+  const voyageSegments = groupVoyageSegments(orderedEvents)
+  const terminalSegments = groupTerminalSegments(orderedEvents, voyageSegments)
   const transshipments = detectTransshipmentsBetweenVoyages(voyageSegments)
-  const gapMarkers = computeGapMarkers(events)
-  const portRiskEntries = computePortRiskMarkers(events, now)
+  const gapMarkers = computeGapMarkers(orderedEvents)
+  const portRiskEntries = computePortRiskMarkers(orderedEvents, now)
 
   // Build a set of port-risk afterEventIds for Phase 19:
   // suppress generic gap markers that overlap with port risk windows
@@ -433,7 +517,7 @@ export function buildTimelineRenderList(
   // Map gap markers by position: keyed by "fromEventId" for placement
   const gapsByFromEvent = new Map<string, GapMarker>()
   {
-    const datedEvents = events.filter((event) => toTimelineInstant(event.eventTime) !== null)
+    const datedEvents = orderedEvents.filter((event) => toTimelineInstant(event.eventTime) !== null)
     let gapIdx = 0
     for (let i = 0; i < datedEvents.length - 1 && gapIdx < gapMarkers.length; i++) {
       const current = datedEvents[i]
@@ -486,7 +570,7 @@ export function buildTimelineRenderList(
     blockEvents: readonly TrackingTimelineItem[],
     isLastBlock: boolean,
   ): void {
-    const lastOverallEvent = events[events.length - 1] ?? null
+    const lastOverallEvent = orderedEvents[orderedEvents.length - 1] ?? null
 
     for (let i = 0; i < blockEvents.length; i++) {
       const event = blockEvents[i]
@@ -574,9 +658,11 @@ export function buildTimelineRenderList(
         if (lastCurrentVoyageEvent === undefined || firstNextVoyageEvent === undefined) continue
 
         // Check if the terminal event is positioned between the two voyages
-        const termEventIdx = events.findIndex((e) => e.id === firstTermEvent.id)
-        const lastCurrentVoyageIdx = events.findIndex((e) => e.id === lastCurrentVoyageEvent.id)
-        const firstNextVoyageIdx = events.findIndex((e) => e.id === firstNextVoyageEvent.id)
+        const termEventIdx = orderedEvents.findIndex((e) => e.id === firstTermEvent.id)
+        const lastCurrentVoyageIdx = orderedEvents.findIndex(
+          (e) => e.id === lastCurrentVoyageEvent.id,
+        )
+        const firstNextVoyageIdx = orderedEvents.findIndex((e) => e.id === firstNextVoyageEvent.id)
 
         if (termEventIdx > lastCurrentVoyageIdx && termEventIdx < firstNextVoyageIdx) {
           usedTerminalKinds.add(`ts-${segIdx}`)

--- a/src/modules/tracking/features/validation/application/tests/trackingValidation.projection.test.ts
+++ b/src/modules/tracking/features/validation/application/tests/trackingValidation.projection.test.ts
@@ -35,6 +35,128 @@ function makeObservation(
   }
 }
 
+type SameDayValidationTieEventKey = 'load' | 'positionedIn' | 'positionedOut'
+
+function makeSameDayTransshipmentValidationObservations(
+  sameDayOrder: readonly SameDayValidationTieEventKey[],
+): readonly Observation[] {
+  const sameDayCreatedAt = '2026-04-04T16:08:29.699745+00'
+  const sameDayEvents: Record<SameDayValidationTieEventKey, Observation> = {
+    load: makeObservation({
+      id: 'same-day-load',
+      type: 'LOAD',
+      created_at: sameDayCreatedAt,
+      event_time: temporalValueFromCanonical('2026-02-28'),
+      location_code: 'KRPUS',
+      location_display: 'BUSAN, KR',
+      vessel_name: 'MSC BIANCA SILVIA',
+      voyage: 'UX605A',
+    }),
+    positionedIn: makeObservation({
+      id: 'same-day-positioned-in',
+      type: 'TRANSSHIPMENT_POSITIONED_IN',
+      created_at: sameDayCreatedAt,
+      event_time: temporalValueFromCanonical('2026-02-28'),
+      location_code: 'KRPUS',
+      location_display: 'BUSAN, KR',
+      vessel_name: null,
+      voyage: null,
+    }),
+    positionedOut: makeObservation({
+      id: 'same-day-positioned-out',
+      type: 'TRANSSHIPMENT_POSITIONED_OUT',
+      created_at: sameDayCreatedAt,
+      event_time: temporalValueFromCanonical('2026-02-28'),
+      location_code: 'KRPUS',
+      location_display: 'BUSAN, KR',
+      vessel_name: null,
+      voyage: null,
+    }),
+  }
+
+  return [
+    makeObservation({
+      id: 'pre-gate-out',
+      type: 'GATE_OUT',
+      created_at: '2026-04-04T16:08:29.699745+00',
+      event_time: temporalValueFromCanonical('2025-11-30'),
+      location_code: 'PKLYP',
+      location_display: 'FAISALABAD, PK',
+      vessel_name: null,
+      voyage: null,
+      is_empty: true,
+    }),
+    makeObservation({
+      id: 'pre-gate-in',
+      type: 'GATE_IN',
+      created_at: '2026-04-04T16:08:29.699745+00',
+      event_time: temporalValueFromCanonical('2025-12-30'),
+      location_code: 'PKKHI',
+      location_display: 'KARACHI, PK',
+      vessel_name: null,
+      voyage: null,
+      is_empty: false,
+    }),
+    makeObservation({
+      id: 'voyage-a-load',
+      type: 'LOAD',
+      created_at: '2026-04-04T16:08:29.699745+00',
+      event_time: temporalValueFromCanonical('2026-01-02'),
+      location_code: 'PKKHI',
+      location_display: 'KARACHI, PK',
+      vessel_name: 'MSC IRIS',
+      voyage: 'QS551R',
+    }),
+    makeObservation({
+      id: 'voyage-a-discharge',
+      type: 'DISCHARGE',
+      created_at: '2026-04-04T16:08:29.699745+00',
+      event_time: temporalValueFromCanonical('2026-02-10'),
+      location_code: 'KRPUS',
+      location_display: 'BUSAN, KR',
+      vessel_name: 'MSC IRIS',
+      voyage: 'UX604A',
+    }),
+    ...sameDayOrder.map((key) => sameDayEvents[key]),
+    makeObservation({
+      id: 'voyage-b-arrival-expected',
+      type: 'ARRIVAL',
+      created_at: '2026-04-04T16:08:29.699745+00',
+      event_time_type: 'EXPECTED',
+      event_time: temporalValueFromCanonical('2026-05-08'),
+      location_code: 'BRSSZ',
+      location_display: 'SANTOS, BR',
+      vessel_name: 'MSC BIANCA SILVIA',
+      voyage: 'UX614R',
+    }),
+  ]
+}
+
+function deriveValidationSummaryForObservations(
+  observations: readonly Observation[],
+  containerNumber = 'CAIU6241835',
+) {
+  return deriveTrackingValidationSummaryFromState({
+    containerId: 'container-1',
+    containerNumber,
+    observations,
+    timeline: {
+      container_id: 'container-1',
+      container_number: containerNumber,
+      observations,
+      derived_at: '2026-04-08T10:00:00.000Z',
+      holes: [],
+    },
+    status: 'IN_TRANSIT',
+    transshipment: {
+      hasTransshipment: true,
+      transshipmentCount: 1,
+      ports: ['KRPUS'],
+    },
+    now: Instant.fromIso('2026-04-08T10:00:00.000Z'),
+  })
+}
+
 describe('trackingValidation.projection', () => {
   it('exposes ordered active issues with public explanation metadata only', () => {
     const observations = [
@@ -640,6 +762,32 @@ describe('trackingValidation.projection', () => {
     })
 
     expect(summary).toEqual({
+      hasIssues: false,
+      findingCount: 0,
+      highestSeverity: null,
+      activeIssues: [],
+      topIssue: null,
+    })
+  })
+
+  it('keeps same-day transshipment ties from surfacing canonical timeline advisories', () => {
+    const badOrderSummary = deriveValidationSummaryForObservations(
+      makeSameDayTransshipmentValidationObservations(['load', 'positionedIn', 'positionedOut']),
+      'CAIU6241835',
+    )
+    const goodOrderSummary = deriveValidationSummaryForObservations(
+      makeSameDayTransshipmentValidationObservations(['positionedIn', 'positionedOut', 'load']),
+      'MSBU3493578',
+    )
+
+    expect(badOrderSummary).toEqual({
+      hasIssues: false,
+      findingCount: 0,
+      highestSeverity: null,
+      activeIssues: [],
+      topIssue: null,
+    })
+    expect(goodOrderSummary).toEqual({
       hasIssues: false,
       findingCount: 0,
       highestSeverity: null,


### PR DESCRIPTION
This pull request improves the stability and correctness of timeline event grouping and validation, especially for events that occur at the same time (i.e., same-day events such as transshipment helpers). The changes ensure that the timeline block derivation logic produces consistent output regardless of the input order of same-day events, preventing helper events from being misclassified or drifting into incorrect segments. Comprehensive tests have been added to verify these behaviors.

**Timeline event ordering and block derivation:**

* Introduced a semantic tie-breaker for timeline events with identical timestamps by defining an explicit event type priority (`EVENT_TIE_BREAK_PRIORITY`) and a new sorting function (`sortTimelineItemsForBlockDerivation`). This ensures stable and predictable grouping of same-day events, particularly for transshipment scenarios.
* Updated the main timeline render logic in `buildTimelineRenderList` to use the new sorted event order throughout all block and marker computations, replacing previous reliance on input order. [[1]](diffhunk://#diff-489967e4aa0a412b599bd6f81d1dabfad896f703fcf74e23b3200f04d538331dL423-R511) [[2]](diffhunk://#diff-489967e4aa0a412b599bd6f81d1dabfad896f703fcf74e23b3200f04d538331dL436-R520) [[3]](diffhunk://#diff-489967e4aa0a412b599bd6f81d1dabfad896f703fcf74e23b3200f04d538331dL489-R573) [[4]](diffhunk://#diff-489967e4aa0a412b599bd6f81d1dabfad896f703fcf74e23b3200f04d538331dL577-R665)

**Testing and validation improvements:**

* Added new test fixtures and helper functions (`makeMscSameDayTransshipmentFixture`, `renderListSignature`, and related types) to generate and verify permutations of same-day event orders, ensuring output consistency for all permutations.
* Introduced a new test suite (`buildTimelineRenderList same-day tie-break ordering`) to assert that the block output is stable across all permutations of same-day transshipment events, and that unknown event types do not disrupt grouping.
* Updated existing tests to include explicit event times, ensuring that all timeline logic is exercised with realistic date data. [[1]](diffhunk://#diff-fb98bd44cada12a492f86e7a0ae91beb4314f37aca22616e2c5a052ff46b985cL45-R172) [[2]](diffhunk://#diff-fb98bd44cada12a492f86e7a0ae91beb4314f37aca22616e2c5a052ff46b985cR195) [[3]](diffhunk://#diff-fb98bd44cada12a492f86e7a0ae91beb4314f37aca22616e2c5a052ff46b985cR205) [[4]](diffhunk://#diff-fb98bd44cada12a492f86e7a0ae91beb4314f37aca22616e2c5a052ff46b985cL239-R396) [[5]](diffhunk://#diff-fb98bd44cada12a492f86e7a0ae91beb4314f37aca22616e2c5a052ff46b985cR406)

**Validation pipeline stability:**

* Added fixtures and tests to the validation layer to ensure that same-day transshipment ties do not trigger false advisories in the canonical timeline validation summary, regardless of event order. [[1]](diffhunk://#diff-f1a3a3c709c9c15ab170d7d1627d1413461c94358ced36d4ba1ea769bcfbf1f7R38-R159) [[2]](diffhunk://#diff-f1a3a3c709c9c15ab170d7d1627d1413461c94358ced36d4ba1ea769bcfbf1f7R772-R797)
