### PR TITLE
fix(process-ui): align timeline text export with UI blocks

### DIFF
--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -445,6 +445,8 @@
         "transshipmentTerminal": "Terminal de Transbordo",
         "transshipment": "Transbordo",
         "plannedTransshipment": "Transbordo Planejado",
+        "events": "Eventos",
+        "markers": "Marcadores",
         "transshipmentPort": "Transbordo — {{port}}",
         "vesselChange": "Troca de navio",
         "vesselChangeDetail": "{{from}} → {{to}}",

--- a/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts
+++ b/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts
@@ -274,7 +274,8 @@ it('serializes a simple timeline with pre-carriage, a single voyage and an expec
       '',
       '## Bloco: Pré-transporte',
       'block_kind: PRE_CARRIAGE',
-      'block_title: Pré-transporte',
+      'block_title_canonical: Pré-transporte',
+      'block_title_display: Pré-transporte',
       'location: FAISALABAD, PK',
       '- label: Saída do Terminal',
       '  type: GATE_OUT',
@@ -284,7 +285,9 @@ it('serializes a simple timeline with pre-carriage, a single voyage and an expec
       '',
       '## Bloco: Viagem',
       'block_kind: VOYAGE',
-      'block_title: Viagem',
+      'block_title_canonical: Viagem',
+      'block_title_display: MSC ARICA',
+      'block_badges: Atual',
       'vessel: MSC ARICA',
       'voyage: OB610R',
       'route: KARACHI-MUHAMMAD BIN QASIM, PK → SANTOS, BR',
@@ -384,7 +387,8 @@ it('serializes a real transshipment with voyage, handoff block, terminal block a
       '',
       '## Bloco: Viagem',
       'block_kind: VOYAGE',
-      'block_title: Viagem',
+      'block_title_canonical: Viagem',
+      'block_title_display: MSC ARICA',
       'vessel: MSC ARICA',
       'voyage: OB610R',
       'route: KARACHI, PK → COLOMBO, LK',
@@ -405,7 +409,8 @@ it('serializes a real transshipment with voyage, handoff block, terminal block a
       '',
       '## Bloco: Transbordo',
       'block_kind: TRANSSHIPMENT',
-      'block_title: Transbordo',
+      'block_title_canonical: Transbordo',
+      'block_title_display: Transbordo',
       'transshipment_mode: CONFIRMED',
       'location: COLOMBO, LK',
       'handoff_summary: MSC ARICA → GSL VIOLETTA',
@@ -417,7 +422,8 @@ it('serializes a real transshipment with voyage, handoff block, terminal block a
       '',
       '## Bloco: Terminal de Transbordo',
       'block_kind: TRANSSHIPMENT_TERMINAL',
-      'block_title: Terminal de Transbordo',
+      'block_title_canonical: Terminal de Transbordo',
+      'block_title_display: Terminal de Transbordo',
       'location: COLOMBO, LK',
       '- label: Entrada Operacional no Transbordo',
       '  type: TRANSSHIPMENT_POSITIONED_IN',
@@ -427,7 +433,9 @@ it('serializes a real transshipment with voyage, handoff block, terminal block a
       '',
       '## Bloco: Viagem',
       'block_kind: VOYAGE',
-      'block_title: Viagem',
+      'block_title_canonical: Viagem',
+      'block_title_display: GSL VIOLETTA',
+      'block_badges: Atual',
       'vessel: GSL VIOLETTA',
       'voyage: 2613W',
       'route: COLOMBO, LK → SANTOS, BR',
@@ -519,7 +527,8 @@ it('serializes an explicit planned transshipment block with future leg metadata'
     [
       '## Bloco: Transbordo Planejado',
       'block_kind: PLANNED_TRANSSHIPMENT',
-      'block_title: Transbordo Planejado',
+      'block_title_canonical: Transbordo Planejado',
+      'block_title_display: Transbordo Planejado',
       'transshipment_mode: PLANNED',
       'location: SINGAPORE, SG',
       'handoff_summary: MSC ARICA → SAO PAULO EXPRESS',
@@ -582,7 +591,8 @@ it('preserves heterogeneous block order and serializes visible gap and port-risk
     [
       '## Bloco: Viagem',
       'block_kind: VOYAGE',
-      'block_title: Viagem',
+      'block_title_canonical: Viagem',
+      'block_title_display: MSC ARICA',
       'vessel: MSC ARICA',
       'voyage: OB610R',
       'route: KARACHI, PK → SANTOS, BR',
@@ -704,13 +714,16 @@ it('omits optional fields cleanly when vessel, voyage and handoff summary are un
       '',
       '## Bloco: Transbordo',
       'block_kind: TRANSSHIPMENT',
-      'block_title: Transbordo',
+      'block_title_canonical: Transbordo',
+      'block_title_display: Transbordo',
       'transshipment_mode: CONFIRMED',
       'location: COLOMBO, LK',
       '',
       '## Bloco: Viagem',
       'block_kind: VOYAGE',
-      'block_title: Viagem',
+      'block_title_canonical: Viagem',
+      'block_title_display: Viagem',
+      'route: ? → SANTOS, BR',
       '- label: Chegada ao Porto',
       '  type: ARRIVAL',
       '  event_time_type: EXPECTED',
@@ -815,7 +828,9 @@ it('uses the visible historical checkpoint and its reference_now for export', ()
       '',
       '## Bloco: Viagem',
       'block_kind: VOYAGE',
-      'block_title: Viagem',
+      'block_title_canonical: Viagem',
+      'block_title_display: SAO PAULO EXPRESS',
+      'block_badges: Atual',
       'vessel: SAO PAULO EXPRESS',
       'voyage: 2613W',
       'route: SINGAPORE, SG → SANTOS, BR',
@@ -889,4 +904,195 @@ it('uses the visible historical checkpoint and its reference_now for export', ()
 
   expect(historicalWithoutContainer).not.toContain('UNKNOWN')
   expect(historicalWithoutContainer.split('\n')[1]).toBe('export_mode: HISTORICAL')
+})
+
+it('keeps planned-block markers under the planned transshipment instead of emitting standalone markers', () => {
+  const source = makeCurrentSource(
+    makeContainer({
+      currentContext: {
+        locationCode: 'SGSIN',
+        locationDisplay: 'SINGAPORE, SG',
+        vesselName: 'MSC MIRAYA V',
+        voyage: 'OB612R',
+        vesselVisible: true,
+      },
+      transshipment: {
+        hasTransshipment: true,
+        count: 1,
+        ports: [
+          {
+            code: 'SGSIN',
+            display: 'SINGAPORE, SG',
+          },
+        ],
+      },
+      timeline: [
+        makeEvent({
+          id: 'leg-a-load',
+          type: 'LOAD',
+          eventTime: '2026-03-01',
+          vesselName: 'MSC MIRAYA V',
+          voyage: 'OB612R',
+          location: 'KARACHI, PK',
+        }),
+        makeEvent({
+          id: 'leg-a-discharge',
+          type: 'DISCHARGE',
+          eventTime: '2026-03-11',
+          vesselName: 'MSC MIRAYA V',
+          voyage: 'OB612R',
+          location: 'SINGAPORE, SG',
+        }),
+        makeEvent({
+          id: 'planned-intended',
+          type: 'TRANSSHIPMENT_INTENDED',
+          eventTime: '2026-03-12',
+          eventTimeType: 'EXPECTED',
+          location: 'SINGAPORE, SG',
+          vesselName: 'SAO PAULO EXPRESS',
+          voyage: 'SPX001',
+        }),
+        makeEvent({
+          id: 'planned-arrival',
+          type: 'ARRIVAL',
+          eventTime: '2026-04-10',
+          eventTimeType: 'EXPECTED',
+          location: 'SANTOS, BR',
+        }),
+        makeEvent({
+          id: 'planned-discharge',
+          type: 'DISCHARGE',
+          eventTime: '2026-04-12',
+          eventTimeType: 'EXPECTED',
+          location: 'SANTOS, BR',
+        }),
+      ],
+    }),
+  )
+
+  const output = serialize(source)
+
+  expect(output).toContain(
+    [
+      '## Bloco: Transbordo Planejado',
+      'block_kind: PLANNED_TRANSSHIPMENT',
+      'block_title_canonical: Transbordo Planejado',
+      'block_title_display: Transbordo Planejado',
+      'transshipment_mode: PLANNED',
+      'location: SINGAPORE, SG',
+      'handoff_summary: MSC MIRAYA V → SAO PAULO EXPRESS',
+      'canonical_type: TRANSSHIPMENT_INTENDED',
+      'event_time_type: EXPECTED',
+      'date: 12/03/2026',
+      'from_vessel: MSC MIRAYA V',
+      'from_voyage: OB612R',
+      'to_vessel: SAO PAULO EXPRESS',
+      'to_voyage: SPX001',
+      '- marker_kind: GAP',
+      '  label: Intervalo: 29 dias sem novos eventos',
+      '  gap_kind: GENERIC',
+      '  duration_days: 29',
+      '  from_event_type: TRANSSHIPMENT_INTENDED',
+      '  to_event_type: ARRIVAL',
+    ].join('\n'),
+  )
+  expect(output).not.toContain('block_kind: TIMELINE_MARKERS')
+})
+
+it('preserves real voyage discrepancies between block header metadata and child events without inventing a fake alignment', () => {
+  const source = makeCurrentSource(
+    makeContainer({
+      timeline: [
+        makeEvent({
+          id: 'voyage-load',
+          type: 'LOAD',
+          eventTime: '2026-03-19',
+          vesselName: 'MSC ARICA',
+          voyage: 'OB610R',
+          location: 'KARACHI-MUHAMMAD BIN QASIM, PK',
+        }),
+        makeEvent({
+          id: 'voyage-discharge',
+          type: 'DISCHARGE',
+          eventTime: '2026-03-28',
+          vesselName: 'MSC ARICA',
+          voyage: 'IV610A',
+          location: 'COLOMBO, LK',
+        }),
+      ],
+    }),
+  )
+
+  const output = serialize(source)
+
+  expect(output).toContain(
+    [
+      '## Bloco: Viagem',
+      'block_kind: VOYAGE',
+      'block_title_canonical: Viagem',
+      'block_title_display: MSC ARICA',
+      'block_badges: Atual',
+      'vessel: MSC ARICA',
+      'voyage: OB610R',
+      'route: KARACHI-MUHAMMAD BIN QASIM, PK → COLOMBO, LK',
+    ].join('\n'),
+  )
+  expect(output).toContain(
+    [
+      '- label: Descarregado do Navio',
+      '  type: DISCHARGE',
+      '  event_time_type: ACTUAL',
+      '  date: 28/03/2026',
+      '  location: COLOMBO, LK',
+      '  vessel: MSC ARICA',
+      '  voyage: IV610A',
+    ].join('\n'),
+  )
+  expect(output).not.toContain('block_kind: TIMELINE_MARKERS')
+})
+
+it('uses a readable timeline markers fallback only when markers are truly standalone', () => {
+  const source: TimelineTextExportSource = {
+    mode: 'current',
+    title: t(keys.shipmentView.timeline.title),
+    containerNumber: 'MSCU9999999',
+    statusCode: 'IN_PROGRESS',
+    statusLabel: t(trackingStatusToLabelKey(keys, 'IN_PROGRESS')),
+    eta: null,
+    currentContext: {
+      locationDisplay: null,
+      vesselName: null,
+      voyage: null,
+      vesselVisible: true,
+    },
+    transshipment: {
+      hasTransshipment: false,
+      count: 0,
+      ports: [],
+    },
+    referenceNowIso: null,
+    renderList: [
+      {
+        type: 'gap-marker',
+        marker: {
+          blockType: 'gap-marker',
+          kind: 'generic',
+          durationDays: 4,
+          fromEventType: 'GATE_IN',
+          toEventType: 'GATE_OUT',
+        },
+      },
+    ],
+  }
+
+  expect(serialize(source)).toContain(
+    [
+      '## Bloco: Marcadores',
+      'block_kind: TIMELINE_MARKERS',
+      'block_title_canonical: Marcadores',
+      'block_title_display: Marcadores',
+      '- marker_kind: GAP',
+      '  label: Intervalo: 4 dias sem novos eventos',
+    ].join('\n'),
+  )
 })

--- a/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts
+++ b/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts
@@ -10,6 +10,7 @@ import {
   toHistoricalTimelineTextExportSource,
 } from '~/modules/process/ui/screens/shipment/lib/serializeTimelineToText'
 import type { TrackingTimeTravelSyncVM } from '~/modules/process/ui/screens/shipment/types/tracking-time-travel.vm'
+import type { TimelineRenderItem } from '~/modules/process/ui/timeline/timelineBlockModel'
 import type { ContainerDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
 import type { TrackingTimelineItem } from '~/modules/tracking/features/timeline/application/projection/tracking.timeline.readmodel'
 import { createTranslationApi } from '~/shared/localization/i18n'
@@ -1049,6 +1050,120 @@ it('preserves real voyage discrepancies between block header metadata and child 
     ].join('\n'),
   )
   expect(output).not.toContain('block_kind: TIMELINE_MARKERS')
+})
+
+it('keeps the current voyage badge aligned when standalone markers appear between voyages', () => {
+  const source: TimelineTextExportSource = {
+    mode: 'current',
+    title: t(keys.shipmentView.timeline.title),
+    containerNumber: 'GLDU2928252',
+    statusCode: 'IN_TRANSIT',
+    statusLabel: t(trackingStatusToLabelKey(keys, 'IN_TRANSIT')),
+    eta: null,
+    currentContext: {
+      locationDisplay: 'SINGAPORE, SG',
+      vesselName: 'GSL VIOLETTA',
+      voyage: '2613W',
+      vesselVisible: true,
+    },
+    transshipment: {
+      hasTransshipment: false,
+      count: 0,
+      ports: [],
+    },
+    referenceNowIso: null,
+    renderList: [
+      {
+        type: 'voyage-block',
+        block: {
+          blockType: 'voyage',
+          vessel: 'MSC ARICA',
+          voyage: 'OB610R',
+          origin: 'KARACHI, PK',
+          destination: 'COLOMBO, LK',
+          events: [
+            makeEvent({
+              id: 'voyage-1-load',
+              type: 'LOAD',
+              eventTime: '2026-04-05',
+              vesselName: 'MSC ARICA',
+              voyage: 'OB610R',
+              location: 'KARACHI, PK',
+            }),
+            makeEvent({
+              id: 'voyage-1-discharge',
+              type: 'DISCHARGE',
+              eventTime: '2026-04-06',
+              vesselName: 'MSC ARICA',
+              voyage: 'OB610R',
+              location: 'COLOMBO, LK',
+            }),
+          ],
+        },
+      },
+      {
+        type: 'block-end',
+      },
+      {
+        type: 'gap-marker',
+        marker: {
+          blockType: 'gap-marker',
+          kind: 'generic',
+          durationDays: 2,
+          fromEventType: 'DISCHARGE',
+          toEventType: 'LOAD',
+        },
+      },
+      {
+        type: 'port-risk-marker',
+        marker: {
+          blockType: 'port-risk-marker',
+          durationDays: 3,
+          ongoing: false,
+          severity: 'warning',
+        },
+      },
+      {
+        type: 'voyage-block',
+        block: {
+          blockType: 'voyage',
+          vessel: 'GSL VIOLETTA',
+          voyage: '2613W',
+          origin: 'SINGAPORE, SG',
+          destination: 'SANTOS, BR',
+          events: [
+            makeEvent({
+              id: 'voyage-2-load',
+              type: 'LOAD',
+              eventTime: '2026-04-08',
+              vesselName: 'GSL VIOLETTA',
+              voyage: '2613W',
+              location: 'SINGAPORE, SG',
+            }),
+            makeEvent({
+              id: 'voyage-2-departure',
+              type: 'DEPARTURE',
+              eventTime: '2026-04-09',
+              vesselName: 'GSL VIOLETTA',
+              voyage: '2613W',
+              location: 'SINGAPORE, SG',
+            }),
+          ],
+        },
+      },
+      {
+        type: 'block-end',
+      },
+    ] satisfies readonly TimelineRenderItem[],
+  }
+
+  const output = serialize(source)
+
+  expect(output).toContain('block_title_display: GSL VIOLETTA\nblock_badges: Atual')
+  expect(output).not.toContain('block_title_display: MSC ARICA\nblock_badges: Atual')
+  expect(output).toContain('block_kind: TIMELINE_MARKERS')
+  expect(output).toContain('label: Intervalo: 2 dias sem novos eventos')
+  expect(output).toContain('label: No porto por 3 dias')
 })
 
 it('uses a readable timeline markers fallback only when markers are truly standalone', () => {

--- a/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts
+++ b/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts
@@ -1,6 +1,10 @@
 import { resolveTimelineEventLabel } from '~/modules/process/ui/mappers/trackingEventLabel.ui-mapper'
 import type { TrackingTimeTravelSyncVM } from '~/modules/process/ui/screens/shipment/types/tracking-time-travel.vm'
 import {
+  resolveCurrentVoyageIndex,
+  toCurrentVoyageGroups,
+} from '~/modules/process/ui/timeline/currentVoyage'
+import {
   buildTimelineRenderList,
   type PlannedTransshipmentBlock,
   type TerminalBlock,
@@ -8,6 +12,22 @@ import {
   type TransshipmentBlock,
   type VoyageBlock,
 } from '~/modules/process/ui/timeline/timelineBlockModel'
+import {
+  toPlannedTransshipmentBlockCanonicalTitle,
+  toPlannedTransshipmentBlockDisplayTitle,
+  toPlannedTransshipmentHandoffSummary,
+  toTerminalBlockCanonicalTitle,
+  toTerminalBlockDisplayTitle,
+  toTimelineEventsBlockTitle,
+  toTimelineMarkersBlockTitle,
+  toTransshipmentBlockCanonicalTitle,
+  toTransshipmentBlockDisplayTitle,
+  toTransshipmentHandoffSummary,
+  toVoyageBlockBadges,
+  toVoyageBlockCanonicalTitle,
+  toVoyageBlockDisplayTitle,
+  toVoyageBlockRoute,
+} from '~/modules/process/ui/timeline/timelineBlockPresentation'
 import type { ContainerDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
 import type { TranslationKeys } from '~/shared/localization/translationTypes'
 import { systemClock } from '~/shared/time/clock'
@@ -146,6 +166,25 @@ function pushKeyValue(lines: string[], key: string, value: string | null): void 
   lines.push(`${key}: ${value}`)
 }
 
+function pushBlockHeader(
+  lines: string[],
+  command: {
+    readonly kind: string
+    readonly canonicalTitle: string
+    readonly displayTitle: string
+    readonly badges?: readonly string[]
+  },
+): void {
+  pushLine(lines, `## Bloco: ${command.canonicalTitle}`)
+  pushLine(lines, `block_kind: ${command.kind}`)
+  pushLine(lines, `block_title_canonical: ${command.canonicalTitle}`)
+  pushLine(lines, `block_title_display: ${command.displayTitle}`)
+
+  if ((command.badges?.length ?? 0) > 0) {
+    pushLine(lines, `block_badges: ${command.badges?.join(' | ') ?? ''}`)
+  }
+}
+
 function toTerminalBlockKind(block: TerminalBlock): string {
   switch (block.kind) {
     case 'pre-carriage':
@@ -154,20 +193,6 @@ function toTerminalBlockKind(block: TerminalBlock): string {
       return 'TRANSSHIPMENT_TERMINAL'
     case 'post-carriage':
       return 'POST_CARRIAGE'
-  }
-}
-
-function toTerminalBlockTitle(
-  block: TerminalBlock,
-  dependencies: TimelineTextExportDependencies,
-): string {
-  switch (block.kind) {
-    case 'pre-carriage':
-      return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.preCarriage)
-    case 'transshipment-terminal':
-      return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.transshipmentTerminal)
-    case 'post-carriage':
-      return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.postCarriage)
   }
 }
 
@@ -198,37 +223,6 @@ function toMarkerLabel(
     : dependencies.t(dependencies.keys.shipmentView.timeline.blocks.portRiskShort, {
         days: item.marker.durationDays,
       })
-}
-
-function toRoute(block: VoyageBlock, dependencies: TimelineTextExportDependencies): string | null {
-  if (block.origin === null && block.destination === null) {
-    return null
-  }
-
-  return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.voyageRoute, {
-    origin: block.origin ?? '?',
-    destination: block.destination ?? '?',
-  })
-}
-
-function toHandoffSummary(
-  block: TransshipmentBlock,
-  dependencies: TimelineTextExportDependencies,
-): string | null {
-  if (block.handoffDisplayMode === 'FULL') {
-    return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.vesselChangeDetail, {
-      from: block.previousVesselName ?? '?',
-      to: block.nextVesselName ?? '?',
-    })
-  }
-
-  if (block.handoffDisplayMode === 'NEXT_ONLY' && block.nextVesselName !== null) {
-    return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.vesselChangeNextOnly, {
-      to: block.nextVesselName,
-    })
-  }
-
-  return null
 }
 
 function toIntermediatePorts(source: TimelineTextExportSource): string | null {
@@ -297,7 +291,14 @@ function serializeBlockChildren(
 
   while (index < renderList.length) {
     const child = renderList[index]
-    if (child === undefined || child.type === 'block-end') {
+    if (
+      child === undefined ||
+      child.type === 'block-end' ||
+      child.type === 'voyage-block' ||
+      child.type === 'terminal-block' ||
+      child.type === 'transshipment-block' ||
+      child.type === 'planned-transshipment-block'
+    ) {
       break
     }
 
@@ -313,23 +314,111 @@ function serializeBlockChildren(
   return renderList[index]?.type === 'block-end' ? index + 1 : index
 }
 
+function serializeInlineMarkerChildren(
+  lines: string[],
+  renderList: readonly TimelineRenderItem[],
+  startIndex: number,
+  dependencies: TimelineTextExportDependencies,
+): number {
+  let index = startIndex
+
+  while (index < renderList.length) {
+    const child = renderList[index]
+    if (child === undefined || (child.type !== 'gap-marker' && child.type !== 'port-risk-marker')) {
+      break
+    }
+
+    serializeMarker(lines, child, dependencies)
+    index += 1
+  }
+
+  return index
+}
+
+function serializeStandaloneItems(
+  lines: string[],
+  renderList: readonly TimelineRenderItem[],
+  startIndex: number,
+  dependencies: TimelineTextExportDependencies,
+): number {
+  const firstItem = renderList[startIndex]
+  if (firstItem === undefined) {
+    return startIndex
+  }
+
+  if (firstItem.type === 'gap-marker' || firstItem.type === 'port-risk-marker') {
+    const title = toTimelineMarkersBlockTitle(dependencies)
+    pushBlockHeader(lines, {
+      kind: 'TIMELINE_MARKERS',
+      canonicalTitle: title,
+      displayTitle: title,
+    })
+
+    let index = startIndex
+    while (index < renderList.length) {
+      const child = renderList[index]
+      if (
+        child === undefined ||
+        (child.type !== 'gap-marker' && child.type !== 'port-risk-marker')
+      ) {
+        break
+      }
+
+      serializeMarker(lines, child, dependencies)
+      index += 1
+    }
+
+    return index
+  }
+
+  const title = toTimelineEventsBlockTitle(dependencies)
+  pushBlockHeader(lines, {
+    kind: 'TIMELINE_EVENTS',
+    canonicalTitle: title,
+    displayTitle: title,
+  })
+
+  let index = startIndex
+  while (index < renderList.length) {
+    const child = renderList[index]
+    if (
+      child === undefined ||
+      child.type === 'block-end' ||
+      child.type === 'voyage-block' ||
+      child.type === 'terminal-block' ||
+      child.type === 'transshipment-block' ||
+      child.type === 'planned-transshipment-block'
+    ) {
+      break
+    }
+
+    if (child.type === 'event') {
+      serializeEvent(lines, child, dependencies)
+    } else if (child.type === 'gap-marker' || child.type === 'port-risk-marker') {
+      serializeMarker(lines, child, dependencies)
+    }
+
+    index += 1
+  }
+
+  return index
+}
+
 function serializeVoyageBlock(
   lines: string[],
   block: VoyageBlock,
   dependencies: TimelineTextExportDependencies,
+  options?: { readonly isCurrent?: boolean },
 ): void {
-  pushLine(
-    lines,
-    `## Bloco: ${dependencies.t(dependencies.keys.shipmentView.timeline.blocks.voyage)}`,
-  )
-  pushLine(lines, 'block_kind: VOYAGE')
-  pushLine(
-    lines,
-    `block_title: ${dependencies.t(dependencies.keys.shipmentView.timeline.blocks.voyage)}`,
-  )
+  pushBlockHeader(lines, {
+    kind: 'VOYAGE',
+    canonicalTitle: toVoyageBlockCanonicalTitle(dependencies),
+    displayTitle: toVoyageBlockDisplayTitle(block, dependencies),
+    badges: toVoyageBlockBadges(dependencies, options),
+  })
   pushKeyValue(lines, 'vessel', block.vessel)
   pushKeyValue(lines, 'voyage', block.voyage)
-  pushKeyValue(lines, 'route', toRoute(block, dependencies))
+  pushKeyValue(lines, 'route', toVoyageBlockRoute(block, dependencies))
 }
 
 function serializeTerminalBlock(
@@ -337,9 +426,11 @@ function serializeTerminalBlock(
   block: TerminalBlock,
   dependencies: TimelineTextExportDependencies,
 ): void {
-  pushLine(lines, `## Bloco: ${toTerminalBlockTitle(block, dependencies)}`)
-  pushLine(lines, `block_kind: ${toTerminalBlockKind(block)}`)
-  pushLine(lines, `block_title: ${toTerminalBlockTitle(block, dependencies)}`)
+  pushBlockHeader(lines, {
+    kind: toTerminalBlockKind(block),
+    canonicalTitle: toTerminalBlockCanonicalTitle(block, dependencies),
+    displayTitle: toTerminalBlockDisplayTitle(block, dependencies),
+  })
   pushKeyValue(lines, 'location', block.location)
 }
 
@@ -349,19 +440,16 @@ function serializeTransshipmentBlock(
   dependencies: TimelineTextExportDependencies,
 ): void {
   const isPlanned = block.mode === 'planned'
-  const title = dependencies.t(
-    isPlanned
-      ? dependencies.keys.shipmentView.timeline.blocks.plannedTransshipment
-      : dependencies.keys.shipmentView.timeline.blocks.transshipment,
-  )
   const representativeEvent = block.events[block.events.length - 1] ?? null
 
-  pushLine(lines, `## Bloco: ${title}`)
-  pushLine(lines, `block_kind: ${isPlanned ? 'PLANNED_TRANSSHIPMENT' : 'TRANSSHIPMENT'}`)
-  pushLine(lines, `block_title: ${title}`)
+  pushBlockHeader(lines, {
+    kind: isPlanned ? 'PLANNED_TRANSSHIPMENT' : 'TRANSSHIPMENT',
+    canonicalTitle: toTransshipmentBlockCanonicalTitle(block, dependencies),
+    displayTitle: toTransshipmentBlockDisplayTitle(block, dependencies),
+  })
   pushLine(lines, `transshipment_mode: ${block.mode.toUpperCase()}`)
   pushKeyValue(lines, 'location', block.port)
-  pushKeyValue(lines, 'handoff_summary', toHandoffSummary(block, dependencies))
+  pushKeyValue(lines, 'handoff_summary', toTransshipmentHandoffSummary(block, dependencies))
   pushKeyValue(lines, 'reason', block.reason)
   if (isPlanned && representativeEvent !== null) {
     pushLine(lines, `canonical_type: ${representativeEvent.type}`)
@@ -385,26 +473,13 @@ function serializePlannedTransshipmentBlock(
   block: PlannedTransshipmentBlock,
   dependencies: TimelineTextExportDependencies,
 ): void {
-  pushLine(
-    lines,
-    `## Bloco: ${dependencies.t(dependencies.keys.shipmentView.timeline.blocks.plannedTransshipment)}`,
-  )
-  pushLine(lines, 'block_kind: PLANNED_TRANSSHIPMENT')
-  pushLine(
-    lines,
-    `block_title: ${dependencies.t(dependencies.keys.shipmentView.timeline.blocks.plannedTransshipment)}`,
-  )
+  pushBlockHeader(lines, {
+    kind: 'PLANNED_TRANSSHIPMENT',
+    canonicalTitle: toPlannedTransshipmentBlockCanonicalTitle(dependencies),
+    displayTitle: toPlannedTransshipmentBlockDisplayTitle(dependencies),
+  })
   pushKeyValue(lines, 'location', block.port)
-  pushKeyValue(
-    lines,
-    'handoff_summary',
-    block.fromVessel === null && block.toVessel === null
-      ? null
-      : dependencies.t(dependencies.keys.shipmentView.timeline.blocks.vesselChangeDetail, {
-          from: block.fromVessel ?? '?',
-          to: block.toVessel ?? '?',
-        }),
-  )
+  pushKeyValue(lines, 'handoff_summary', toPlannedTransshipmentHandoffSummary(block, dependencies))
   pushLine(lines, `canonical_type: ${block.event.type}`)
   pushLine(lines, `event_time_type: ${block.event.eventTimeType}`)
   pushKeyValue(
@@ -448,6 +523,8 @@ export function serializeTimelineToText(
     pushLine(lines, '')
   }
 
+  const currentVoyageIndex = resolveCurrentVoyageIndex(toCurrentVoyageGroups(source.renderList))
+  let groupIndex = 0
   let index = 0
   while (index < source.renderList.length) {
     const item = source.renderList[index]
@@ -457,38 +534,36 @@ export function serializeTimelineToText(
 
     switch (item.type) {
       case 'voyage-block':
-        serializeVoyageBlock(lines, item.block, dependencies)
+        serializeVoyageBlock(lines, item.block, dependencies, {
+          isCurrent: groupIndex === currentVoyageIndex,
+        })
         index = serializeBlockChildren(lines, source.renderList, index + 1, dependencies)
+        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'terminal-block':
         serializeTerminalBlock(lines, item.block, dependencies)
         index = serializeBlockChildren(lines, source.renderList, index + 1, dependencies)
+        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'transshipment-block':
         serializeTransshipmentBlock(lines, item.block, dependencies)
-        index += 1
+        index = serializeInlineMarkerChildren(lines, source.renderList, index + 1, dependencies)
+        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'planned-transshipment-block':
         serializePlannedTransshipmentBlock(lines, item.block, dependencies)
-        index += 1
+        index = serializeInlineMarkerChildren(lines, source.renderList, index + 1, dependencies)
+        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'event':
-        pushLine(lines, '## Bloco: Eventos')
-        pushLine(lines, 'block_kind: STANDALONE_EVENTS')
-        serializeEvent(lines, item, dependencies)
-        index += 1
-        pushLine(lines, '')
-        continue
       case 'gap-marker':
       case 'port-risk-marker':
-        pushLine(lines, '## Bloco: Marcadores')
-        pushLine(lines, 'block_kind: STANDALONE_MARKERS')
-        serializeMarker(lines, item, dependencies)
-        index += 1
+        index = serializeStandaloneItems(lines, source.renderList, index, dependencies)
+        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'block-end':

--- a/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts
+++ b/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts
@@ -404,6 +404,56 @@ function serializeStandaloneItems(
   return index
 }
 
+function buildRenderIndexToCurrentVoyageGroupIndex(
+  renderList: readonly TimelineRenderItem[],
+): ReadonlyMap<number, number> {
+  const groupIndexByRenderIndex = new Map<number, number>()
+  let groupIndex = 0
+  let index = 0
+
+  while (index < renderList.length) {
+    const item = renderList[index]
+    if (item === undefined) {
+      break
+    }
+
+    if (item.type === 'block-end') {
+      index += 1
+      continue
+    }
+
+    groupIndexByRenderIndex.set(index, groupIndex)
+
+    if (item.type === 'voyage-block' || item.type === 'terminal-block') {
+      groupIndex += 1
+      index += 1
+      while (index < renderList.length) {
+        const child = renderList[index]
+        if (
+          child === undefined ||
+          child.type === 'block-end' ||
+          child.type === 'voyage-block' ||
+          child.type === 'terminal-block' ||
+          child.type === 'transshipment-block' ||
+          child.type === 'planned-transshipment-block'
+        ) {
+          break
+        }
+        index += 1
+      }
+      if (renderList[index]?.type === 'block-end') {
+        index += 1
+      }
+      continue
+    }
+
+    groupIndex += 1
+    index += 1
+  }
+
+  return groupIndexByRenderIndex
+}
+
 function serializeVoyageBlock(
   lines: string[],
   block: VoyageBlock,
@@ -524,7 +574,7 @@ export function serializeTimelineToText(
   }
 
   const currentVoyageIndex = resolveCurrentVoyageIndex(toCurrentVoyageGroups(source.renderList))
-  let groupIndex = 0
+  const groupIndexByRenderIndex = buildRenderIndexToCurrentVoyageGroupIndex(source.renderList)
   let index = 0
   while (index < source.renderList.length) {
     const item = source.renderList[index]
@@ -535,35 +585,30 @@ export function serializeTimelineToText(
     switch (item.type) {
       case 'voyage-block':
         serializeVoyageBlock(lines, item.block, dependencies, {
-          isCurrent: groupIndex === currentVoyageIndex,
+          isCurrent: groupIndexByRenderIndex.get(index) === currentVoyageIndex,
         })
         index = serializeBlockChildren(lines, source.renderList, index + 1, dependencies)
-        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'terminal-block':
         serializeTerminalBlock(lines, item.block, dependencies)
         index = serializeBlockChildren(lines, source.renderList, index + 1, dependencies)
-        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'transshipment-block':
         serializeTransshipmentBlock(lines, item.block, dependencies)
         index = serializeInlineMarkerChildren(lines, source.renderList, index + 1, dependencies)
-        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'planned-transshipment-block':
         serializePlannedTransshipmentBlock(lines, item.block, dependencies)
         index = serializeInlineMarkerChildren(lines, source.renderList, index + 1, dependencies)
-        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'event':
       case 'gap-marker':
       case 'port-risk-marker':
         index = serializeStandaloneItems(lines, source.renderList, index, dependencies)
-        groupIndex += 1
         pushLine(lines, '')
         continue
       case 'block-end':

--- a/src/modules/process/ui/timeline/TimelineBlocks.tsx
+++ b/src/modules/process/ui/timeline/TimelineBlocks.tsx
@@ -11,6 +11,15 @@ import type {
   TransshipmentBlock,
   VoyageBlock,
 } from '~/modules/process/ui/timeline/timelineBlockModel'
+import {
+  toPlannedTransshipmentBlockCanonicalTitle,
+  toPlannedTransshipmentHandoffSummary,
+  toTerminalBlockDisplayTitle,
+  toTransshipmentBlockCanonicalTitle,
+  toTransshipmentHandoffSummary,
+  toVoyageBlockDisplayTitle,
+  toVoyageBlockRoute,
+} from '~/modules/process/ui/timeline/timelineBlockPresentation'
 import type { ContainerObservationVM } from '~/modules/process/ui/viewmodels/shipment.vm'
 import type { TrackingTimelineItem } from '~/modules/tracking/features/timeline/application/projection/tracking.timeline.readmodel'
 import { useTranslation } from '~/shared/localization/i18n'
@@ -27,60 +36,11 @@ export function VoyageBlockHeader(props: {
   readonly isCurrent?: boolean
 }): JSX.Element {
   const { t, keys } = useTranslation()
-
-  const route = () => {
-    const b = props.block
-    let origin = b.origin
-    let destination = b.destination
-
-    if (!origin) {
-      for (const ev of b.events) {
-        if (ev.location && (ev.type === 'LOAD' || ev.type === 'DEPARTURE')) {
-          origin = ev.location
-          break
-        }
-      }
-    }
-
-    if (!destination) {
-      for (let i = b.events.length - 1; i >= 0; i--) {
-        const ev = b.events[i]
-        if (!ev) continue
-        if (ev.type === 'ARRIVAL' && ev.eventTimeType === 'EXPECTED' && ev.location) {
-          destination = ev.location
-          break
-        }
-      }
-    }
-
-    if (!destination) {
-      for (let i = b.events.length - 1; i >= 0; i--) {
-        const ev = b.events[i]
-        if (!ev) continue
-        if (ev.type === 'DISCHARGE' && ev.eventTimeType === 'EXPECTED' && ev.location) {
-          destination = ev.location
-          break
-        }
-      }
-    }
-
-    if (!destination) {
-      for (let i = b.events.length - 1; i >= 0; i--) {
-        const ev = b.events[i]
-        if (!ev) continue
-        if (ev.location && (ev.type === 'ARRIVAL' || ev.type === 'DISCHARGE')) {
-          destination = ev.location
-          break
-        }
-      }
-    }
-
-    if (!origin && !destination) return null
-    return t(keys.shipmentView.timeline.blocks.voyageRoute, {
-      origin: origin ?? '?',
-      destination: destination ?? '?',
-    })
-  }
+  const presentation = {
+    t,
+    keys,
+  } as const
+  const route = () => toVoyageBlockRoute(props.block, presentation)
 
   return (
     <div class="rounded-t-xl border-b border-border/70 bg-surface-muted px-3 py-2.5">
@@ -88,7 +48,7 @@ export function VoyageBlockHeader(props: {
         {/* Ship icon */}
         <Ship class="w-4 h-4 shrink-0 opacity-70" aria-hidden="true" />
         <span class="text-sm-ui font-bold text-foreground tracking-tight">
-          {props.block.vessel ?? t(keys.shipmentView.timeline.blocks.voyage)}
+          {toVoyageBlockDisplayTitle(props.block, presentation)}
         </span>
         <Show when={props.isCurrent}>
           <span class="inline-flex items-center rounded-full bg-tone-info-bg px-1.5 py-px text-micro font-bold uppercase tracking-wider text-tone-info-fg ring-1 ring-tone-info-border">
@@ -122,19 +82,7 @@ export function VoyageBlockHeader(props: {
 
 export function TerminalBlockHeader(props: { readonly block: TerminalBlock }): JSX.Element {
   const { t, keys } = useTranslation()
-
-  const title = () => {
-    switch (props.block.kind) {
-      case 'pre-carriage':
-        return t(keys.shipmentView.timeline.blocks.preCarriage)
-      case 'transshipment-terminal':
-        return t(keys.shipmentView.timeline.blocks.transshipmentTerminal)
-      case 'post-carriage':
-        return t(keys.shipmentView.timeline.blocks.postCarriage)
-      default:
-        return t(keys.shipmentView.timeline.blocks.terminalInland)
-    }
-  }
+  const title = () => toTerminalBlockDisplayTitle(props.block, { t, keys })
 
   const Icon = () => (
     <Switch fallback={<Construction class="w-4 h-4 shrink-0" aria-hidden="true" />}>
@@ -227,20 +175,7 @@ function transshipmentHandoffLabel(
   translate: ReturnType<typeof useTranslation>['t'],
   keys: ReturnType<typeof useTranslation>['keys'],
 ): string | null {
-  if (block.handoffDisplayMode === 'FULL') {
-    return translate(keys.shipmentView.timeline.blocks.vesselChangeDetail, {
-      from: block.previousVesselName ?? '?',
-      to: block.nextVesselName ?? '?',
-    })
-  }
-
-  if (block.handoffDisplayMode === 'NEXT_ONLY' && block.nextVesselName !== null) {
-    return translate(keys.shipmentView.timeline.blocks.vesselChangeNextOnly, {
-      to: block.nextVesselName,
-    })
-  }
-
-  return null
+  return toTransshipmentHandoffSummary(block, { t: translate, keys })
 }
 
 function PlannedTransshipmentHandoffCard(props: TransshipmentBlockCardProps): JSX.Element {
@@ -316,7 +251,7 @@ function PlannedTransshipmentHandoffCard(props: TransshipmentBlockCardProps): JS
             <div class="flex flex-wrap items-center gap-1.5">
               <Repeat class="w-4 h-4 shrink-0 text-tone-warning-fg" aria-hidden="true" />
               <span class="text-sm-ui font-semibold text-foreground tracking-tight">
-                {t(keys.shipmentView.timeline.blocks.plannedTransshipment)}
+                {toTransshipmentBlockCanonicalTitle(props.block, { t, keys })}
               </span>
               <Show when={canOpenObservation()}>
                 <ObservationButton
@@ -390,7 +325,7 @@ function ConfirmedTransshipmentBlockCard(props: TransshipmentBlockCardProps): JS
       <div class="flex items-center gap-1.5">
         <Repeat class="w-4 h-4 shrink-0" aria-hidden="true" />
         <span class="text-sm-ui font-bold text-tone-warning-fg tracking-tight">
-          {t(keys.shipmentView.timeline.blocks.transshipment)}
+          {toTransshipmentBlockCanonicalTitle(props.block, { t, keys })}
         </span>
       </div>
       <Show when={props.block.port}>
@@ -416,17 +351,7 @@ export function PlannedTransshipmentBlockCard(props: {
   readonly block: PlannedTransshipmentBlock
 }): JSX.Element {
   const { t, keys, locale } = useTranslation()
-
-  const handoffSummary = () => {
-    if (!props.block.fromVessel && !props.block.toVessel) {
-      return null
-    }
-
-    return t(keys.shipmentView.timeline.blocks.vesselChangeDetail, {
-      from: props.block.fromVessel ?? '?',
-      to: props.block.toVessel ?? '?',
-    })
-  }
+  const handoffSummary = () => toPlannedTransshipmentHandoffSummary(props.block, { t, keys })
 
   const nextLeg = () => {
     const details = [props.block.toVessel, props.block.toVoyage].filter((value): value is string =>
@@ -446,7 +371,7 @@ export function PlannedTransshipmentBlockCard(props: {
       <div class="flex items-center gap-1.5">
         <Hourglass class="h-4 w-4 shrink-0" aria-hidden="true" />
         <span class="text-sm-ui font-bold tracking-tight text-tone-info-fg">
-          {t(keys.shipmentView.timeline.blocks.plannedTransshipment)}
+          {toPlannedTransshipmentBlockCanonicalTitle({ t, keys })}
         </span>
       </div>
       <Show when={props.block.port}>

--- a/src/modules/process/ui/timeline/timelineBlockPresentation.ts
+++ b/src/modules/process/ui/timeline/timelineBlockPresentation.ts
@@ -1,0 +1,209 @@
+import type {
+  PlannedTransshipmentBlock,
+  TerminalBlock,
+  TransshipmentBlock,
+  VoyageBlock,
+} from '~/modules/process/ui/timeline/timelineBlockModel'
+import type { TranslationKeys } from '~/shared/localization/translationTypes'
+
+type TranslateFn = (key: string, params?: Readonly<Record<string, unknown>>) => string
+
+export type TimelineBlockPresentationDependencies = {
+  readonly t: TranslateFn
+  readonly keys: TranslationKeys
+}
+
+function toVoyageCanonicalTitle(dependencies: TimelineBlockPresentationDependencies): string {
+  return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.voyage)
+}
+
+export function toVoyageBlockDisplayTitle(
+  block: VoyageBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return block.vessel ?? toVoyageCanonicalTitle(dependencies)
+}
+
+export function toVoyageBlockRoute(
+  block: VoyageBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string | null {
+  let origin = block.origin
+  let destination = block.destination
+
+  if (!origin) {
+    for (const event of block.events) {
+      if (event.location && (event.type === 'LOAD' || event.type === 'DEPARTURE')) {
+        origin = event.location
+        break
+      }
+    }
+  }
+
+  if (!destination) {
+    for (let index = block.events.length - 1; index >= 0; index--) {
+      const event = block.events[index]
+      if (event === undefined) continue
+
+      if (event.type === 'ARRIVAL' && event.eventTimeType === 'EXPECTED' && event.location) {
+        destination = event.location
+        break
+      }
+    }
+  }
+
+  if (!destination) {
+    for (let index = block.events.length - 1; index >= 0; index--) {
+      const event = block.events[index]
+      if (event === undefined) continue
+
+      if (event.type === 'DISCHARGE' && event.eventTimeType === 'EXPECTED' && event.location) {
+        destination = event.location
+        break
+      }
+    }
+  }
+
+  if (!destination) {
+    for (let index = block.events.length - 1; index >= 0; index--) {
+      const event = block.events[index]
+      if (event === undefined) continue
+
+      if (event.location && (event.type === 'ARRIVAL' || event.type === 'DISCHARGE')) {
+        destination = event.location
+        break
+      }
+    }
+  }
+
+  if (!origin && !destination) {
+    return null
+  }
+
+  return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.voyageRoute, {
+    origin: origin ?? '?',
+    destination: destination ?? '?',
+  })
+}
+
+export function toVoyageBlockBadges(
+  dependencies: TimelineBlockPresentationDependencies,
+  options?: { readonly isCurrent?: boolean },
+): readonly string[] {
+  if (options?.isCurrent !== true) {
+    return []
+  }
+
+  return [dependencies.t(dependencies.keys.shipmentView.timeline.blocks.currentLeg)]
+}
+
+export function toVoyageBlockCanonicalTitle(
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return toVoyageCanonicalTitle(dependencies)
+}
+
+export function toTerminalBlockCanonicalTitle(
+  block: TerminalBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  switch (block.kind) {
+    case 'pre-carriage':
+      return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.preCarriage)
+    case 'transshipment-terminal':
+      return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.transshipmentTerminal)
+    case 'post-carriage':
+      return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.postCarriage)
+  }
+}
+
+export function toTerminalBlockDisplayTitle(
+  block: TerminalBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return toTerminalBlockCanonicalTitle(block, dependencies)
+}
+
+function toVesselHandoffSummary(
+  fromVessel: string | null,
+  toVessel: string | null,
+  dependencies: TimelineBlockPresentationDependencies,
+): string | null {
+  if (fromVessel === null && toVessel === null) {
+    return null
+  }
+
+  return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.vesselChangeDetail, {
+    from: fromVessel ?? '?',
+    to: toVessel ?? '?',
+  })
+}
+
+export function toTransshipmentBlockCanonicalTitle(
+  block: TransshipmentBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return dependencies.t(
+    block.mode === 'planned'
+      ? dependencies.keys.shipmentView.timeline.blocks.plannedTransshipment
+      : dependencies.keys.shipmentView.timeline.blocks.transshipment,
+  )
+}
+
+export function toTransshipmentBlockDisplayTitle(
+  block: TransshipmentBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return toTransshipmentBlockCanonicalTitle(block, dependencies)
+}
+
+export function toTransshipmentHandoffSummary(
+  block: TransshipmentBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string | null {
+  if (block.handoffDisplayMode === 'FULL') {
+    return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.vesselChangeDetail, {
+      from: block.previousVesselName ?? '?',
+      to: block.nextVesselName ?? '?',
+    })
+  }
+
+  if (block.handoffDisplayMode === 'NEXT_ONLY' && block.nextVesselName !== null) {
+    return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.vesselChangeNextOnly, {
+      to: block.nextVesselName,
+    })
+  }
+
+  return null
+}
+
+export function toPlannedTransshipmentBlockCanonicalTitle(
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.plannedTransshipment)
+}
+
+export function toPlannedTransshipmentBlockDisplayTitle(
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return toPlannedTransshipmentBlockCanonicalTitle(dependencies)
+}
+
+export function toPlannedTransshipmentHandoffSummary(
+  block: PlannedTransshipmentBlock,
+  dependencies: TimelineBlockPresentationDependencies,
+): string | null {
+  return toVesselHandoffSummary(block.fromVessel, block.toVessel, dependencies)
+}
+
+export function toTimelineMarkersBlockTitle(
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.markers)
+}
+
+export function toTimelineEventsBlockTitle(
+  dependencies: TimelineBlockPresentationDependencies,
+): string {
+  return dependencies.t(dependencies.keys.shipmentView.timeline.blocks.events)
+}


### PR DESCRIPTION
This pull request refactors and enhances the timeline serialization logic for shipment blocks, focusing on improving the clarity and structure of exported timeline text. The changes introduce new helper functions for generating block titles and headers, unify block header formatting, and ensure that markers and events are grouped and displayed more accurately. Additionally, the test suite is expanded to cover new behaviors and edge cases.

**Improvements to timeline block serialization and presentation:**

* Introduced new helper functions from `timelineBlockPresentation` to generate canonical and display titles, badges, routes, and handoff summaries for all block types, replacing inline logic and simplifying the main serialization flow. (`src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts`, [src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.tsR15-R30](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dR15-R30))
* Added a `pushBlockHeader` function to standardize block header output, now used by all block serializers to ensure consistent formatting for block kind, canonical title, display title, and badges. (`src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts`, [[1]](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dR169-R187) [[2]](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dR317-R433)
* Refactored block serialization functions (voyage, terminal, transshipment, planned transshipment) to use the new presentation helpers and header function, removing duplicated and inline title/route logic. (`src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts`, [[1]](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dL160-L173) [[2]](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dL203-L233) [[3]](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dR317-R433)

**Better handling and grouping of timeline markers and events:**

* Added logic to group standalone markers into a dedicated "Marcadores" block, and to inline planned-block markers under their associated planned transshipment block, preventing emission of unnecessary standalone marker blocks. (`src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.ts`, [[1]](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dR317-R433) [[2]](diffhunk://#diff-7236ebaf045b5c7e27f89971a00fc2caea890c67e1143025d0eedc3b9314c65dL300-R301)
* Updated test cases and added new tests to verify correct grouping of markers, preservation of voyage discrepancies, and fallback behavior for standalone markers. (`src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts`, [src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.tsR908-R1098](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbR908-R1098))

**Localization and test data updates:**

* Added new keys for "Eventos" and "Marcadores" to the Portuguese locale for use in block titles. (`src/locales/pt-BR.json`, [src/locales/pt-BR.jsonR448-R449](diffhunk://#diff-8f3a0cf8394e26b3755643fc71adc9d48caffe815b748da3cc521976bb524f7cR448-R449))
* Updated test snapshots and assertions to match the new block header structure and marker grouping logic, ensuring test coverage for all new behaviors. (`src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts`, [[1]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL277-R278) [[2]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL287-R290) [[3]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL387-R391) [[4]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL408-R413) [[5]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL420-R426) [[6]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL430-R438) [[7]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL522-R531) [[8]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL585-R595) [[9]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL707-R726) [[10]](diffhunk://#diff-0e4a2d8b8bbef3eda96e77a7236c57e3fbcb5663bc9bfbc2974234e32c5099bbL818-R833)

These changes make the timeline export logic more maintainable, ensure a clearer and more consistent user-facing export format, and improve test reliability and coverage.