### PR TITLE
Add container current-status action menu for time travel

### DIFF
--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -382,7 +382,10 @@
       "lastUpdate": "Última atualização",
       "noContainer": "Selecione um container para visualizar o status.",
       "unknown": "—",
-      "vesselNotApplicable": "Já descarregado"
+      "vesselNotApplicable": "Já descarregado",
+      "actions": {
+        "openMenu": "Abrir ações do container"
+      }
     },
     "containerSummary": {
       "moreContainers": "+{{count}} containers neste processo",

--- a/src/modules/process/ui/components/ShipmentCurrentStatus.tsx
+++ b/src/modules/process/ui/components/ShipmentCurrentStatus.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'solid-js'
 import { Show } from 'solid-js'
+import { ShipmentCurrentStatusActionMenu } from '~/modules/process/ui/components/ShipmentCurrentStatusActionMenu'
 import { ShipmentCurrentStatusDetails } from '~/modules/process/ui/components/ShipmentCurrentStatusDetails'
 import type { ContainerDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
 import { useTranslation } from '~/shared/localization/i18n'
@@ -9,16 +10,22 @@ import { Panel } from '~/shared/ui/layout/Panel'
 type Props = {
   readonly selectedContainer: ContainerDetailVM | null
   readonly syncNow: Instant
+  readonly onOpenTimeTravel: () => void
 }
 
 export function ShipmentCurrentStatus(props: Props): JSX.Element {
   const { t, keys } = useTranslation()
+  const headerSlot = () => {
+    if (!props.selectedContainer) return undefined
+    return <ShipmentCurrentStatusActionMenu onOpenTimeTravel={props.onOpenTimeTravel} />
+  }
 
   return (
     <Panel
       title={t(keys.shipmentView.currentStatus.title)}
       class="rounded-xl"
       bodyClass="px-5 py-4"
+      headerSlot={headerSlot()}
     >
       <Show
         when={props.selectedContainer}

--- a/src/modules/process/ui/components/ShipmentCurrentStatusActionMenu.tsx
+++ b/src/modules/process/ui/components/ShipmentCurrentStatusActionMenu.tsx
@@ -1,0 +1,120 @@
+import { Clock3, MoreVertical } from 'lucide-solid'
+import { createSignal, type JSX, onCleanup, onMount } from 'solid-js'
+import { useTranslation } from '~/shared/localization/i18n'
+
+type ShipmentCurrentStatusActionMenuProps = {
+  readonly onOpenTimeTravel: () => void
+}
+
+const TRIGGER_CLASS =
+  'inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-surface text-text-muted transition-colors hover:border-border-strong hover:bg-surface-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
+
+const ITEM_CLASS =
+  'flex w-full items-center gap-2 px-3 py-2 text-left text-xs-ui font-medium text-foreground transition-colors hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
+
+export function ShipmentCurrentStatusActionMenu(
+  props: ShipmentCurrentStatusActionMenuProps,
+): JSX.Element {
+  const { t, keys } = useTranslation()
+  const [isOpen, setIsOpen] = createSignal(false)
+  let menuRef: HTMLDetailsElement | undefined
+  let triggerRef: HTMLElement | undefined
+
+  const closeMenu = (shouldRestoreFocus: boolean): void => {
+    if (menuRef) {
+      menuRef.open = false
+    } else {
+      setIsOpen(false)
+    }
+
+    if (shouldRestoreFocus) {
+      triggerRef?.focus()
+    }
+  }
+
+  const handleOpenTimeTravel = (): void => {
+    closeMenu(false)
+    props.onOpenTimeTravel()
+  }
+
+  onMount(() => {
+    const onDocumentClick: EventListener = (event) => {
+      if (!menuRef?.open) return
+      const target = event.target
+      if (target instanceof Node && menuRef.contains(target)) return
+      closeMenu(false)
+    }
+
+    const onEscape = (event: KeyboardEvent) => {
+      if (!menuRef?.open) return
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      closeMenu(true)
+    }
+
+    const onOtherOpened: EventListener = (event) => {
+      if (!menuRef) return
+      if (!(event instanceof CustomEvent)) return
+      if (event.detail !== menuRef) {
+        closeMenu(false)
+      }
+    }
+
+    const onToggle: EventListener = () => {
+      if (!menuRef) return
+      setIsOpen(menuRef.open)
+      if (menuRef.open) {
+        window.dispatchEvent(new CustomEvent('unified-dropdown-opened', { detail: menuRef }))
+      }
+    }
+
+    document.addEventListener('click', onDocumentClick)
+    document.addEventListener('keydown', onEscape)
+    window.addEventListener('unified-dropdown-opened', onOtherOpened)
+    menuRef?.addEventListener('toggle', onToggle)
+
+    onCleanup(() => {
+      document.removeEventListener('click', onDocumentClick)
+      document.removeEventListener('keydown', onEscape)
+      window.removeEventListener('unified-dropdown-opened', onOtherOpened)
+      menuRef?.removeEventListener('toggle', onToggle)
+    })
+  })
+
+  return (
+    <details
+      ref={(element) => {
+        if (element instanceof HTMLDetailsElement) {
+          menuRef = element
+          return
+        }
+        menuRef = undefined
+      }}
+      class="relative"
+    >
+      <summary
+        ref={(element) => {
+          if (element instanceof HTMLElement) {
+            triggerRef = element
+            return
+          }
+          triggerRef = undefined
+        }}
+        aria-haspopup="menu"
+        aria-label={t(keys.shipmentView.currentStatus.actions.openMenu)}
+        data-state={isOpen() ? 'open' : 'closed'}
+        class={TRIGGER_CLASS}
+      >
+        <MoreVertical class="h-4 w-4" aria-hidden="true" />
+        <span class="sr-only">{t(keys.shipmentView.currentStatus.actions.openMenu)}</span>
+      </summary>
+
+      <div class="absolute right-0 top-full z-20 mt-1 min-w-52 overflow-hidden rounded-md border border-border bg-surface shadow-lg">
+        <button type="button" class={ITEM_CLASS} onClick={handleOpenTimeTravel}>
+          <Clock3 class="h-4 w-4 shrink-0 text-text-muted" aria-hidden="true" />
+          <span>{t(keys.shipmentView.timeTravel.open)}</span>
+        </button>
+      </div>
+    </details>
+  )
+}

--- a/src/modules/process/ui/components/ShipmentCurrentStatusActionMenu.tsx
+++ b/src/modules/process/ui/components/ShipmentCurrentStatusActionMenu.tsx
@@ -7,7 +7,7 @@ type ShipmentCurrentStatusActionMenuProps = {
 }
 
 const TRIGGER_CLASS =
-  'inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-surface text-text-muted transition-colors hover:border-border-strong hover:bg-surface-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
+  'inline-flex h-8 w-8 list-none cursor-pointer select-none items-center justify-center rounded-md border border-border bg-surface text-text-muted transition-colors hover:border-border-strong hover:bg-surface-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
 
 const ITEM_CLASS =
   'flex w-full items-center gap-2 px-3 py-2 text-left text-xs-ui font-medium text-foreground transition-colors hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'

--- a/src/modules/process/ui/components/ShipmentDataView.tsx
+++ b/src/modules/process/ui/components/ShipmentDataView.tsx
@@ -200,6 +200,7 @@ function ShipmentSidebarRegion(props: ShipmentSidebarRegionProps): JSX.Element {
             <ShipmentCurrentStatus
               selectedContainer={props.selectedContainer}
               syncNow={props.syncNow}
+              onOpenTimeTravel={props.trackingTimeTravel.open}
             />
           </section>
         }
@@ -227,7 +228,6 @@ function ShipmentSidebarRegion(props: ShipmentSidebarRegionProps): JSX.Element {
 }
 
 export function ShipmentDataView(props: ShipmentDataViewProps): JSX.Element {
-  const { t, keys } = useTranslation()
   const isHistoricalMode = () => props.trackingTimeTravel.isActive()
   const trackingValidationDisplay = createMemo(() =>
     resolveShipmentTrackingValidationDisplay({
@@ -266,21 +266,8 @@ export function ShipmentDataView(props: ShipmentDataViewProps): JSX.Element {
         />
       </Show>
 
-      <div class="sticky top-4 z-30">
-        <Show
-          when={isHistoricalMode()}
-          fallback={
-            <div class="flex justify-end">
-              <button
-                type="button"
-                class="rounded-md border border-border bg-surface px-3 py-2 text-xs-ui font-medium text-foreground"
-                onClick={() => props.trackingTimeTravel.open()}
-              >
-                {t(keys.shipmentView.timeTravel.open)}
-              </button>
-            </div>
-          }
-        >
+      <Show when={isHistoricalMode()}>
+        <div class="sticky top-4 z-30">
           <TrackingTimeTravelBar
             isLoading={props.trackingTimeTravel.isLoading()}
             errorMessage={props.trackingTimeTravel.errorMessage()}
@@ -293,8 +280,8 @@ export function ShipmentDataView(props: ShipmentDataViewProps): JSX.Element {
             onPrevious={props.trackingTimeTravel.selectPrevious}
             onNext={props.trackingTimeTravel.selectNext}
           />
-        </Show>
-      </div>
+        </div>
+      </Show>
 
       <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
         <div class="space-y-4">

--- a/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts
+++ b/src/modules/process/ui/screens/shipment/lib/serializeTimelineToText.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import {
   trackingStatusToLabelKey,
   trackingStatusToVariant,
@@ -40,8 +40,18 @@ type SyncOverrides = {
 
 const translationApi = createTranslationApi({ devMode: false })
 const { t, keys, locale } = translationApi
+const FIXED_NOW = new Date('2026-04-04T12:00:00.000Z')
 
 let eventCounter = 0
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 function defaultCurrentContext(): ContainerDetailVM['currentContext'] {
   return {


### PR DESCRIPTION
## Summary
- Added an action menu to the current container status panel so users can open time travel from the status header.
- Moved the standalone time travel button out of the main shipment view and only render the time travel bar when historical mode is active.
- Added the new Portuguese locale string for the action menu label.
- Stabilized timeline serialization tests with a fixed system time.

## Testing
- Not run (PR description only).
- Added/updated unit test setup in `serializeTimelineToText.test.ts` to use fixed fake timers.
- Verified the diff includes the new action menu component and the updated shipment view wiring.