### PR TITLE
Add BOOKED as a distinct pre-shipment status

### DIFF
--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -766,7 +766,7 @@
   "tracking": {
     "status": {
       "UNKNOWN": "Desconhecido",
-      "BOOKED": "Reservado",
+      "BOOKED": "Pré-embarque",
       "AWAITING_DATA": "Aguardando dados",
       "NOT_SYNCED": "Não sincronizado",
       "IN_PROGRESS": "Em Andamento",

--- a/src/modules/process/features/operational-projection/application/deriveProcessStatus.ts
+++ b/src/modules/process/features/operational-projection/application/deriveProcessStatus.ts
@@ -6,6 +6,7 @@ import type {
 export type OperationalStatusCounts = {
   readonly UNKNOWN: number
   readonly IN_PROGRESS: number
+  readonly BOOKED: number
   readonly LOADED: number
   readonly IN_TRANSIT: number
   readonly ARRIVED_AT_POD: number
@@ -30,6 +31,7 @@ type ProcessStatusDispersion = {
 type MutableOperationalStatusCounts = {
   UNKNOWN: number
   IN_PROGRESS: number
+  BOOKED: number
   LOADED: number
   IN_TRANSIT: number
   ARRIVED_AT_POD: number
@@ -42,6 +44,7 @@ type MutableOperationalStatusCounts = {
 const OPERATIONAL_STATUS_LIFECYCLE_ORDER: readonly OperationalStatus[] = [
   'UNKNOWN',
   'IN_PROGRESS',
+  'BOOKED',
   'LOADED',
   'IN_TRANSIT',
   'ARRIVED_AT_POD',
@@ -54,13 +57,14 @@ const OPERATIONAL_STATUS_LIFECYCLE_ORDER: readonly OperationalStatus[] = [
 const OPERATIONAL_STATUS_ORDER_INDEX: Readonly<Record<OperationalStatus, number>> = {
   UNKNOWN: 0,
   IN_PROGRESS: 1,
-  LOADED: 2,
-  IN_TRANSIT: 3,
-  ARRIVED_AT_POD: 4,
-  DISCHARGED: 5,
-  AVAILABLE_FOR_PICKUP: 6,
-  DELIVERED: 7,
-  EMPTY_RETURNED: 8,
+  BOOKED: 2,
+  LOADED: 3,
+  IN_TRANSIT: 4,
+  ARRIVED_AT_POD: 5,
+  DISCHARGED: 6,
+  AVAILABLE_FOR_PICKUP: 7,
+  DELIVERED: 8,
+  EMPTY_RETURNED: 9,
 }
 
 const PROCESS_STATUS_ORDER = [
@@ -93,7 +97,7 @@ const MICROBADGE_MEANINGFUL_STATUSES: ReadonlySet<OperationalStatus> = new Set([
 
 function toProcessLifecycleStatus(status: OperationalStatus): ProcessLifecycleStatus {
   if (status === 'UNKNOWN') return 'UNKNOWN'
-  if (status === 'IN_PROGRESS') return 'BOOKED'
+  if (status === 'IN_PROGRESS' || status === 'BOOKED') return 'BOOKED'
   if (status === 'LOADED' || status === 'IN_TRANSIT') return 'IN_TRANSIT'
   if (status === 'ARRIVED_AT_POD') return 'ARRIVED_AT_POD'
   if (status === 'DISCHARGED' || status === 'AVAILABLE_FOR_PICKUP') return 'DISCHARGED'
@@ -117,6 +121,7 @@ function createEmptyOperationalStatusCounts(): MutableOperationalStatusCounts {
   return {
     UNKNOWN: 0,
     IN_PROGRESS: 0,
+    BOOKED: 0,
     LOADED: 0,
     IN_TRANSIT: 0,
     ARRIVED_AT_POD: 0,
@@ -138,6 +143,11 @@ function incrementStatusCount(
 
   if (status === 'IN_PROGRESS') {
     statusCounts.IN_PROGRESS += 1
+    return
+  }
+
+  if (status === 'BOOKED') {
+    statusCounts.BOOKED += 1
     return
   }
 
@@ -177,6 +187,7 @@ function incrementStatusCount(
 function toStatusCount(statusCounts: OperationalStatusCounts, status: OperationalStatus): number {
   if (status === 'UNKNOWN') return statusCounts.UNKNOWN
   if (status === 'IN_PROGRESS') return statusCounts.IN_PROGRESS
+  if (status === 'BOOKED') return statusCounts.BOOKED
   if (status === 'LOADED') return statusCounts.LOADED
   if (status === 'IN_TRANSIT') return statusCounts.IN_TRANSIT
   if (status === 'ARRIVED_AT_POD') return statusCounts.ARRIVED_AT_POD
@@ -218,7 +229,7 @@ function toPrimaryStatusOrderIndex(primaryStatus: ProcessAggregatedStatus): numb
   }
 
   if (primaryStatus === 'BOOKED') {
-    return OPERATIONAL_STATUS_ORDER_INDEX.IN_PROGRESS
+    return OPERATIONAL_STATUS_ORDER_INDEX.BOOKED
   }
 
   if (primaryStatus === 'IN_TRANSIT') {

--- a/src/modules/process/features/operational-projection/application/operationalSemantics.ts
+++ b/src/modules/process/features/operational-projection/application/operationalSemantics.ts
@@ -1,6 +1,7 @@
 export type OperationalStatus =
   | 'UNKNOWN'
   | 'IN_PROGRESS'
+  | 'BOOKED'
   | 'LOADED'
   | 'IN_TRANSIT'
   | 'ARRIVED_AT_POD'
@@ -22,6 +23,7 @@ export type ProcessAggregatedStatus =
 const OPERATIONAL_STATUSES: readonly OperationalStatus[] = [
   'UNKNOWN',
   'IN_PROGRESS',
+  'BOOKED',
   'LOADED',
   'IN_TRANSIT',
   'ARRIVED_AT_POD',

--- a/src/modules/process/features/operational-projection/application/tests/aggregateOperationalSummary.test.ts
+++ b/src/modules/process/features/operational-projection/application/tests/aggregateOperationalSummary.test.ts
@@ -129,7 +129,7 @@ describe('aggregateOperationalSummary', () => {
   it('returns BOOKED when observations include both pre-shipment and transit statuses', () => {
     const summaries = [
       makeSummary({
-        status: 'IN_PROGRESS',
+        status: 'BOOKED',
         observations: [{ event_time: '2026-03-01T00:00:00.000Z' }],
       }),
       makeSummary({

--- a/src/modules/process/features/operational-projection/application/tests/deriveProcessStatus.test.ts
+++ b/src/modules/process/features/operational-projection/application/tests/deriveProcessStatus.test.ts
@@ -17,6 +17,10 @@ describe('deriveProcessStatusFromContainers', () => {
     expect(deriveProcessStatusFromContainers(['UNKNOWN', 'IN_PROGRESS'])).toBe('BOOKED')
   })
 
+  it('returns BOOKED when canonical BOOKED is present in pre-shipment statuses', () => {
+    expect(deriveProcessStatusFromContainers(['UNKNOWN', 'BOOKED'])).toBe('BOOKED')
+  })
+
   it('returns IN_TRANSIT for single transit container', () => {
     expect(deriveProcessStatusFromContainers(['IN_TRANSIT'])).toBe('IN_TRANSIT')
   })
@@ -81,6 +85,20 @@ describe('deriveProcessStatusDispersion', () => {
     expect(result.status_microbadge).toBeNull()
     expect(result.status_counts.UNKNOWN).toBe(2)
     expect(result.has_status_dispersion).toBe(false)
+  })
+
+  it('tracks BOOKED counts and highest container status for mixed pre-shipment states', () => {
+    const statuses = ['IN_PROGRESS', 'BOOKED'] as const
+    const primaryStatus = deriveProcessStatusFromContainers(statuses)
+    const result = deriveProcessStatusDispersion({
+      statuses,
+      primaryStatus,
+    })
+
+    expect(primaryStatus).toBe('BOOKED')
+    expect(result.highest_container_status).toBe('BOOKED')
+    expect(result.status_counts.IN_PROGRESS).toBe(1)
+    expect(result.status_counts.BOOKED).toBe(1)
   })
 
   it('derives ARRIVED_AT_POD microbadge when process is still IN_TRANSIT', () => {

--- a/src/modules/process/interface/http/tests/process.controllers.test.ts
+++ b/src/modules/process/interface/http/tests/process.controllers.test.ts
@@ -44,6 +44,7 @@ type ContainerSummaryStatus = ContainerHotReadProjection['status']
 const CONTAINER_SUMMARY_STATUSES: readonly ContainerSummaryStatus[] = [
   'UNKNOWN',
   'IN_PROGRESS',
+  'BOOKED',
   'LOADED',
   'IN_TRANSIT',
   'ARRIVED_AT_POD',

--- a/src/modules/process/interface/http/tests/process.http.mappers.test.ts
+++ b/src/modules/process/interface/http/tests/process.http.mappers.test.ts
@@ -68,6 +68,7 @@ function createSummary(
     status_counts: {
       UNKNOWN: 0,
       IN_PROGRESS: 0,
+      BOOKED: 0,
       LOADED: 0,
       IN_TRANSIT: 1,
       ARRIVED_AT_POD: 0,
@@ -204,6 +205,7 @@ describe('process.http.mappers', () => {
         status_counts: {
           UNKNOWN: 0,
           IN_PROGRESS: 0,
+          BOOKED: 0,
           LOADED: 0,
           IN_TRANSIT: 0,
           ARRIVED_AT_POD: 0,
@@ -403,6 +405,7 @@ describe('process.http.mappers', () => {
         status_counts: {
           UNKNOWN: 2,
           IN_PROGRESS: 0,
+          BOOKED: 0,
           LOADED: 0,
           IN_TRANSIT: 0,
           ARRIVED_AT_POD: 0,

--- a/src/modules/process/ui/components/tests/process-status-badges.presenter.test.ts
+++ b/src/modules/process/ui/components/tests/process-status-badges.presenter.test.ts
@@ -18,6 +18,7 @@ function createTranslationStub(
 ): (key: string, options?: Record<string, unknown>) => string {
   return (key: string, options?: Record<string, unknown>) => {
     const count = typeof options?.count === 'number' ? options.count : 0
+    if (key === keys.tracking.status.BOOKED) return 'Aguardando embarque'
     if (key === keys.tracking.status.IN_TRANSIT) return 'Em trânsito'
     if (key === keys.tracking.status.DISCHARGED) return 'Descarregado'
     if (key === keys.tracking.statusMicrobadge.DISCHARGED.one) return `${count} descarregado`
@@ -76,6 +77,24 @@ describe('process-status-badges.presenter', () => {
     })
 
     expect(display.primary.label).toBe('Em trânsito')
+    expect(display.microbadge).toBeNull()
+  })
+
+  it('uses the operational waiting label for BOOKED process badges', () => {
+    const { keys } = useTranslation()
+    const display = toProcessStatusBadgesDisplay({
+      source: createStatusSource({
+        status: 'slate-400',
+        statusCode: 'BOOKED',
+      }),
+      t: createTranslationStub(keys),
+      keys,
+    })
+
+    expect(display.primary).toEqual({
+      label: 'Aguardando embarque',
+      variant: 'slate-400',
+    })
     expect(display.microbadge).toBeNull()
   })
 })

--- a/src/modules/process/ui/mappers/tests/containerSummary.ui-mapper.test.ts
+++ b/src/modules/process/ui/mappers/tests/containerSummary.ui-mapper.test.ts
@@ -82,6 +82,7 @@ function makeMapperCommand(containers: readonly ContainerDetailVM[]) {
     locale,
     keys,
     t: (key: string): string => {
+      if (key === keys.tracking.status.BOOKED) return 'Aguardando embarque'
       if (key === keys.shipmentView.operational.chips.etaArrived) return 'Arrived'
       if (key === keys.shipmentView.operational.chips.etaExpected) return 'ETA'
       if (key === keys.shipmentView.operational.chips.etaDelayedSuffix) return 'delayed'
@@ -115,6 +116,19 @@ describe('toContainerSummaryRowVMs', () => {
 
     expect(row.statusVariant).toBe('orange-500')
     expect(row.statusLabel).toBe(command.t(command.keys.tracking.status.DISCHARGED))
+  })
+
+  it('renders BOOKED containers with the operational waiting label', () => {
+    const container = makeContainer({
+      status: 'slate-400',
+      statusCode: 'BOOKED',
+    })
+    const command = makeMapperCommand([container])
+    const [row] = toContainerSummaryRowVMs(command)
+    if (!row) throw new Error('Expected row at index 0')
+
+    expect(row.statusVariant).toBe('slate-400')
+    expect(row.statusLabel).toBe('Aguardando embarque')
   })
 
   it('maps ETA label using eta chip semantics', () => {

--- a/src/modules/process/ui/mappers/trackingStatus.ui-mapper.ts
+++ b/src/modules/process/ui/mappers/trackingStatus.ui-mapper.ts
@@ -20,6 +20,8 @@ export function trackingStatusToLabelKey(
   const normalizedStatusCode = toTrackingStatusCode(statusCode)
 
   switch (normalizedStatusCode) {
+    case 'BOOKED':
+      return keys.tracking.status.BOOKED
     case 'IN_PROGRESS':
       return keys.tracking.status.IN_PROGRESS
     case 'LOADED':

--- a/src/modules/process/ui/status-color.ts
+++ b/src/modules/process/ui/status-color.ts
@@ -4,6 +4,7 @@ import type { StatusVariant } from '~/shared/ui/StatusBadge'
 export const STATUS_COLOR = {
   UNKNOWN: 'slate-400',
   IN_PROGRESS: 'slate-500',
+  BOOKED: 'slate-400',
   LOADED: 'indigo-500',
   IN_TRANSIT: 'blue-500',
   ARRIVED_AT_POD: 'amber-500',

--- a/src/modules/tracking/domain/tests/actualVsExpected.test.ts
+++ b/src/modules/tracking/domain/tests/actualVsExpected.test.ts
@@ -307,8 +307,8 @@ describe('ACTUAL vs EXPECTED differentiation', () => {
         ],
         now,
       )
-      // Only GATE_IN is ACTUAL, so status should be IN_PROGRESS
-      expect(deriveStatus(timeline)).toBe('IN_PROGRESS')
+      // Only GATE_IN is ACTUAL, so status should remain in pre-shipment BOOKED
+      expect(deriveStatus(timeline)).toBe('BOOKED')
     })
   })
 

--- a/src/modules/tracking/features/status/application/projection/tests/tracking.status.projection.test.ts
+++ b/src/modules/tracking/features/status/application/projection/tests/tracking.status.projection.test.ts
@@ -11,6 +11,7 @@ describe('toTrackingStatusCode', () => {
   })
 
   it('maps known status values as-is', () => {
+    expect(toTrackingStatusCode('BOOKED')).toBe('BOOKED')
     expect(toTrackingStatusCode('IN_TRANSIT')).toBe('IN_TRANSIT')
     expect(toTrackingStatusCode('DELIVERED')).toBe('DELIVERED')
   })

--- a/src/modules/tracking/features/status/domain/derive/deriveStatus.ts
+++ b/src/modules/tracking/features/status/domain/derive/deriveStatus.ts
@@ -13,7 +13,7 @@ import type { Timeline } from '~/modules/tracking/features/timeline/domain/model
  * Maps observation types to the status they imply.
  */
 const OBSERVATION_TO_STATUS: Partial<Record<ObservationType, ContainerStatus>> = {
-  GATE_IN: 'IN_PROGRESS',
+  GATE_IN: 'BOOKED',
   GATE_OUT: 'IN_PROGRESS',
   LOAD: 'LOADED',
   DEPARTURE: 'IN_TRANSIT',
@@ -25,6 +25,13 @@ const OBSERVATION_TO_STATUS: Partial<Record<ObservationType, ContainerStatus>> =
   CUSTOMS_RELEASE: 'DISCHARGED',
 }
 
+const BOOKING_ROUTE_MILESTONE_TYPES: readonly ObservationType[] = [
+  'LOAD',
+  'DEPARTURE',
+  'ARRIVAL',
+  'DISCHARGE',
+]
+
 /**
  * Derive the current status of a container from its timeline.
  *
@@ -32,8 +39,9 @@ const OBSERVATION_TO_STATUS: Partial<Record<ObservationType, ContainerStatus>> =
  * The algorithm finds the highest-dominance status implied by any
  * **ACTUAL** observation in the timeline.
  *
- * CRITICAL RULE: Only ACTUAL observations can advance status.
- * EXPECTED observations are informational only and do NOT affect status.
+ * CRITICAL RULE: Strong lifecycle progression is driven by ACTUAL observations.
+ * EXPECTED observations do NOT advance vessel/transit/post-arrival states, but they
+ * may corroborate BOOKED when paired with ACTUAL pre-shipment handling facts.
  *
  * Pseudocode from master doc:
  *   if delivered (ACTUAL) → DELIVERED
@@ -41,6 +49,7 @@ const OBSERVATION_TO_STATUS: Partial<Record<ObservationType, ContainerStatus>> =
  *   else if arrived_at_final (ACTUAL) → ARRIVED_AT_POD
  *   else if any_departure (ACTUAL) → IN_TRANSIT
  *   else if any_load (ACTUAL) → LOADED
+ *   else if pre-shipment evidence without confirmed embarkation → BOOKED
  *   else → IN_PROGRESS
  *
  * @param timeline - Derived timeline for the container
@@ -144,6 +153,15 @@ export function deriveStatus(timeline: Timeline): ContainerStatus {
     return true
   }
 
+  const hasRelevantRouteExpectation = () =>
+    timeline.observations.some((observation) => {
+      if (observation.event_time_type !== 'EXPECTED') return false
+      return BOOKING_ROUTE_MILESTONE_TYPES.includes(observation.type)
+    })
+
+  const hasActualGateOutWithRelevantFutureChain = () =>
+    hasActualOfType('GATE_OUT') && hasRelevantRouteExpectation()
+
   // Follow the explicit dominance order requested by the product rules.
   // EMPTY_RETURN should take precedence over DELIVERY when present
   if (hasActualOfType('EMPTY_RETURN')) return 'EMPTY_RETURNED'
@@ -173,7 +191,8 @@ export function deriveStatus(timeline: Timeline): ContainerStatus {
   if (hasActualArrivalAtFinal()) return 'ARRIVED_AT_POD'
   if (hasActualOfType('DEPARTURE')) return 'IN_TRANSIT'
   if (hasActualOfType('LOAD')) return 'LOADED'
-  if (hasActualOfType('GATE_IN')) return 'IN_PROGRESS'
+  if (hasActualOfType('GATE_IN')) return 'BOOKED'
+  if (hasActualGateOutWithRelevantFutureChain()) return 'BOOKED'
 
   // If there are any observations but none that advance status, report IN_PROGRESS
   if (timeline.observations.length > 0) return 'IN_PROGRESS'

--- a/src/modules/tracking/features/status/domain/model/containerStatus.ts
+++ b/src/modules/tracking/features/status/domain/model/containerStatus.ts
@@ -11,6 +11,8 @@ export type ContainerStatus =
   | 'UNKNOWN'
   /** Container exists, minimal info */
   | 'IN_PROGRESS'
+  /** Pre-shipment operational preparation confirmed */
+  | 'BOOKED'
   /** Container loaded on vessel */
   | 'LOADED'
   /** Vessel departed (container in transit) */
@@ -32,6 +34,7 @@ export type ContainerStatus =
 export const CONTAINER_STATUSES: readonly ContainerStatus[] = [
   'UNKNOWN',
   'IN_PROGRESS',
+  'BOOKED',
   'LOADED',
   'IN_TRANSIT',
   'ARRIVED_AT_POD',

--- a/src/modules/tracking/features/status/domain/tests/deriveStatus.test.ts
+++ b/src/modules/tracking/features/status/domain/tests/deriveStatus.test.ts
@@ -49,10 +49,48 @@ describe('deriveStatus', () => {
     expect(deriveStatus(timeline)).toBe('IN_PROGRESS')
   })
 
-  it('should return IN_PROGRESS for GATE_IN events', () => {
+  it('should return BOOKED for GATE_IN events', () => {
     const timeline = deriveTimeline(CONTAINER_ID, CONTAINER_NUMBER, [
       makeObs({ type: 'GATE_IN', id: '00000000-0000-0000-0000-000000000011', fingerprint: 'fp1' }),
     ])
+    expect(deriveStatus(timeline)).toBe('BOOKED')
+  })
+
+  it('should return BOOKED for ACTUAL GATE_OUT when a relevant future route chain exists', () => {
+    const timeline = deriveTimeline(CONTAINER_ID, CONTAINER_NUMBER, [
+      makeObs({
+        type: 'GATE_OUT',
+        id: '00000000-0000-0000-0000-000000000011',
+        fingerprint: 'fp1',
+      }),
+      makeObs({
+        type: 'DEPARTURE',
+        event_time_type: 'EXPECTED',
+        id: '00000000-0000-0000-0000-000000000012',
+        fingerprint: 'fp2',
+        event_time: '2027-11-26T00:00:00.000Z',
+      }),
+      makeObs({
+        type: 'ARRIVAL',
+        event_time_type: 'EXPECTED',
+        id: '00000000-0000-0000-0000-000000000013',
+        fingerprint: 'fp3',
+        event_time: '2027-12-05T00:00:00.000Z',
+      }),
+    ])
+
+    expect(deriveStatus(timeline)).toBe('BOOKED')
+  })
+
+  it('should keep IN_PROGRESS for isolated ACTUAL GATE_OUT without future route chain', () => {
+    const timeline = deriveTimeline(CONTAINER_ID, CONTAINER_NUMBER, [
+      makeObs({
+        type: 'GATE_OUT',
+        id: '00000000-0000-0000-0000-000000000011',
+        fingerprint: 'fp1',
+      }),
+    ])
+
     expect(deriveStatus(timeline)).toBe('IN_PROGRESS')
   })
 

--- a/src/shared/api-schemas/processes.schemas.ts
+++ b/src/shared/api-schemas/processes.schemas.ts
@@ -9,6 +9,7 @@ const ProcessLastSyncStatusSchema = z.enum(['DONE', 'FAILED', 'RUNNING', 'UNKNOW
 const ProcessStatusMicrobadgeStatusSchema = z.enum([
   'UNKNOWN',
   'IN_PROGRESS',
+  'BOOKED',
   'LOADED',
   'IN_TRANSIT',
   'ARRIVED_AT_POD',
@@ -21,6 +22,7 @@ const ProcessStatusMicrobadgeStatusSchema = z.enum([
 const ProcessStatusCountsSchema = z.object({
   UNKNOWN: z.number().int().nonnegative(),
   IN_PROGRESS: z.number().int().nonnegative(),
+  BOOKED: z.number().int().nonnegative(),
   LOADED: z.number().int().nonnegative(),
   IN_TRANSIT: z.number().int().nonnegative(),
   ARRIVED_AT_POD: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary
- Introduce `BOOKED` as a first-class pre-shipment status across tracking, process aggregation, UI mapping, and API schemas.
- Update status derivation so `GATE_IN` now resolves to `BOOKED`, and preserve `BOOKED` through process/status aggregation and badges.
- Adjust labels and colors so the UI shows the new pre-shipment wording consistently.
- Expand tests to cover status derivation, aggregation, HTTP mapping, and presenter behavior for `BOOKED`.

## Testing
- Added/updated unit tests for tracking status derivation, including `GATE_IN` -> `BOOKED` and relevant future-route chain handling.
- Added/updated process aggregation and UI mapper tests to ensure `BOOKED` is counted, mapped, and rendered correctly.
- Added/updated HTTP schema/mapping tests for the new `BOOKED` enum value.
- Not run