### PR TITLE
feat(tracking): substitute weaker expected voyage projections

### DIFF
--- a/src/modules/tracking/application/projection/tests/tracking.operational-summary.readmodel.test.ts
+++ b/src/modules/tracking/application/projection/tests/tracking.operational-summary.readmodel.test.ts
@@ -355,6 +355,78 @@ describe('deriveTrackingOperationalSummary', () => {
     expect(summary.eta?.locationCode).toBe('BRSSZBT')
   })
 
+  it('prefers the stronger final expected when a future voyage chain supersedes a generic POD ETA', () => {
+    const summary = deriveTrackingOperationalSummary({
+      observations: [
+        makeObservation({
+          id: 'final-generic-old',
+          type: 'ARRIVAL',
+          event_time: '2026-05-20',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS',
+          created_at: '2026-04-01T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'colombo-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-13',
+          location_code: 'LKCMB',
+          location_display: 'COLOMBO',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-arrival',
+          type: 'ARRIVAL',
+          event_time: '2026-04-18',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-23',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'final-specific-new',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+      ],
+      status: 'IN_TRANSIT',
+      transshipment: {
+        hasTransshipment: true,
+        transshipmentCount: 1,
+        ports: ['LKCMB', 'SGSIN'],
+      },
+      podLocationCode: 'BRSSZ',
+      now: instantFromIsoText('2026-04-06T00:00:00.000Z'),
+    })
+
+    const eta = requireEta(summary)
+    const nextLocation = requireNextLocation(summary)
+
+    expect(temporalCanonicalText(eta.eventTime)).toBe('2026-05-15')
+    expect(eta.locationCode).toBe('BRSSZ')
+    expect(nextLocation).toEqual({
+      eventTime: eta.eventTime,
+      eventTimeType: 'EXPECTED',
+      type: 'ARRIVAL',
+      locationCode: 'BRSSZ',
+      locationDisplay: 'SANTOS',
+    })
+  })
+
   it('infers final ETA from expected DISCHARGE when POD code is missing but the route is canonical', () => {
     const summary = deriveTrackingOperationalSummary({
       observations: [

--- a/src/modules/tracking/application/projection/tests/tracking.operational-summary.readmodel.test.ts
+++ b/src/modules/tracking/application/projection/tests/tracking.operational-summary.readmodel.test.ts
@@ -427,6 +427,60 @@ describe('deriveTrackingOperationalSummary', () => {
     })
   })
 
+  it('prefers the stronger final expected when both final arrivals share the same created_at', () => {
+    const summary = deriveTrackingOperationalSummary({
+      observations: [
+        makeObservation({
+          id: 'final-generic-same-created-at',
+          type: 'ARRIVAL',
+          event_time: '2026-05-20',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-23',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'final-specific-same-created-at',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+      ],
+      status: 'IN_TRANSIT',
+      transshipment: {
+        hasTransshipment: true,
+        transshipmentCount: 1,
+        ports: ['SGSIN'],
+      },
+      podLocationCode: 'BRSSZ',
+      now: instantFromIsoText('2026-04-06T00:00:00.000Z'),
+    })
+
+    const eta = requireEta(summary)
+    const nextLocation = requireNextLocation(summary)
+
+    expect(temporalCanonicalText(eta.eventTime)).toBe('2026-05-15')
+    expect(eta.locationCode).toBe('BRSSZ')
+    expect(nextLocation).toEqual({
+      eventTime: eta.eventTime,
+      eventTimeType: 'EXPECTED',
+      type: 'ARRIVAL',
+      locationCode: 'BRSSZ',
+      locationDisplay: 'SANTOS',
+    })
+  })
+
   it('infers final ETA from expected DISCHARGE when POD code is missing but the route is canonical', () => {
     const summary = deriveTrackingOperationalSummary({
       observations: [

--- a/src/modules/tracking/application/projection/tracking.operational-summary.readmodel.ts
+++ b/src/modules/tracking/application/projection/tracking.operational-summary.readmodel.ts
@@ -1,6 +1,10 @@
+import { applyVoyageExpectedSubstitution } from '~/modules/tracking/application/projection/voyageExpectedSubstitution.readmodel'
 import type { TransshipmentInfo } from '~/modules/tracking/domain/logistics/transshipment'
 import { isTrackingTemporalValueExpired } from '~/modules/tracking/domain/temporal/tracking-temporal'
-import { classifySeries } from '~/modules/tracking/features/series/domain/reconcile/seriesClassification'
+import {
+  type ClassifiedObservation,
+  classifySeries,
+} from '~/modules/tracking/features/series/domain/reconcile/seriesClassification'
 import {
   buildSeriesKey,
   compareObservationsChronologically,
@@ -126,13 +130,21 @@ function derivePrimarySeriesObservations(
     }
   }
 
-  const primaries: TrackingObservationForOperationalSummary[] = []
+  const candidates: Array<{
+    readonly primary: TrackingObservationForOperationalSummary
+    readonly classified: readonly ClassifiedObservation<TrackingObservationForOperationalSummary>[]
+    readonly hasActualConflict: boolean
+  }> = []
 
   for (const series of groups.values()) {
     series.sort(compareObservationsChronologically)
     const classification = classifySeries(series, now)
     if (classification.primary) {
-      primaries.push(classification.primary)
+      candidates.push({
+        primary: classification.primary,
+        classified: classification.classified,
+        hasActualConflict: classification.hasActualConflict,
+      })
       continue
     }
 
@@ -143,11 +155,17 @@ function derivePrimarySeriesObservations(
       .find((observation) => observation.event_time_type === 'EXPECTED')
 
     if (latestExpected) {
-      primaries.push(latestExpected)
+      candidates.push({
+        primary: latestExpected,
+        classified: classification.classified,
+        hasActualConflict: classification.hasActualConflict,
+      })
     }
   }
 
-  return primaries
+  return applyVoyageExpectedSubstitution(candidates).visibleCandidates.map(
+    (candidate) => candidate.primary,
+  )
 }
 
 function locationCodesMatch(

--- a/src/modules/tracking/application/projection/voyageExpectedSubstitution.readmodel.ts
+++ b/src/modules/tracking/application/projection/voyageExpectedSubstitution.readmodel.ts
@@ -86,6 +86,11 @@ function compareByCreatedAtThenChronology(
     return createdCompare
   }
 
+  const specificityCompare = specificityScore(left) - specificityScore(right)
+  if (specificityCompare !== 0) {
+    return specificityCompare
+  }
+
   return compareObservationsChronologically(left, right)
 }
 
@@ -181,7 +186,7 @@ function canBeSuppressedBy<T extends VoyageExpectedSubstitutionObservation>(
   newer: T,
   allPrimaries: readonly T[],
 ): boolean {
-  if (older.created_at >= newer.created_at) return false
+  if (older.created_at > newer.created_at) return false
   if (older.type !== newer.type) return false
 
   const olderAnchor = normalizeLocationAnchor(older)

--- a/src/modules/tracking/application/projection/voyageExpectedSubstitution.readmodel.ts
+++ b/src/modules/tracking/application/projection/voyageExpectedSubstitution.readmodel.ts
@@ -1,0 +1,292 @@
+import { normalizeVesselName } from '~/modules/tracking/domain/identity/normalizeVesselName'
+import type {
+  ClassifiedObservation,
+  SeriesLabel,
+} from '~/modules/tracking/features/series/domain/reconcile/seriesClassification'
+import { compareObservationsChronologically } from '~/modules/tracking/features/timeline/domain/derive/deriveTimeline'
+import type { TemporalValue } from '~/shared/time/temporal-value'
+
+const TERMINAL_MILESTONE_TYPES: ReadonlySet<string> = new Set(['ARRIVAL', 'DISCHARGE', 'DELIVERY'])
+const MARITIME_MILESTONE_TYPES: ReadonlySet<string> = new Set([
+  'LOAD',
+  'DEPARTURE',
+  'ARRIVAL',
+  'DISCHARGE',
+])
+
+export type VoyageExpectedSubstitutionObservation = {
+  readonly id: string
+  readonly type: string
+  readonly event_time: TemporalValue | null
+  readonly event_time_type: 'ACTUAL' | 'EXPECTED'
+  readonly location_code: string | null
+  readonly location_display: string | null
+  readonly vessel_name: string | null
+  readonly voyage: string | null
+  readonly created_at: string
+}
+
+export type VoyageExpectedSubstitutionCandidate<
+  T extends VoyageExpectedSubstitutionObservation = VoyageExpectedSubstitutionObservation,
+> = {
+  readonly primary: T
+  readonly classified: readonly ClassifiedObservation<T>[]
+  readonly hasActualConflict: boolean
+}
+
+export type VoyageExpectedSubstitutionResult<
+  T extends VoyageExpectedSubstitutionObservation = VoyageExpectedSubstitutionObservation,
+> = {
+  readonly visibleCandidates: readonly VoyageExpectedSubstitutionCandidate<T>[]
+  readonly mergedSuppressedHistoryByPrimaryId: ReadonlyMap<
+    string,
+    readonly ClassifiedObservation<T>[]
+  >
+}
+
+type WorkingCandidate<T extends VoyageExpectedSubstitutionObservation> = {
+  readonly candidate: VoyageExpectedSubstitutionCandidate<T>
+  readonly mergedSuppressedHistory: readonly ClassifiedObservation<T>[]
+}
+
+function normalizeLocationAnchor(
+  observation: Pick<VoyageExpectedSubstitutionObservation, 'location_code' | 'location_display'>,
+): string | null {
+  const normalizedCode = observation.location_code?.trim().toUpperCase() ?? ''
+  if (normalizedCode.length >= 5) {
+    return normalizedCode.slice(0, 5)
+  }
+  if (normalizedCode.length > 0) {
+    return normalizedCode
+  }
+
+  const normalizedDisplay = observation.location_display?.trim().toUpperCase() ?? ''
+  return normalizedDisplay.length > 0 ? normalizedDisplay : null
+}
+
+function normalizeVoyage(voyage: string | null | undefined): string | null {
+  const normalized = voyage?.trim().toUpperCase() ?? ''
+  return normalized.length > 0 ? normalized : null
+}
+
+function isEligibleTerminalExpected(observation: VoyageExpectedSubstitutionObservation): boolean {
+  return (
+    observation.event_time_type === 'EXPECTED' &&
+    TERMINAL_MILESTONE_TYPES.has(observation.type) &&
+    normalizeLocationAnchor(observation) !== null
+  )
+}
+
+function compareByCreatedAtThenChronology(
+  left: VoyageExpectedSubstitutionObservation,
+  right: VoyageExpectedSubstitutionObservation,
+): number {
+  const createdCompare = left.created_at.localeCompare(right.created_at)
+  if (createdCompare !== 0) {
+    return createdCompare
+  }
+
+  return compareObservationsChronologically(left, right)
+}
+
+function specificityScore(observation: VoyageExpectedSubstitutionObservation): number {
+  let score = 0
+  if (normalizeVesselName(observation.vessel_name) !== null) score += 1
+  if (normalizeVoyage(observation.voyage) !== null) score += 1
+  return score
+}
+
+function sharesPromotedLegIdentity(
+  support: VoyageExpectedSubstitutionObservation,
+  promoted: VoyageExpectedSubstitutionObservation,
+): boolean {
+  const promotedVessel = normalizeVesselName(promoted.vessel_name)
+  const promotedVoyage = normalizeVoyage(promoted.voyage)
+  if (promotedVessel === null && promotedVoyage === null) return false
+
+  const supportVessel = normalizeVesselName(support.vessel_name)
+  const supportVoyage = normalizeVoyage(support.voyage)
+
+  const vesselMatches = promotedVessel !== null && supportVessel === promotedVessel
+  const voyageMatches = promotedVoyage !== null && supportVoyage === promotedVoyage
+  const vesselCompatible =
+    promotedVessel === null || supportVessel === null || supportVessel === promotedVessel
+  const voyageCompatible =
+    promotedVoyage === null || supportVoyage === null || supportVoyage === promotedVoyage
+
+  return (vesselMatches || voyageMatches) && vesselCompatible && voyageCompatible
+}
+
+function isEarlierFutureChainSupport(
+  support: VoyageExpectedSubstitutionObservation,
+  promoted: VoyageExpectedSubstitutionObservation,
+): boolean {
+  if (support.event_time_type !== 'EXPECTED') return false
+  if (support.event_time === null || promoted.event_time === null) return false
+
+  return compareObservationsChronologically(support, promoted) < 0
+}
+
+function hasCoherentFutureChainEvidence<T extends VoyageExpectedSubstitutionObservation>(
+  promoted: T,
+  allPrimaries: readonly T[],
+): boolean {
+  const promotedAnchor = normalizeLocationAnchor(promoted)
+  if (promotedAnchor === null) return false
+
+  for (const support of allPrimaries) {
+    if (support.id === promoted.id) continue
+    if (!isEarlierFutureChainSupport(support, promoted)) continue
+
+    const supportAnchor = normalizeLocationAnchor(support)
+    if (supportAnchor !== null && supportAnchor === promotedAnchor) {
+      continue
+    }
+
+    if (support.type === 'TRANSSHIPMENT_INTENDED') {
+      return true
+    }
+
+    if (
+      MARITIME_MILESTONE_TYPES.has(support.type) &&
+      sharesPromotedLegIdentity(support, promoted)
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function relabelSuppressedSeriesHistory<T extends VoyageExpectedSubstitutionObservation>(
+  classified: readonly ClassifiedObservation<T>[],
+): readonly ClassifiedObservation<T>[] {
+  return classified.map((entry) => {
+    const seriesLabel: SeriesLabel =
+      entry.seriesLabel === 'ACTIVE' ? 'SUPERSEDED_EXPECTED' : entry.seriesLabel
+
+    return seriesLabel === entry.seriesLabel ? entry : { ...entry, seriesLabel }
+  })
+}
+
+function sortClassifiedObservations<T extends VoyageExpectedSubstitutionObservation>(
+  classified: readonly ClassifiedObservation<T>[],
+): readonly ClassifiedObservation<T>[] {
+  if (classified.length < 2) return classified
+  return [...classified].sort(compareObservationsChronologically)
+}
+
+function canBeSuppressedBy<T extends VoyageExpectedSubstitutionObservation>(
+  older: T,
+  newer: T,
+  allPrimaries: readonly T[],
+): boolean {
+  if (older.created_at >= newer.created_at) return false
+  if (older.type !== newer.type) return false
+
+  const olderAnchor = normalizeLocationAnchor(older)
+  const newerAnchor = normalizeLocationAnchor(newer)
+  if (olderAnchor === null || newerAnchor === null || olderAnchor !== newerAnchor) return false
+
+  if (specificityScore(newer) <= specificityScore(older)) return false
+
+  return hasCoherentFutureChainEvidence(newer, allPrimaries)
+}
+
+export function applyVoyageExpectedSubstitution<T extends VoyageExpectedSubstitutionObservation>(
+  candidates: readonly VoyageExpectedSubstitutionCandidate<T>[],
+): VoyageExpectedSubstitutionResult<T> {
+  if (candidates.length < 2) {
+    return {
+      visibleCandidates: candidates,
+      mergedSuppressedHistoryByPrimaryId: new Map(),
+    }
+  }
+
+  const allPrimaries = candidates.map((candidate) => candidate.primary)
+  const nonEligible: WorkingCandidate<T>[] = []
+  const eligibleGroups = new Map<string, VoyageExpectedSubstitutionCandidate<T>[]>()
+
+  for (const candidate of candidates) {
+    if (!isEligibleTerminalExpected(candidate.primary)) {
+      nonEligible.push({
+        candidate,
+        mergedSuppressedHistory: [],
+      })
+      continue
+    }
+
+    const anchor = normalizeLocationAnchor(candidate.primary)
+    if (anchor === null) {
+      nonEligible.push({
+        candidate,
+        mergedSuppressedHistory: [],
+      })
+      continue
+    }
+
+    const groupKey = `${candidate.primary.type}|${anchor}`
+    const existing = eligibleGroups.get(groupKey)
+    if (existing === undefined) {
+      eligibleGroups.set(groupKey, [candidate])
+    } else {
+      existing.push(candidate)
+    }
+  }
+
+  const visibleWorking: WorkingCandidate<T>[] = [...nonEligible]
+
+  for (const group of eligibleGroups.values()) {
+    const orderedGroup = [...group].sort((left, right) =>
+      compareByCreatedAtThenChronology(left.primary, right.primary),
+    )
+
+    let visibleGroup: WorkingCandidate<T>[] = []
+
+    for (const candidate of orderedGroup) {
+      let mergedSuppressedHistory: readonly ClassifiedObservation<T>[] = []
+      const survivors: WorkingCandidate<T>[] = []
+
+      for (const prior of visibleGroup) {
+        if (canBeSuppressedBy(prior.candidate.primary, candidate.primary, allPrimaries)) {
+          mergedSuppressedHistory = [
+            ...mergedSuppressedHistory,
+            ...relabelSuppressedSeriesHistory(prior.candidate.classified),
+            ...prior.mergedSuppressedHistory,
+          ]
+          continue
+        }
+
+        survivors.push(prior)
+      }
+
+      visibleGroup = [
+        ...survivors,
+        {
+          candidate,
+          mergedSuppressedHistory: sortClassifiedObservations(mergedSuppressedHistory),
+        },
+      ]
+    }
+
+    visibleWorking.push(...visibleGroup)
+  }
+
+  const visibleCandidates = visibleWorking
+    .map((entry) => entry.candidate)
+    .sort((left, right) => compareObservationsChronologically(left.primary, right.primary))
+
+  const mergedSuppressedHistoryByPrimaryId = new Map<string, readonly ClassifiedObservation<T>[]>()
+  for (const entry of visibleWorking) {
+    if (entry.mergedSuppressedHistory.length === 0) continue
+    mergedSuppressedHistoryByPrimaryId.set(
+      entry.candidate.primary.id,
+      entry.mergedSuppressedHistory,
+    )
+  }
+
+  return {
+    visibleCandidates,
+    mergedSuppressedHistoryByPrimaryId,
+  }
+}

--- a/src/modules/tracking/features/timeline/application/projection/tests/tracking.timeline.voyage-expected-substitution.readmodel.test.ts
+++ b/src/modules/tracking/features/timeline/application/projection/tests/tracking.timeline.voyage-expected-substitution.readmodel.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest'
+import type { TrackingObservationProjection } from '~/modules/tracking/features/observation/application/projection/tracking.observation.projection'
+import { deriveTimelineWithSeriesReadModel } from '~/modules/tracking/features/timeline/application/projection/tracking.timeline.readmodel'
+import {
+  instantFromIsoText,
+  resolveTemporalValue,
+  temporalValueFromCanonical,
+} from '~/shared/time/tests/helpers'
+
+type ObservationOverrides = Omit<Partial<TrackingObservationProjection>, 'event_time'> & {
+  readonly event_time?: string | TrackingObservationProjection['event_time']
+}
+
+const DEFAULT_EVENT_TIME = temporalValueFromCanonical('2026-05-17')
+
+function makeObservation(overrides: ObservationOverrides = {}): TrackingObservationProjection {
+  const { event_time, ...rest } = overrides
+
+  return {
+    id: overrides.id ?? 'obs-1',
+    type: overrides.type ?? 'ARRIVAL',
+    carrier_label: overrides.carrier_label ?? null,
+    event_time: resolveTemporalValue(event_time, DEFAULT_EVENT_TIME),
+    event_time_type: overrides.event_time_type ?? 'EXPECTED',
+    location_code: overrides.location_code ?? 'BRSSZ',
+    location_display: overrides.location_display ?? 'SANTOS, BR',
+    vessel_name: overrides.vessel_name ?? null,
+    voyage: overrides.voyage ?? null,
+    created_at: overrides.created_at ?? '2026-04-01T00:00:00.000Z',
+    ...rest,
+  }
+}
+
+function requireTimelineItem(
+  timeline: ReturnType<typeof deriveTimelineWithSeriesReadModel>,
+  id: string,
+) {
+  const item = timeline.find((entry) => entry.id === id)
+  if (item === undefined) {
+    throw new Error(`Expected timeline item ${id}`)
+  }
+
+  return item
+}
+
+describe('deriveTimelineWithSeriesReadModel voyage expected substitution', () => {
+  const now = instantFromIsoText('2026-04-06T00:00:00.000Z')
+
+  it('suppresses an older generic final arrival when a newer vessel-backed chain exists', () => {
+    const timeline = deriveTimelineWithSeriesReadModel(
+      [
+        makeObservation({
+          id: 'final-generic-old',
+          type: 'ARRIVAL',
+          event_time: '2026-05-17',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          created_at: '2026-04-02T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'departure-leg',
+          type: 'DEPARTURE',
+          event_time: '2026-04-07',
+          location_code: 'PKBQM',
+          location_display: 'KARACHI, PK',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-23',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE, SG',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'final-specific-new',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+      ],
+      now,
+    )
+
+    expect(timeline.map((item) => item.id)).not.toContain('final-generic-old')
+    const promoted = requireTimelineItem(timeline, 'final-specific-new')
+    expect(promoted.hasSeriesHistory).toBe(true)
+    expect(promoted.seriesHistory?.classified.map((item) => [item.id, item.seriesLabel])).toEqual([
+      ['final-specific-new', 'ACTIVE'],
+      ['final-generic-old', 'SUPERSEDED_EXPECTED'],
+    ])
+  })
+
+  it('collapses final expected duplication when a full future voyage chain points to the same port', () => {
+    const timeline = deriveTimelineWithSeriesReadModel(
+      [
+        makeObservation({
+          id: 'final-generic-old',
+          type: 'ARRIVAL',
+          event_time: '2026-05-20',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          created_at: '2026-04-01T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'colombo-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-13',
+          location_code: 'LKCMB',
+          location_display: 'COLOMBO, LK',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-arrival',
+          type: 'ARRIVAL',
+          event_time: '2026-04-18',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE, SG',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-23',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE, SG',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'final-specific-new',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+      ],
+      now,
+    )
+
+    const santosExpectedArrivals = timeline.filter(
+      (item) =>
+        item.type === 'ARRIVAL' &&
+        item.eventTimeType === 'EXPECTED' &&
+        item.location === 'SANTOS, BR',
+    )
+
+    expect(santosExpectedArrivals.map((item) => item.id)).toEqual(['final-specific-new'])
+  })
+
+  it('keeps simple expected variants visible when no supporting future chain exists', () => {
+    const timeline = deriveTimelineWithSeriesReadModel(
+      [
+        makeObservation({
+          id: 'final-generic-old',
+          type: 'ARRIVAL',
+          event_time: '2026-05-17',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          created_at: '2026-04-02T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'final-specific-isolated',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+      ],
+      now,
+    )
+
+    expect(timeline.map((item) => item.id)).toEqual([
+      'final-specific-isolated',
+      'final-generic-old',
+    ])
+  })
+
+  it('keeps ACTUAL as the winning primary when it exists in the series', () => {
+    const timeline = deriveTimelineWithSeriesReadModel(
+      [
+        makeObservation({
+          id: 'arrival-expected',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'arrival-actual',
+          type: 'ARRIVAL',
+          event_time: '2026-05-14',
+          event_time_type: 'ACTUAL',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-05-14T12:00:00.000Z',
+        }),
+      ],
+      instantFromIsoText('2026-05-16T00:00:00.000Z'),
+    )
+
+    expect(timeline).toHaveLength(1)
+    expect(timeline[0]?.id).toBe('arrival-actual')
+    expect(timeline[0]?.eventTimeType).toBe('ACTUAL')
+    expect(
+      timeline[0]?.seriesHistory?.classified.map((item) => [item.id, item.seriesLabel]),
+    ).toEqual([
+      ['arrival-actual', 'CONFIRMED'],
+      ['arrival-expected', 'REDUNDANT_AFTER_ACTUAL'],
+    ])
+  })
+
+  it('keeps lazy history affordance when cross-series substitution happens without embedded history', () => {
+    const timeline = deriveTimelineWithSeriesReadModel(
+      [
+        makeObservation({
+          id: 'final-generic-old',
+          type: 'ARRIVAL',
+          event_time: '2026-05-17',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          created_at: '2026-04-02T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-23',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE, SG',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'final-specific-new',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+      ],
+      now,
+      { includeSeriesHistory: false },
+    )
+
+    const promoted = requireTimelineItem(timeline, 'final-specific-new')
+    expect(promoted.hasSeriesHistory).toBe(true)
+    expect(promoted.seriesHistory).toBeUndefined()
+  })
+})

--- a/src/modules/tracking/features/timeline/application/projection/tests/tracking.timeline.voyage-expected-substitution.readmodel.test.ts
+++ b/src/modules/tracking/features/timeline/application/projection/tests/tracking.timeline.voyage-expected-substitution.readmodel.test.ts
@@ -98,6 +98,49 @@ describe('deriveTimelineWithSeriesReadModel voyage expected substitution', () =>
     ])
   })
 
+  it('suppresses a generic final arrival even when both terminal expecteds share the same created_at', () => {
+    const timeline = deriveTimelineWithSeriesReadModel(
+      [
+        makeObservation({
+          id: 'final-generic-same-created-at',
+          type: 'ARRIVAL',
+          event_time: '2026-05-20',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'singapore-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          event_time: '2026-04-23',
+          location_code: 'SGSIN',
+          location_display: 'SINGAPORE, SG',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+        makeObservation({
+          id: 'final-specific-same-created-at',
+          type: 'ARRIVAL',
+          event_time: '2026-05-15',
+          location_code: 'BRSSZ',
+          location_display: 'SANTOS, BR',
+          vessel_name: 'SAO PAULO EXPRESS',
+          voyage: '2613W',
+          created_at: '2026-04-05T00:00:00.000Z',
+        }),
+      ],
+      now,
+    )
+
+    expect(timeline.map((item) => item.id)).not.toContain('final-generic-same-created-at')
+
+    const promoted = requireTimelineItem(timeline, 'final-specific-same-created-at')
+    expect(promoted.hasSeriesHistory).toBe(true)
+    expect(promoted.seriesHistory?.classified.map((item) => [item.id, item.seriesLabel])).toEqual([
+      ['final-specific-same-created-at', 'ACTIVE'],
+      ['final-generic-same-created-at', 'SUPERSEDED_EXPECTED'],
+    ])
+  })
+
   it('collapses final expected duplication when a full future voyage chain points to the same port', () => {
     const timeline = deriveTimelineWithSeriesReadModel(
       [

--- a/src/modules/tracking/features/timeline/application/projection/tracking.timeline.readmodel.ts
+++ b/src/modules/tracking/features/timeline/application/projection/tracking.timeline.readmodel.ts
@@ -1,4 +1,5 @@
 import { resolveLocationDisplay } from '~/modules/tracking/application/projection/locationDisplayResolver'
+import { applyVoyageExpectedSubstitution } from '~/modules/tracking/application/projection/voyageExpectedSubstitution.readmodel'
 import { trackingTemporalValueToDto } from '~/modules/tracking/domain/temporal/tracking-temporal'
 import type { TrackingObservationProjection } from '~/modules/tracking/features/observation/application/projection/tracking.observation.projection'
 import {
@@ -6,6 +7,7 @@ import {
   deriveObservationState,
 } from '~/modules/tracking/features/series/domain/reconcile/expiredExpected'
 import {
+  type ClassifiedObservation,
   classifySeries,
   type SeriesLabel,
 } from '~/modules/tracking/features/series/domain/reconcile/seriesClassification'
@@ -52,6 +54,12 @@ export type TrackingTimelineItem = {
   readonly hasSeriesHistory?: boolean
   /** Optional series history with backend-derived classification. */
   readonly seriesHistory?: TrackingSeriesHistory
+}
+
+type TimelineSeriesCandidate = {
+  readonly primary: TrackingObservationProjection
+  readonly classified: readonly ClassifiedObservation<TrackingObservationProjection>[]
+  readonly hasActualConflict: boolean
 }
 
 function observationToTrackingTimelineItem(
@@ -101,6 +109,26 @@ function timelineItemToTrackingItem(
     : { ...base, hasSeriesHistory: true, seriesHistory: item.seriesHistory }
 }
 
+function toTrackingSeriesHistoryItem(
+  observation: ClassifiedObservation<TrackingObservationProjection>,
+): TrackingSeriesHistoryItem {
+  return {
+    id: observation.id,
+    type: observation.type,
+    event_time: trackingTemporalValueToDto(observation.event_time),
+    event_time_type: observation.event_time_type,
+    created_at: observation.created_at,
+    seriesLabel: observation.seriesLabel,
+  }
+}
+
+function sortClassifiedTimelineHistory(
+  classified: readonly ClassifiedObservation<TrackingObservationProjection>[],
+): readonly ClassifiedObservation<TrackingObservationProjection>[] {
+  if (classified.length < 2) return classified
+  return [...classified].sort(compareObservationsChronologically)
+}
+
 /**
  * Derive timeline with event series grouping from observations.
  *
@@ -132,34 +160,45 @@ export function deriveTimelineWithSeriesReadModel(
     hasSeriesHistory: boolean
     seriesHistory?: TrackingSeriesHistory
   }> = []
+  const seriesCandidates: TimelineSeriesCandidate[] = []
 
   for (const series of groups.values()) {
     series.sort(compareObservationsChronologically)
     const classification = classifySeries(series, now)
 
     if (classification.primary) {
-      const shouldIncludeSeriesHistory = options?.includeSeriesHistory ?? true
-      const seriesHistory: TrackingSeriesHistory | undefined =
-        shouldIncludeSeriesHistory && series.length > 1
-          ? {
-              hasActualConflict: classification.hasActualConflict,
-              classified: classification.classified.map((observation) => ({
-                id: observation.id,
-                type: observation.type,
-                event_time: trackingTemporalValueToDto(observation.event_time),
-                event_time_type: observation.event_time_type,
-                created_at: observation.created_at,
-                seriesLabel: observation.seriesLabel,
-              })),
-            }
-          : undefined
-
-      result.push({
+      seriesCandidates.push({
         primary: classification.primary,
-        hasSeriesHistory: series.length > 1,
-        ...(seriesHistory === undefined ? {} : { seriesHistory }),
+        classified: classification.classified,
+        hasActualConflict: classification.hasActualConflict,
       })
     }
+  }
+
+  const shouldIncludeSeriesHistory = options?.includeSeriesHistory ?? true
+  const substitution = applyVoyageExpectedSubstitution(seriesCandidates)
+
+  for (const candidate of substitution.visibleCandidates) {
+    const mergedSuppressedHistory =
+      substitution.mergedSuppressedHistoryByPrimaryId.get(candidate.primary.id) ?? []
+    const combinedClassified = sortClassifiedTimelineHistory([
+      ...candidate.classified,
+      ...mergedSuppressedHistory,
+    ])
+    const hasSeriesHistory = combinedClassified.length > 1
+    const seriesHistory: TrackingSeriesHistory | undefined =
+      shouldIncludeSeriesHistory && hasSeriesHistory
+        ? {
+            hasActualConflict: candidate.hasActualConflict,
+            classified: combinedClassified.map(toTrackingSeriesHistoryItem),
+          }
+        : undefined
+
+    result.push({
+      primary: candidate.primary,
+      hasSeriesHistory,
+      ...(seriesHistory === undefined ? {} : { seriesHistory }),
+    })
   }
 
   result.sort((a, b) => compareObservationsChronologically(a.primary, b.primary))

--- a/src/modules/tracking/interface/http/tests/tracking.controllers.test.ts
+++ b/src/modules/tracking/interface/http/tests/tracking.controllers.test.ts
@@ -330,6 +330,96 @@ describe('tracking controllers', () => {
     expect(findAllObservationsByContainerId).toHaveBeenCalledWith(containerId)
   })
 
+  it('series-history drilldown includes cross-series suppressed expected entries on the promoted item', async () => {
+    const containerId = 'container-voyage-substitution'
+    const observations: readonly Observation[] = [
+      {
+        id: 'final-generic-old',
+        fingerprint: 'fp-final-generic-old',
+        container_id: containerId,
+        container_number: 'MSDU1976635',
+        type: 'ARRIVAL',
+        event_time: temporalValueFromCanonical('2026-05-20'),
+        event_time_type: 'EXPECTED',
+        location_code: 'BRSSZ',
+        location_display: 'SANTOS, BR',
+        vessel_name: null,
+        voyage: null,
+        is_empty: null,
+        confidence: 'medium',
+        provider: 'msc',
+        created_from_snapshot_id: 'snapshot-1',
+        carrier_label: 'Estimated Time of Arrival',
+        created_at: '2026-04-01T00:00:00.000Z',
+        retroactive: false,
+      },
+      {
+        id: 'singapore-intended',
+        fingerprint: 'fp-singapore-intended',
+        container_id: containerId,
+        container_number: 'MSDU1976635',
+        type: 'TRANSSHIPMENT_INTENDED',
+        event_time: temporalValueFromCanonical('2026-04-23'),
+        event_time_type: 'EXPECTED',
+        location_code: 'SGSIN',
+        location_display: 'SINGAPORE, SG',
+        vessel_name: null,
+        voyage: null,
+        is_empty: null,
+        confidence: 'medium',
+        provider: 'msc',
+        created_from_snapshot_id: 'snapshot-2',
+        carrier_label: 'Full Intended Transshipment',
+        created_at: '2026-04-05T00:00:00.000Z',
+        retroactive: false,
+      },
+      {
+        id: 'final-specific-new',
+        fingerprint: 'fp-final-specific-new',
+        container_id: containerId,
+        container_number: 'MSDU1976635',
+        type: 'ARRIVAL',
+        event_time: temporalValueFromCanonical('2026-05-15'),
+        event_time_type: 'EXPECTED',
+        location_code: 'BRSSZ',
+        location_display: 'SANTOS, BR',
+        vessel_name: 'SAO PAULO EXPRESS',
+        voyage: '2613W',
+        is_empty: null,
+        confidence: 'medium',
+        provider: 'msc',
+        created_from_snapshot_id: 'snapshot-2',
+        carrier_label: 'Estimated Time of Arrival',
+        created_at: '2026-04-05T00:00:00.000Z',
+        retroactive: false,
+      },
+    ]
+
+    const { controllers } = createControllers({
+      observationsByContainerId: new Map([[containerId, observations]]),
+    })
+
+    const request = new Request(
+      `http://localhost/api/tracking/containers/${containerId}/timeline-items/final-specific-new/history?now=2026-04-06T00:00:00.000Z`,
+    )
+    const response = await controllers.detail.getTimelineItemSeriesHistory({
+      params: { containerId, timelineItemId: 'final-specific-new' },
+      request,
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(
+      body.classified.map((item: { id: string; series_label: string }) => ({
+        id: item.id,
+        series_label: item.series_label,
+      })),
+    ).toEqual([
+      { id: 'final-specific-new', series_label: 'ACTIVE' },
+      { id: 'final-generic-old', series_label: 'SUPERSEDED_EXPECTED' },
+    ])
+  })
+
   it('observation-inspector drilldown returns a single observation payload', async () => {
     const containerId = 'container-observation'
     const observation: Observation = {


### PR DESCRIPTION
This pull request introduces a new mechanism for suppressing less-specific expected terminal milestone observations (such as generic final arrival ETAs) when a more specific, vessel-backed future voyage chain exists. This improves the accuracy and clarity of operational summaries and tracking timelines by promoting the most reliable ETA and suppressing outdated or less-specific predictions. The changes include the implementation of the voyage expected substitution logic, integration into both the operational summary and timeline projections, and comprehensive tests to ensure correct behavior.

**Key changes:**

### Voyage Expected Substitution Logic

* Introduced `voyageExpectedSubstitution.readmodel.ts`, which implements logic to identify and suppress generic expected terminal milestone observations in favor of more specific, vessel/voyage-backed future chain observations. This includes normalization, specificity scoring, and cross-series suppression rules.

### Integration with Operational Summary

* Updated `derivePrimarySeriesObservations` in `tracking.operational-summary.readmodel.ts` to apply voyage expected substitution after classifying primary observations, ensuring only the most relevant observations are surfaced in operational summaries. [[1]](diffhunk://#diff-11782f2aa308878efa326992fc6e2339285615758a2eb9ccfa909979999687ceL129-R147) [[2]](diffhunk://#diff-11782f2aa308878efa326992fc6e2339285615758a2eb9ccfa909979999687ceL146-R168)
* Imported and used the new substitution logic in the operational summary readmodel.

### Integration with Timeline Projection

* Integrated voyage expected substitution into the timeline projection logic by importing and applying the new logic in `tracking.timeline.readmodel.ts`, ensuring timeline views also benefit from the improved suppression and promotion of expected events.

### Testing and Validation

* Added comprehensive tests for the new substitution logic in `tracking.timeline.voyage-expected-substitution.readmodel.test.ts`, covering scenarios such as suppression of generic arrivals, promotion of vessel-backed arrivals, coexistence when no future chain exists, and preservation of actuals.
* Added a new operational summary test to verify that a stronger, vessel-backed ETA is preferred over a generic POD ETA when a future voyage chain exists.