### PR TITLE
Fix leg-aware missing milestone validation for MSC transshipments

### DIFF
--- a/src/modules/tracking/dev/scenario-lab/scenario.catalog.ts
+++ b/src/modules/tracking/dev/scenario-lab/scenario.catalog.ts
@@ -589,6 +589,65 @@ const MSC_EMPTY_TO_SHIPPER = mscEvent({
   detail: ['EMPTY'],
 })
 
+const MSC_LEG_AWARE_KARACHI_LOAD = mscEvent({
+  description: 'Export Loaded on Vessel',
+  eventTime: atPast(18, 10),
+  locationCode: 'PKKHI',
+  locationDisplay: 'KARACHI, PK',
+  vesselName: 'MSC ARICA',
+  voyage: 'OB610R',
+})
+
+const MSC_LEG_AWARE_COLOMBO_DISCHARGE = mscEvent({
+  description: 'Full Transshipment Discharged',
+  eventTime: atPast(27, 10),
+  locationCode: 'LKCMB',
+  locationDisplay: 'COLOMBO, LK',
+  vesselName: 'MSC ARICA',
+  voyage: 'IV610A',
+})
+
+const MSC_LEG_AWARE_COLOMBO_DISCHARGE_DUPLICATE = mscEvent({
+  description: 'Full Transshipment Discharged',
+  eventTime: atPast(27, 10),
+  locationCode: 'LKCMB',
+  locationDisplay: 'COLOMBO, LK',
+  vesselName: 'MSC ARICA',
+  voyage: 'OB610R',
+})
+
+const MSC_LEG_AWARE_COLOMBO_POSITIONED_IN = mscEvent({
+  description: 'Full Transshipment Positioned In',
+  eventTime: atPast(28, 8),
+  locationCode: 'LKCMB',
+  locationDisplay: 'COLOMBO, LK',
+})
+
+const MSC_LEG_AWARE_COLOMBO_POSITIONED_OUT = mscEvent({
+  description: 'Full Transshipment Positioned Out',
+  eventTime: atPast(28, 18),
+  locationCode: 'LKCMB',
+  locationDisplay: 'COLOMBO, LK',
+})
+
+const MSC_LEG_AWARE_COLOMBO_LOAD = mscEvent({
+  description: 'Full Transshipment Loaded',
+  eventTime: atPast(30, 10),
+  locationCode: 'LKCMB',
+  locationDisplay: 'COLOMBO, LK',
+  vesselName: 'GSL VIOLETTA',
+  voyage: 'ZF609R',
+})
+
+const MSC_LEG_AWARE_SINGAPORE_DISCHARGE = mscEvent({
+  description: 'Import Discharged from Vessel',
+  eventTime: atPast(37, 10),
+  locationCode: 'SGSIN',
+  locationDisplay: 'SINGAPORE, SG',
+  vesselName: 'GSL VIOLETTA',
+  voyage: 'ZF609R',
+})
+
 const CMACGM_EMPTY_TO_SHIPPER = cmaMove({
   statusDescription: 'Empty to shipper',
   eventTime: atPast(0, 7),
@@ -1823,6 +1882,41 @@ function buildPathologyScenarios(): readonly TrackingScenario[] {
           newEvents: [],
         },
       ]),
+    }),
+    createScenario({
+      id: 'msc.leg_aware_missing_milestone',
+      title: 'Pathology · Split Maritime Legs (MSC)',
+      description:
+        'Valid MSC transshipment across Colombo must not trigger missing critical milestone.',
+      category: 'data_pathologies',
+      stage: 6,
+      tags: ['pathology', 'msc', 'transshipment', 'leg-aware'],
+      containers: singleContainer('msc'),
+      steps: [
+        {
+          id: 'step-1',
+          title: 'Two ACTUAL maritime legs around Colombo',
+          description: 'Reload at Colombo opens a new maritime leg before Singapore discharge.',
+          snapshots: [
+            mscSnapshot({
+              containerKey: 'c1',
+              fetchedAt: addMinutes(MSC_LEG_AWARE_SINGAPORE_DISCHARGE.eventTime, 45),
+              currentDate: toMscDate(addMinutes(MSC_LEG_AWARE_SINGAPORE_DISCHARGE.eventTime, 45)),
+              events: [
+                MSC_LEG_AWARE_KARACHI_LOAD,
+                MSC_LEG_AWARE_COLOMBO_DISCHARGE,
+                MSC_LEG_AWARE_COLOMBO_DISCHARGE_DUPLICATE,
+                MSC_LEG_AWARE_COLOMBO_POSITIONED_IN,
+                MSC_LEG_AWARE_COLOMBO_POSITIONED_OUT,
+                MSC_LEG_AWARE_COLOMBO_LOAD,
+                MSC_LEG_AWARE_SINGAPORE_DISCHARGE,
+              ],
+              podEtaDate: toMscDate(atFuture(20, 8)),
+              podLocation: buildLocationName(LOC_POD.city, LOC_POD.countryCode),
+            }),
+          ],
+        },
+      ],
     }),
     createScenario({
       id: 'carrier_time_travel',

--- a/src/modules/tracking/dev/scenario-lab/tests/scenario.seed.test.ts
+++ b/src/modules/tracking/dev/scenario-lab/tests/scenario.seed.test.ts
@@ -67,6 +67,48 @@ describe('scenario seeder', () => {
     ).rejects.toThrow('Scenario not found')
   })
 
+  it('loads the MSC leg-aware validation regression scenario through the normal seeder contract', async () => {
+    const createProcess = vi.fn(
+      async (command: {
+        record: { reference: string | null }
+        containers: readonly { container_number: string; carrier_code: string | null }[]
+      }) => {
+        return {
+          process: {
+            id: 'process-lab-msc-1',
+            reference: command.record.reference,
+          },
+          containers: command.containers.map((container, index) => ({
+            id: `container-msc-${index + 1}`,
+            containerNumber: container.container_number,
+          })),
+        }
+      },
+    )
+
+    const saveAndProcess = vi.fn(async () => {})
+
+    const seeder = createScenarioSeeder({
+      createProcess,
+      findProcessByIdWithContainers: async () => ({
+        process: null,
+        containers: [],
+      }),
+      saveAndProcess,
+    })
+
+    const result = await seeder.loadScenario({
+      scenarioId: 'msc.leg_aware_missing_milestone',
+      step: 1,
+    })
+
+    expect(createProcess).toHaveBeenCalledTimes(1)
+    expect(saveAndProcess).toHaveBeenCalledTimes(1)
+    expect(result.processId).toBe('process-lab-msc-1')
+    expect(result.totalSnapshotsApplied).toBe(1)
+    expect(result.containerNumbers).toHaveLength(1)
+  })
+
   it('reuses an existing process and preserves container identity for later steps', async () => {
     const createProcess = vi.fn(async () => {
       throw new Error('createProcess should not run during reuse')

--- a/src/modules/tracking/features/validation/application/tests/trackingValidation.projection.test.ts
+++ b/src/modules/tracking/features/validation/application/tests/trackingValidation.projection.test.ts
@@ -159,6 +159,88 @@ function deriveValidationSummaryForObservations(
   })
 }
 
+function makeLegAwareSplitObservations(): readonly Observation[] {
+  return [
+    makeObservation({
+      id: 'karachi-load-arica',
+      type: 'LOAD',
+      created_at: '2026-03-19T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-19T10:00:00.000Z'),
+      location_code: 'PKKHI',
+      location_display: 'Karachi',
+      vessel_name: 'MSC ARICA',
+      voyage: 'OB610R',
+      carrier_label: 'Export Loaded on Vessel',
+    }),
+    makeObservation({
+      id: 'colombo-discharge-arica',
+      type: 'DISCHARGE',
+      created_at: '2026-03-28T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-28T10:00:00.000Z'),
+      location_code: 'LKCMB',
+      location_display: 'Colombo',
+      vessel_name: 'MSC ARICA',
+      voyage: 'IV610A',
+      carrier_label: 'Full Transshipment Discharged',
+    }),
+    makeObservation({
+      id: 'colombo-discharge-arica-duplicate',
+      type: 'DISCHARGE',
+      created_at: '2026-03-28T11:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-28T10:00:00.000Z'),
+      location_code: 'LKCMB',
+      location_display: 'Colombo',
+      vessel_name: 'MSC ARICA',
+      voyage: 'OB610R',
+      carrier_label: 'Full Transshipment Discharged',
+    }),
+    makeObservation({
+      id: 'colombo-positioned-in',
+      type: 'TRANSSHIPMENT_POSITIONED_IN',
+      created_at: '2026-03-29T08:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-29T08:00:00.000Z'),
+      location_code: 'LKCMB',
+      location_display: 'Colombo',
+      vessel_name: null,
+      voyage: null,
+      carrier_label: 'Full Transshipment Positioned In',
+    }),
+    makeObservation({
+      id: 'colombo-positioned-out',
+      type: 'TRANSSHIPMENT_POSITIONED_OUT',
+      created_at: '2026-03-29T18:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-29T18:00:00.000Z'),
+      location_code: 'LKCMB',
+      location_display: 'Colombo',
+      vessel_name: null,
+      voyage: null,
+      carrier_label: 'Full Transshipment Positioned Out',
+    }),
+    makeObservation({
+      id: 'colombo-load-violetta',
+      type: 'LOAD',
+      created_at: '2026-03-31T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-31T10:00:00.000Z'),
+      location_code: 'LKCMB',
+      location_display: 'Colombo',
+      vessel_name: 'GSL VIOLETTA',
+      voyage: 'ZF609R',
+      carrier_label: 'Full Transshipment Loaded',
+    }),
+    makeObservation({
+      id: 'singapore-discharge-violetta',
+      type: 'DISCHARGE',
+      created_at: '2026-04-07T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-04-07T10:00:00.000Z'),
+      location_code: 'SGSIN',
+      location_display: 'Singapore',
+      vessel_name: 'GSL VIOLETTA',
+      voyage: 'ZF609R',
+      carrier_label: 'Import Discharged from Vessel',
+    }),
+  ]
+}
+
 describe('trackingValidation.projection', () => {
   it('exposes ordered active issues with public explanation metadata only', () => {
     const observations = [
@@ -449,6 +531,38 @@ describe('trackingValidation.projection', () => {
       },
     ])
     expect(summary.activeIssues[0]).not.toHaveProperty('debugEvidence')
+  })
+
+  it('does not surface missing critical milestone when repeated maritime ACTUAL belongs to a new leg', () => {
+    const observations = makeLegAwareSplitObservations()
+
+    const summary = deriveTrackingValidationSummaryFromState({
+      containerId: 'container-1',
+      containerNumber: 'GLDU2928252',
+      observations,
+      timeline: {
+        container_id: 'container-1',
+        container_number: 'GLDU2928252',
+        observations,
+        derived_at: '2026-04-08T10:00:00.000Z',
+        holes: [],
+      },
+      status: 'DISCHARGED',
+      transshipment: {
+        hasTransshipment: true,
+        transshipmentCount: 1,
+        ports: ['LKCMB'],
+      },
+      now: Instant.fromIso('2026-04-08T10:00:00.000Z'),
+    })
+
+    expect(summary).toEqual({
+      hasIssues: false,
+      findingCount: 0,
+      highestSeverity: null,
+      topIssue: null,
+      activeIssues: [],
+    })
   })
 
   it('flags duplicated canonical voyage segments when the same rendered leg appears twice', () => {

--- a/src/modules/tracking/features/validation/domain/detectors/missingCriticalMilestoneWithContradictoryContext.detector.ts
+++ b/src/modules/tracking/features/validation/domain/detectors/missingCriticalMilestoneWithContradictoryContext.detector.ts
@@ -17,19 +17,27 @@ type MaritimeObservation = Observation & {
   readonly type: MaritimeObservationType
 }
 
+type MaritimeLeg = {
+  readonly startChronologyIndex: number
+  readonly observations: readonly MaritimeObservation[]
+}
+
 type ContradictionSignal = {
   readonly missingMilestone: MissingMilestone
   readonly previousObservation: MaritimeObservation
   readonly anchorObservation: MaritimeObservation
   readonly anchorChronologyIndex: number
-}
-
-function isMaritimeObservationType(type: Observation['type']): type is MaritimeObservationType {
-  return type === 'LOAD' || type === 'DEPARTURE' || type === 'ARRIVAL' || type === 'DISCHARGE'
+  readonly anchorLegIndex: number
+  readonly legObservations: readonly MaritimeObservation[]
 }
 
 function isMaritimeObservation(observation: Observation): observation is MaritimeObservation {
-  return isMaritimeObservationType(observation.type)
+  return (
+    observation.type === 'LOAD' ||
+    observation.type === 'DEPARTURE' ||
+    observation.type === 'ARRIVAL' ||
+    observation.type === 'DISCHARGE'
+  )
 }
 
 function toActualMaritimeObservationChronology(
@@ -38,14 +46,51 @@ function toActualMaritimeObservationChronology(
   return toActualObservationChronology(observations).filter(isMaritimeObservation)
 }
 
-function detectMaritimeSequenceGaps(
+function segmentActualMaritimeLegs(
   maritimeObservations: readonly MaritimeObservation[],
-): readonly ContradictionSignal[] {
+): readonly MaritimeLeg[] {
+  const legs: Array<{
+    startChronologyIndex: number
+    observations: MaritimeObservation[]
+  }> = []
+  let currentLeg: {
+    startChronologyIndex: number
+    observations: MaritimeObservation[]
+  } | null = null
+
+  for (const [chronologyIndex, observation] of maritimeObservations.entries()) {
+    if (observation.type === 'LOAD') {
+      currentLeg = {
+        startChronologyIndex: chronologyIndex,
+        observations: [observation],
+      }
+      legs.push(currentLeg)
+      continue
+    }
+
+    if (currentLeg === null) {
+      currentLeg = {
+        startChronologyIndex: chronologyIndex,
+        observations: [observation],
+      }
+      legs.push(currentLeg)
+      continue
+    }
+
+    currentLeg.observations.push(observation)
+  }
+
+  return legs
+}
+
+function detectLegSequenceGaps(leg: MaritimeLeg): readonly ContradictionSignal[] {
   let previousMaritimeObservation: MaritimeObservation | null = null
   let missingDeparture: ContradictionSignal | null = null
   let missingArrival: ContradictionSignal | null = null
 
-  for (const [chronologyIndex, observation] of maritimeObservations.entries()) {
+  for (const [legIndex, observation] of leg.observations.entries()) {
+    const chronologyIndex = leg.startChronologyIndex + legIndex
+
     if (
       previousMaritimeObservation !== null &&
       missingDeparture === null &&
@@ -57,6 +102,8 @@ function detectMaritimeSequenceGaps(
         previousObservation: previousMaritimeObservation,
         anchorObservation: observation,
         anchorChronologyIndex: chronologyIndex,
+        anchorLegIndex: legIndex,
+        legObservations: leg.observations,
       }
     }
 
@@ -71,6 +118,8 @@ function detectMaritimeSequenceGaps(
         previousObservation: previousMaritimeObservation,
         anchorObservation: observation,
         anchorChronologyIndex: chronologyIndex,
+        anchorLegIndex: legIndex,
+        legObservations: leg.observations,
       }
     }
 
@@ -82,16 +131,32 @@ function detectMaritimeSequenceGaps(
   )
 }
 
-function hasRepeatedDownstreamMilestone(
-  signal: ContradictionSignal,
-  maritimeObservations: readonly MaritimeObservation[],
+function sharesObservedLocation(
+  left: Pick<Observation, 'location_code' | 'location_display'>,
+  right: Pick<Observation, 'location_code' | 'location_display'>,
 ): boolean {
+  if (left.location_code !== null && right.location_code !== null) {
+    return left.location_code === right.location_code
+  }
+
+  if (left.location_display !== null && right.location_display !== null) {
+    return left.location_display === right.location_display
+  }
+
+  return false
+}
+
+function hasRepeatedDownstreamMilestone(signal: ContradictionSignal): boolean {
   for (
-    let chronologyIndex = signal.anchorChronologyIndex + 1;
-    chronologyIndex < maritimeObservations.length;
-    chronologyIndex += 1
+    let legIndex = signal.anchorLegIndex + 1;
+    legIndex < signal.legObservations.length;
+    legIndex += 1
   ) {
-    if (maritimeObservations[chronologyIndex]?.type === signal.anchorObservation.type) {
+    const candidate = signal.legObservations[legIndex]
+    if (
+      candidate?.type === signal.anchorObservation.type &&
+      !sharesObservedLocation(candidate, signal.anchorObservation)
+    ) {
       return true
     }
   }
@@ -99,11 +164,31 @@ function hasRepeatedDownstreamMilestone(
   return false
 }
 
-function hasAdditionalContradictoryEvidence(
-  signal: ContradictionSignal,
+function selectFirstConfirmedSignalPerMissingMilestone(
+  signals: readonly ContradictionSignal[],
+): readonly ContradictionSignal[] {
+  const firstByMissingMilestone = new Map<MissingMilestone, ContradictionSignal>()
+
+  for (const signal of signals) {
+    const existing = firstByMissingMilestone.get(signal.missingMilestone)
+    if (existing === undefined || signal.anchorChronologyIndex < existing.anchorChronologyIndex) {
+      firstByMissingMilestone.set(signal.missingMilestone, signal)
+    }
+  }
+
+  return [...firstByMissingMilestone.values()].sort(
+    (left, right) => left.anchorChronologyIndex - right.anchorChronologyIndex,
+  )
+}
+
+function detectMaritimeSequenceGaps(
   maritimeObservations: readonly MaritimeObservation[],
-): boolean {
-  return hasRepeatedDownstreamMilestone(signal, maritimeObservations)
+): readonly ContradictionSignal[] {
+  const candidateSignals = segmentActualMaritimeLegs(maritimeObservations)
+    .flatMap((leg) => detectLegSequenceGaps(leg))
+    .filter((signal) => hasRepeatedDownstreamMilestone(signal))
+
+  return selectFirstConfirmedSignalPerMissingMilestone(candidateSignals)
 }
 
 function describeEvidence(signal: ContradictionSignal): string {
@@ -153,8 +238,8 @@ export const missingCriticalMilestoneWithContradictoryContextDetector: TrackingV
         context.timeline.observations,
       )
 
-      return detectMaritimeSequenceGaps(maritimeObservations)
-        .filter((signal) => hasAdditionalContradictoryEvidence(signal, maritimeObservations))
-        .map((signal) => createFinding(context.containerId, signal))
+      return detectMaritimeSequenceGaps(maritimeObservations).map((signal) =>
+        createFinding(context.containerId, signal),
+      )
     },
   }

--- a/src/modules/tracking/features/validation/domain/detectors/missingCriticalMilestoneWithContradictoryContext.detector.ts
+++ b/src/modules/tracking/features/validation/domain/detectors/missingCriticalMilestoneWithContradictoryContext.detector.ts
@@ -135,15 +135,47 @@ function sharesObservedLocation(
   left: Pick<Observation, 'location_code' | 'location_display'>,
   right: Pick<Observation, 'location_code' | 'location_display'>,
 ): boolean {
-  if (left.location_code !== null && right.location_code !== null) {
-    return left.location_code === right.location_code
+  const leftLocationCode = normalizeLocationCode(left.location_code)
+  const rightLocationCode = normalizeLocationCode(right.location_code)
+
+  if (leftLocationCode !== null && rightLocationCode !== null) {
+    return leftLocationCode === rightLocationCode
   }
 
-  if (left.location_display !== null && right.location_display !== null) {
-    return left.location_display === right.location_display
+  const leftLocationDisplay = normalizeLocationDisplay(left.location_display)
+  const rightLocationDisplay = normalizeLocationDisplay(right.location_display)
+
+  if (leftLocationDisplay !== null && rightLocationDisplay !== null) {
+    return leftLocationDisplay === rightLocationDisplay
   }
 
-  return false
+  return true
+}
+
+function normalizeLocationCode(locationCode: string | null): string | null {
+  if (locationCode === null) {
+    return null
+  }
+
+  const normalizedLocationCode = locationCode.trim().toUpperCase()
+  return normalizedLocationCode.length > 0 ? normalizedLocationCode : null
+}
+
+function normalizeLocationDisplay(locationDisplay: string | null): string | null {
+  if (locationDisplay === null) {
+    return null
+  }
+
+  const normalizedLocationDisplay = locationDisplay
+    .trim()
+    .replace(/\s+/g, ' ')
+    .split(',')[0]
+    ?.trim()
+    .toUpperCase()
+
+  return normalizedLocationDisplay && normalizedLocationDisplay.length > 0
+    ? normalizedLocationDisplay
+    : null
 }
 
 function hasRepeatedDownstreamMilestone(signal: ContradictionSignal): boolean {

--- a/src/modules/tracking/features/validation/domain/tests/missingCriticalMilestoneWithContradictoryContext.detector.test.ts
+++ b/src/modules/tracking/features/validation/domain/tests/missingCriticalMilestoneWithContradictoryContext.detector.test.ts
@@ -220,6 +220,37 @@ describe('missingCriticalMilestoneWithContradictoryContextDetector', () => {
     expect(findings).toEqual([])
   })
 
+  it('does not emit when location codes are absent but location_display normalizes to the same port', () => {
+    const findings = detectFindings([
+      makeObservation({
+        id: 'load-1',
+        type: 'LOAD',
+        location_code: null,
+        location_display: 'Colombo',
+        created_at: '2026-04-01T10:30:00.000Z',
+        event_time: temporalValueFromCanonical('2026-04-01T10:00:00.000Z'),
+      }),
+      makeObservation({
+        id: 'discharge-1',
+        type: 'DISCHARGE',
+        location_code: null,
+        location_display: 'Colombo, LK',
+        created_at: '2026-04-10T10:30:00.000Z',
+        event_time: temporalValueFromCanonical('2026-04-10T10:00:00.000Z'),
+      }),
+      makeObservation({
+        id: 'discharge-2',
+        type: 'DISCHARGE',
+        location_code: null,
+        location_display: '  COLOMBO  ',
+        created_at: '2026-04-12T10:30:00.000Z',
+        event_time: temporalValueFromCanonical('2026-04-12T10:00:00.000Z'),
+      }),
+    ])
+
+    expect(findings).toEqual([])
+  })
+
   it('does not emit for a plain LOAD -> DISCHARGE gap', () => {
     const findings = detectFindings([
       makeObservation({

--- a/src/modules/tracking/features/validation/domain/tests/missingCriticalMilestoneWithContradictoryContext.detector.test.ts
+++ b/src/modules/tracking/features/validation/domain/tests/missingCriticalMilestoneWithContradictoryContext.detector.test.ts
@@ -60,6 +60,103 @@ function detectFindings(observations: readonly Observation[]) {
   return missingCriticalMilestoneWithContradictoryContextDetector.detect(makeContext(observations))
 }
 
+function makeSplitLegTransshipmentObservations(command?: {
+  readonly includeTerminalMoves?: boolean
+  readonly includeSamePortDischargeDuplicate?: boolean
+}): readonly Observation[] {
+  const samePortDuplicate = command?.includeSamePortDischargeDuplicate
+    ? [
+        makeObservation({
+          id: 'colombo-discharge-arica-duplicate',
+          type: 'DISCHARGE',
+          location_code: 'LKCMB',
+          location_display: 'Colombo',
+          vessel_name: 'MSC ARICA',
+          voyage: 'OB610R',
+          created_at: '2026-03-28T11:30:00.000Z',
+          event_time: temporalValueFromCanonical('2026-03-28T10:00:00.000Z'),
+          carrier_label: 'Full Transshipment Discharged',
+        }),
+      ]
+    : []
+
+  const terminalMoves = command?.includeTerminalMoves
+    ? [
+        makeObservation({
+          id: 'colombo-positioned-in',
+          type: 'TRANSSHIPMENT_POSITIONED_IN',
+          location_code: 'LKCMB',
+          location_display: 'Colombo',
+          vessel_name: null,
+          voyage: null,
+          created_at: '2026-03-29T08:30:00.000Z',
+          event_time: temporalValueFromCanonical('2026-03-29T08:00:00.000Z'),
+          carrier_label: 'Full Transshipment Positioned In',
+        }),
+        makeObservation({
+          id: 'colombo-positioned-out',
+          type: 'TRANSSHIPMENT_POSITIONED_OUT',
+          location_code: 'LKCMB',
+          location_display: 'Colombo',
+          vessel_name: null,
+          voyage: null,
+          created_at: '2026-03-29T18:30:00.000Z',
+          event_time: temporalValueFromCanonical('2026-03-29T18:00:00.000Z'),
+          carrier_label: 'Full Transshipment Positioned Out',
+        }),
+      ]
+    : []
+
+  return [
+    makeObservation({
+      id: 'karachi-load-arica',
+      type: 'LOAD',
+      location_code: 'PKKHI',
+      location_display: 'Karachi',
+      vessel_name: 'MSC ARICA',
+      voyage: 'OB610R',
+      created_at: '2026-03-19T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-19T10:00:00.000Z'),
+      carrier_label: 'Export Loaded on Vessel',
+    }),
+    makeObservation({
+      id: 'colombo-discharge-arica',
+      type: 'DISCHARGE',
+      location_code: 'LKCMB',
+      location_display: 'Colombo',
+      vessel_name: 'MSC ARICA',
+      voyage: 'IV610A',
+      created_at: '2026-03-28T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-28T10:00:00.000Z'),
+      carrier_label: 'Full Transshipment Discharged',
+    }),
+    ...samePortDuplicate,
+    ...terminalMoves,
+    makeObservation({
+      id: 'colombo-load-violetta',
+      type: 'LOAD',
+      location_code: 'LKCMB',
+      location_display: 'Colombo',
+      vessel_name: 'GSL VIOLETTA',
+      voyage: 'ZF609R',
+      created_at: '2026-03-31T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-03-31T10:00:00.000Z'),
+      carrier_label: 'Full Transshipment Loaded',
+    }),
+    makeObservation({
+      id: 'singapore-discharge-violetta',
+      type: 'DISCHARGE',
+      location_code: 'SGSIN',
+      location_display: 'Singapore',
+      vessel_name: 'GSL VIOLETTA',
+      voyage: 'ZF609R',
+      created_at: '2026-04-07T10:30:00.000Z',
+      event_time: temporalValueFromCanonical('2026-04-07T10:00:00.000Z'),
+      carrier_label: 'Import Discharged from Vessel',
+    }),
+  ]
+}
+
 describe('missingCriticalMilestoneWithContradictoryContextDetector', () => {
   it('does not emit a finding when the ACTUAL maritime sequence is complete', () => {
     const findings = detectFindings([
@@ -98,6 +195,31 @@ describe('missingCriticalMilestoneWithContradictoryContextDetector', () => {
     expect(findings).toEqual([])
   })
 
+  it('does not emit when a new LOAD ACTUAL opens a distinct maritime leg', () => {
+    const findings = detectFindings(makeSplitLegTransshipmentObservations())
+
+    expect(findings).toEqual([])
+  })
+
+  it('does not emit when same-port transshipment helper events sit between maritime legs', () => {
+    const findings = detectFindings(
+      makeSplitLegTransshipmentObservations({ includeTerminalMoves: true }),
+    )
+
+    expect(findings).toEqual([])
+  })
+
+  it('does not emit for the Colombo transshipment case when the same discharge is duplicated at the same port', () => {
+    const findings = detectFindings(
+      makeSplitLegTransshipmentObservations({
+        includeSamePortDischargeDuplicate: true,
+        includeTerminalMoves: true,
+      }),
+    )
+
+    expect(findings).toEqual([])
+  })
+
   it('does not emit for a plain LOAD -> DISCHARGE gap', () => {
     const findings = detectFindings([
       makeObservation({
@@ -117,6 +239,56 @@ describe('missingCriticalMilestoneWithContradictoryContextDetector', () => {
     ])
 
     expect(findings).toEqual([])
+  })
+
+  it('emits one ADVISORY finding when DISCHARGE repeats inside the same leg after a missing DEPARTURE', () => {
+    const findings = detectFindings([
+      makeObservation({
+        id: 'load-1',
+        fingerprint: 'load-1',
+        type: 'LOAD',
+        location_code: 'PKKHI',
+        location_display: 'Karachi',
+        vessel_name: 'MSC ARICA',
+        voyage: 'OB610R',
+        created_at: '2026-03-19T10:30:00.000Z',
+        event_time: temporalValueFromCanonical('2026-03-19T10:00:00.000Z'),
+      }),
+      makeObservation({
+        id: 'discharge-1',
+        fingerprint: 'discharge-1',
+        type: 'DISCHARGE',
+        location_code: 'LKCMB',
+        location_display: 'Colombo',
+        vessel_name: 'MSC ARICA',
+        voyage: 'IV610A',
+        created_at: '2026-03-28T10:30:00.000Z',
+        event_time: temporalValueFromCanonical('2026-03-28T10:00:00.000Z'),
+      }),
+      makeObservation({
+        id: 'discharge-2',
+        fingerprint: 'discharge-2',
+        type: 'DISCHARGE',
+        location_code: 'SGSIN',
+        location_display: 'Singapore',
+        vessel_name: 'MSC ARICA',
+        voyage: 'IV610A',
+        created_at: '2026-04-07T10:30:00.000Z',
+        event_time: temporalValueFromCanonical('2026-04-07T10:00:00.000Z'),
+      }),
+    ])
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      affectedLocation: 'LKCMB',
+      debugEvidence: {
+        anchorObservationId: 'discharge-1',
+        anchorObservationType: 'DISCHARGE',
+        missingMilestone: 'DEPARTURE',
+        previousObservationId: 'load-1',
+        previousObservationType: 'LOAD',
+      },
+    })
   })
 
   it('does not emit for a plain DEPARTURE -> DISCHARGE gap', () => {


### PR DESCRIPTION
## Summary
- Make the missing critical milestone detector leg-aware so a new `LOAD` starts a distinct maritime leg instead of extending the previous one.
- Suppress false positives when repeated milestones belong to a new leg, while still preserving real gap detection inside a single leg.
- Add regression coverage for MSC split-leg transshipment scenarios in the scenario catalog, seeder path, projection summary, and detector unit tests.

## Testing
- `pnpm test src/modules/tracking/features/validation/domain/tests/missingCriticalMilestoneWithContradictoryContext.detector.test.ts`
- `pnpm test src/modules/tracking/features/validation/application/tests/trackingValidation.projection.test.ts`
- `pnpm test src/modules/tracking/dev/scenario-lab/tests/scenario.seed.test.ts`
- Not run: full repository test suite