### PR TITLE
Expand search and UI test coverage

### DIFF
--- a/src/capabilities/search/ui/screens/global-search/GlobalSearchDialog.test.tsx
+++ b/src/capabilities/search/ui/screens/global-search/GlobalSearchDialog.test.tsx
@@ -1,0 +1,339 @@
+import { createComponent, createMemo } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  GlobalSearchFilterChipVM,
+  GlobalSearchResultItemVM,
+  GlobalSearchSuggestionVM,
+} from '~/capabilities/search/ui/screens/global-search/types/global-search.vm'
+
+type DialogControllerStub = {
+  isOpen: () => boolean
+  chips: () => readonly GlobalSearchFilterChipVM[]
+  draft: () => string
+  results: () => readonly GlobalSearchResultItemVM[]
+  suggestions: () => readonly GlobalSearchSuggestionVM[]
+  uiState: () => 'loading' | 'empty' | 'error' | 'ready'
+  activeResultIndex: () => number
+  activeSuggestionIndex: () => number
+  emptyTitle: () => string
+  emptyDescription: () => string
+  emptyExamples: () => readonly string[]
+  showSuggestions: () => boolean
+  open: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  setDraft: ReturnType<typeof vi.fn>
+  handleComposerKeyDown: ReturnType<typeof vi.fn>
+  removeChip: ReturnType<typeof vi.fn>
+  clearComposer: ReturnType<typeof vi.fn>
+  setInputRef: ReturnType<typeof vi.fn>
+  acceptSuggestion: ReturnType<typeof vi.fn>
+  setActiveSuggestionIndex: ReturnType<typeof vi.fn>
+  navigateToResult: ReturnType<typeof vi.fn>
+  prefetchResultIntent: ReturnType<typeof vi.fn>
+  prefetchVisibleResults: ReturnType<typeof vi.fn>
+  setActiveResultIndex: ReturnType<typeof vi.fn>
+}
+
+type SearchTriggerProps = {
+  readonly placeholder: string
+  readonly shortcutLabel: string
+  readonly onOpen: () => void
+}
+
+type GlobalSearchComposerProps = {
+  readonly expanded: boolean
+  readonly listboxId: string | undefined
+  readonly activeDescendantId: string | undefined
+  readonly onDraftInput: (value: string) => void
+  readonly onRemoveChip: (chipId: string) => void
+  readonly onClear: () => void
+}
+
+type GlobalSearchSuggestionsProps = {
+  readonly activeIndex: number
+  readonly listLabel: string
+  readonly onSelect: (suggestion: GlobalSearchSuggestionVM) => void
+  readonly onHover: (index: number) => void
+}
+
+type GlobalSearchBodyProps = {
+  readonly uiState: string
+  readonly showDiscoveryState: boolean
+  readonly showEmptyState: boolean
+  readonly activeIndex: number
+  readonly listLabel: string
+  readonly onSelect: (item: GlobalSearchResultItemVM) => void
+  readonly onHover: (index: number) => void
+  readonly onVisiblePrefetch: (processIds: readonly string[]) => void
+}
+
+type FooterProps = {
+  readonly navigateLabel: string
+  readonly selectLabel: string
+  readonly closeLabel: string
+}
+
+const controllerState = vi.hoisted<DialogControllerStub>(() => {
+  const emptyChips: readonly GlobalSearchFilterChipVM[] = []
+  const emptyResults: readonly GlobalSearchResultItemVM[] = []
+  const emptySuggestions: readonly GlobalSearchSuggestionVM[] = []
+  const emptyExamples: readonly string[] = []
+
+  return {
+    isOpen: () => false,
+    chips: () => emptyChips,
+    draft: () => '',
+    results: () => emptyResults,
+    suggestions: () => emptySuggestions,
+    uiState: () => 'empty',
+    activeResultIndex: () => -1,
+    activeSuggestionIndex: () => -1,
+    emptyTitle: () => '',
+    emptyDescription: () => '',
+    emptyExamples: () => emptyExamples,
+    showSuggestions: () => false,
+    open: vi.fn(),
+    close: vi.fn(),
+    setDraft: vi.fn(),
+    handleComposerKeyDown: vi.fn(),
+    removeChip: vi.fn(),
+    clearComposer: vi.fn(),
+    setInputRef: vi.fn(),
+    acceptSuggestion: vi.fn(),
+    setActiveSuggestionIndex: vi.fn(),
+    navigateToResult: vi.fn(),
+    prefetchResultIntent: vi.fn(),
+    prefetchVisibleResults: vi.fn(),
+    setActiveResultIndex: vi.fn(),
+  }
+})
+
+const capturedInteractions = vi.hoisted<{
+  triggerOpen: (() => () => void) | undefined
+  composerDraftInput: (() => (value: string) => void) | undefined
+  composerRemoveChip: (() => (chipId: string) => void) | undefined
+  composerClear: (() => () => void) | undefined
+  suggestionHover: (() => (index: number) => void) | undefined
+  suggestionSelect: (() => (suggestion: GlobalSearchSuggestionVM) => void) | undefined
+  resultHover: (() => (index: number) => void) | undefined
+  resultSelect: (() => (item: GlobalSearchResultItemVM) => void) | undefined
+  visiblePrefetch: (() => (processIds: readonly string[]) => void) | undefined
+}>(() => ({
+  triggerOpen: undefined,
+  composerDraftInput: undefined,
+  composerRemoveChip: undefined,
+  composerClear: undefined,
+  suggestionHover: undefined,
+  suggestionSelect: undefined,
+  resultHover: undefined,
+  resultSelect: undefined,
+  visiblePrefetch: undefined,
+}))
+
+vi.mock('~/capabilities/search/ui/screens/global-search/hooks/useGlobalSearchController', () => ({
+  useGlobalSearchController: () => controllerState,
+}))
+
+vi.mock('~/capabilities/search/ui/SearchOverlay.footer', () => ({
+  SearchOverlayFooter: (props: FooterProps) => (
+    <div>
+      footer:{props.navigateLabel}:{props.selectLabel}:{props.closeLabel}
+    </div>
+  ),
+}))
+
+vi.mock('~/capabilities/search/ui/SearchOverlay.trigger', () => ({
+  SearchTriggerButton: (props: SearchTriggerProps) => {
+    capturedInteractions.triggerOpen = createMemo(() => props.onOpen)
+
+    return (
+      <div>
+        trigger:{props.placeholder}:{props.shortcutLabel}
+      </div>
+    )
+  },
+}))
+
+vi.mock('~/capabilities/search/ui/screens/global-search/views/GlobalSearchComposerView', () => ({
+  GlobalSearchComposerView: (props: GlobalSearchComposerProps) => {
+    capturedInteractions.composerDraftInput = createMemo(() => props.onDraftInput)
+    capturedInteractions.composerRemoveChip = createMemo(() => props.onRemoveChip)
+    capturedInteractions.composerClear = createMemo(() => props.onClear)
+
+    return (
+      <div>
+        composer:{String(props.expanded)}:{props.listboxId ?? 'none'}:
+        {props.activeDescendantId ?? 'none'}
+      </div>
+    )
+  },
+}))
+
+vi.mock('~/capabilities/search/ui/screens/global-search/views/GlobalSearchSuggestionsView', () => ({
+  GlobalSearchSuggestionsView: (props: GlobalSearchSuggestionsProps) => {
+    capturedInteractions.suggestionHover = createMemo(() => props.onHover)
+    capturedInteractions.suggestionSelect = createMemo(() => props.onSelect)
+
+    return (
+      <div>
+        suggestions:{props.activeIndex}:{props.listLabel}
+      </div>
+    )
+  },
+}))
+
+vi.mock('~/capabilities/search/ui/screens/global-search/views/GlobalSearchBodyView', () => ({
+  GlobalSearchBodyView: (props: GlobalSearchBodyProps) => {
+    capturedInteractions.resultHover = createMemo(() => props.onHover)
+    capturedInteractions.resultSelect = createMemo(() => props.onSelect)
+    capturedInteractions.visiblePrefetch = createMemo(() => props.onVisiblePrefetch)
+
+    return (
+      <div>
+        body:{props.uiState}:{String(props.showDiscoveryState)}:{String(props.showEmptyState)}:
+        {props.activeIndex}:{props.listLabel}
+      </div>
+    )
+  },
+}))
+
+import { GlobalSearchDialog } from '~/capabilities/search/ui/screens/global-search/GlobalSearchDialog'
+
+function normalizeSsrHtml(html: string): string {
+  return html.replaceAll('<!--$-->', '').replaceAll('<!--/-->', '')
+}
+
+describe('GlobalSearchDialog', () => {
+  beforeEach(() => {
+    controllerState.open.mockReset()
+    controllerState.close.mockReset()
+    controllerState.setDraft.mockReset()
+    controllerState.removeChip.mockReset()
+    controllerState.clearComposer.mockReset()
+    controllerState.acceptSuggestion.mockReset()
+    controllerState.setActiveSuggestionIndex.mockReset()
+    controllerState.navigateToResult.mockReset()
+    controllerState.prefetchResultIntent.mockReset()
+    controllerState.prefetchVisibleResults.mockReset()
+    controllerState.setActiveResultIndex.mockReset()
+    controllerState.isOpen = () => false
+    controllerState.chips = () => []
+    controllerState.draft = () => ''
+    controllerState.results = () => []
+    controllerState.suggestions = () => []
+    controllerState.uiState = () => 'empty'
+    controllerState.activeResultIndex = () => -1
+    controllerState.activeSuggestionIndex = () => -1
+    controllerState.emptyTitle = () => ''
+    controllerState.emptyDescription = () => ''
+    controllerState.emptyExamples = () => []
+    controllerState.showSuggestions = () => false
+    capturedInteractions.triggerOpen = undefined
+    capturedInteractions.composerDraftInput = undefined
+    capturedInteractions.composerRemoveChip = undefined
+    capturedInteractions.composerClear = undefined
+    capturedInteractions.suggestionHover = undefined
+    capturedInteractions.suggestionSelect = undefined
+    capturedInteractions.resultHover = undefined
+    capturedInteractions.resultSelect = undefined
+    capturedInteractions.visiblePrefetch = undefined
+  })
+
+  it('renders only the trigger when the dialog is closed', () => {
+    const html = normalizeSsrHtml(renderToString(() => createComponent(GlobalSearchDialog, {})))
+
+    expect(html).toContain('trigger:Buscar processos, filtros e ETA...')
+    expect(html).not.toContain('composer:')
+    expect(html).not.toContain('body:')
+  })
+
+  it('wires composer, suggestions and body with active listbox state when dialog is open', () => {
+    controllerState.isOpen = () => true
+    controllerState.showSuggestions = () => true
+    controllerState.uiState = () => 'ready'
+    controllerState.activeSuggestionIndex = () => 0
+    controllerState.activeResultIndex = () => 1
+    controllerState.results = () => [
+      {
+        processId: 'process-1',
+        title: 'CA048-26',
+        supportingId: 'ID do processo: process-1',
+        badges: [],
+        matchSummary: [],
+        meta: [],
+      },
+    ]
+    controllerState.suggestions = () => [
+      {
+        kind: 'field',
+        fieldKey: 'container',
+        value: null,
+        label: 'Container',
+        description: null,
+        insertText: 'container:',
+      },
+    ]
+
+    const html = normalizeSsrHtml(renderToString(() => createComponent(GlobalSearchDialog, {})))
+
+    expect(html).toContain('role="dialog"')
+    expect(html).toContain(
+      'composer:true:global-search-suggestions-list:global-search-suggestion-0',
+    )
+    expect(html).toContain('suggestions:0:Sugestões de busca')
+    expect(html).toContain('body:ready:false:false:1:Resultados da busca')
+    expect(html).toContain('footer:Navegar:Selecionar:Fechar')
+  })
+
+  it('forwards composer, suggestion and result interactions to the controller', () => {
+    const result: GlobalSearchResultItemVM = {
+      processId: 'process-1',
+      title: 'CA048-26',
+      supportingId: 'ID do processo: process-1',
+      badges: [],
+      matchSummary: [],
+      meta: [],
+    }
+    const suggestion: GlobalSearchSuggestionVM = {
+      kind: 'field',
+      fieldKey: 'container',
+      value: null,
+      label: 'Container',
+      description: null,
+      insertText: 'container:',
+    }
+
+    controllerState.isOpen = () => true
+    controllerState.showSuggestions = () => true
+    controllerState.uiState = () => 'ready'
+    controllerState.results = () => [result]
+    controllerState.suggestions = () => [suggestion]
+
+    renderToString(() => createComponent(GlobalSearchDialog, {}))
+
+    capturedInteractions.triggerOpen?.()()
+    capturedInteractions.composerDraftInput?.()('eta:santos')
+    capturedInteractions.composerRemoveChip?.()('chip-1')
+    capturedInteractions.composerClear?.()()
+    capturedInteractions.suggestionHover?.()(0)
+    capturedInteractions.suggestionSelect?.()(suggestion)
+    capturedInteractions.resultHover?.()(0)
+    capturedInteractions.resultHover?.()(4)
+    capturedInteractions.resultSelect?.()(result)
+    capturedInteractions.visiblePrefetch?.()(['process-1', 'process-2'])
+
+    expect(controllerState.open).toHaveBeenCalledTimes(1)
+    expect(controllerState.setDraft).toHaveBeenCalledWith('eta:santos')
+    expect(controllerState.removeChip).toHaveBeenCalledWith('chip-1')
+    expect(controllerState.clearComposer).toHaveBeenCalledTimes(1)
+    expect(controllerState.setActiveSuggestionIndex).toHaveBeenCalledWith(0)
+    expect(controllerState.acceptSuggestion).toHaveBeenCalledWith(suggestion)
+    expect(controllerState.setActiveResultIndex).toHaveBeenNthCalledWith(1, 0)
+    expect(controllerState.setActiveResultIndex).toHaveBeenNthCalledWith(2, 4)
+    expect(controllerState.prefetchResultIntent).toHaveBeenCalledTimes(1)
+    expect(controllerState.prefetchResultIntent).toHaveBeenCalledWith('process-1')
+    expect(controllerState.navigateToResult).toHaveBeenCalledWith(result)
+    expect(controllerState.prefetchVisibleResults).toHaveBeenCalledWith(['process-1', 'process-2'])
+  })
+})

--- a/src/capabilities/search/ui/screens/global-search/hooks/useGlobalSearchController.test.ts
+++ b/src/capabilities/search/ui/screens/global-search/hooks/useGlobalSearchController.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  SearchHttpResponseDto,
+  SearchSuggestionsHttpResponseDto,
+} from '~/capabilities/search/ui/validation/globalSearchApi.validation'
+
+const fetchResultsMock = vi.hoisted(() => vi.fn())
+const fetchSuggestionsMock = vi.hoisted(() => vi.fn())
+const navigateToProcessMock = vi.hoisted(() => vi.fn())
+const scheduleIntentPrefetchMock = vi.hoisted(() => vi.fn())
+const scheduleVisiblePrefetchMock = vi.hoisted(() => vi.fn())
+const navigateMock = vi.hoisted(() => vi.fn())
+const preloadRouteMock = vi.hoisted(() => vi.fn())
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+vi.mock('@solidjs/router', () => ({
+  useNavigate: () => navigateMock,
+  usePreloadRoute: () => preloadRouteMock,
+}))
+
+vi.mock(
+  '~/capabilities/search/ui/screens/global-search/usecases/fetchGlobalSearchResults.usecase',
+  () => ({
+    fetchGlobalSearchResults: fetchResultsMock,
+  }),
+)
+
+vi.mock(
+  '~/capabilities/search/ui/screens/global-search/usecases/fetchGlobalSearchSuggestions.usecase',
+  () => ({
+    fetchGlobalSearchSuggestions: fetchSuggestionsMock,
+  }),
+)
+
+vi.mock('~/modules/process/ui/fetchProcess', () => ({
+  prefetchProcessDetail: vi.fn(),
+}))
+
+vi.mock('~/shared/ui/navigation/app-navigation', () => ({
+  navigateToProcess: navigateToProcessMock,
+  scheduleIntentPrefetch: scheduleIntentPrefetchMock,
+  scheduleVisiblePrefetch: scheduleVisiblePrefetchMock,
+}))
+
+import { createRoot } from 'solid-js'
+import { useGlobalSearchController } from '~/capabilities/search/ui/screens/global-search/hooks/useGlobalSearchController'
+
+type Deferred<T> = {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveDeferred: ((value: T) => void) | undefined
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve
+  })
+
+  if (resolveDeferred === undefined) {
+    throw new Error('Failed to create deferred promise')
+  }
+
+  return {
+    promise,
+    resolve: resolveDeferred,
+  }
+}
+
+function buildSearchResponse(command: {
+  readonly raw: string
+  readonly processId: string
+  readonly title: string
+}): SearchHttpResponseDto {
+  return {
+    query: {
+      raw: command.raw,
+      freeTextTerms: [],
+      filters: [],
+      warnings: [],
+    },
+    results: [
+      {
+        processId: command.processId,
+        processReference: command.title,
+        billOfLading: null,
+        importerName: 'Flush Logistics',
+        exporterName: null,
+        carrierName: 'MSC',
+        statusCode: 'IN_TRANSIT',
+        eta: null,
+        etaState: null,
+        etaType: null,
+        originLabel: 'Shanghai',
+        destinationLabel: 'Santos',
+        terminalLabel: null,
+        terminalMultiple: false,
+        depotLabel: null,
+        routeLabel: 'Shanghai -> Santos',
+        containerNumbers: ['MSCU1234567'],
+        currentLocationLabel: null,
+        currentLocationMultiple: false,
+        currentVesselName: null,
+        currentVesselMultiple: false,
+        currentVoyageNumber: null,
+        currentVoyageMultiple: false,
+        hasValidationRequired: true,
+        activeAlertCategories: ['data'],
+        matchedBy: [
+          {
+            key: 'process',
+            source: 'free_text',
+            matchedValue: command.title,
+            rawQueryValue: command.raw,
+            bucket: 'text_contains',
+          },
+        ],
+      },
+    ],
+    emptyState: {
+      titleKey: 'search.empty.title',
+      descriptionKey: 'search.empty.description',
+      examples: ['container:MSCU1234567'],
+    },
+  }
+}
+
+function buildEmptySearchResponse(raw: string): SearchHttpResponseDto {
+  return {
+    query: {
+      raw,
+      freeTextTerms: [],
+      filters: [],
+      warnings: [],
+    },
+    results: [],
+    emptyState: {
+      titleKey: 'search.empty.title',
+      descriptionKey: 'search.empty.description',
+      examples: ['process:CA048-26'],
+    },
+  }
+}
+
+function buildSuggestionsResponse(raw: string): SearchSuggestionsHttpResponseDto {
+  return {
+    query: {
+      raw,
+      freeTextTerms: [],
+      filters: [],
+      warnings: [],
+    },
+    suggestions: [
+      {
+        kind: 'field',
+        fieldKey: 'container',
+        value: null,
+        labelKey: null,
+        fallbackLabel: 'Container',
+        descriptionKey: null,
+        insertText: 'container:',
+      },
+    ],
+  }
+}
+
+function createControllerHarness() {
+  return createRoot((dispose) => ({
+    controller: useGlobalSearchController(),
+    dispose,
+  }))
+}
+
+function installDomStubs(): void {
+  vi.stubGlobal('document', {
+    body: {
+      style: {
+        overflow: '',
+      },
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    querySelector: vi.fn(() => ({
+      scrollIntoView: vi.fn(),
+    })),
+  })
+  vi.stubGlobal('window', {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })
+}
+
+describe('useGlobalSearchController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    installDomStubs()
+    fetchResultsMock.mockReset()
+    fetchSuggestionsMock.mockReset()
+    navigateToProcessMock.mockReset()
+    scheduleIntentPrefetchMock.mockReset()
+    scheduleVisiblePrefetchMock.mockReset()
+    navigateMock.mockReset()
+    preloadRouteMock.mockReset()
+    fetchSuggestionsMock.mockResolvedValue(buildSuggestionsResponse(''))
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens with an empty interaction state and fetches/render-ready results after debounce', async () => {
+    fetchResultsMock.mockResolvedValue(
+      buildSearchResponse({
+        raw: 'CA048',
+        processId: 'process-ready',
+        title: 'CA048-26',
+      }),
+    )
+    const harness = createControllerHarness()
+
+    harness.controller.open()
+    harness.controller.setDraft('CA048')
+    await Promise.resolve()
+    expect(harness.controller.uiState()).toBe('loading')
+
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(fetchResultsMock).toHaveBeenCalledWith({
+      query: 'CA048',
+      filters: [],
+    })
+    expect(harness.controller.uiState()).toBe('ready')
+    expect(harness.controller.results()).toHaveLength(1)
+    expect(harness.controller.results()[0]?.processId).toBe('process-ready')
+    expect(harness.controller.activeResultIndex()).toBe(0)
+
+    harness.dispose()
+  })
+
+  it('turns empty backend responses into explicit empty UI state and examples', async () => {
+    fetchResultsMock.mockResolvedValue(buildEmptySearchResponse('missing'))
+    const harness = createControllerHarness()
+
+    harness.controller.open()
+    harness.controller.setDraft('missing')
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(harness.controller.uiState()).toBe('empty')
+    expect(harness.controller.results()).toEqual([])
+    expect(harness.controller.emptyExamples()).toEqual(['process:CA048-26'])
+    expect(harness.controller.activeResultIndex()).toBe(-1)
+
+    harness.dispose()
+  })
+
+  it('keeps the latest request authoritative when a stale response resolves last', async () => {
+    const staleResponse = createDeferred<SearchHttpResponseDto>()
+    fetchResultsMock.mockImplementation((command: { readonly query: string }) => {
+      if (command.query === 'old') {
+        return staleResponse.promise
+      }
+      return Promise.resolve(
+        buildSearchResponse({
+          raw: 'new',
+          processId: 'process-new',
+          title: 'NEW-26',
+        }),
+      )
+    })
+    const harness = createControllerHarness()
+
+    harness.controller.open()
+    harness.controller.setDraft('old')
+    await vi.advanceTimersByTimeAsync(200)
+
+    harness.controller.setDraft('new')
+    await vi.advanceTimersByTimeAsync(200)
+    expect(harness.controller.results()[0]?.processId).toBe('process-new')
+
+    staleResponse.resolve(
+      buildSearchResponse({
+        raw: 'old',
+        processId: 'process-old',
+        title: 'OLD-26',
+      }),
+    )
+    await Promise.resolve()
+
+    expect(harness.controller.results()[0]?.processId).toBe('process-new')
+    expect(harness.controller.uiState()).toBe('ready')
+
+    harness.dispose()
+  })
+
+  it('accepts value suggestions as chips and clears all interaction state on close', async () => {
+    const harness = createControllerHarness()
+
+    harness.controller.acceptSuggestion({
+      kind: 'value',
+      fieldKey: 'container',
+      value: 'MSCU1234567',
+      label: 'MSCU1234567',
+      description: null,
+      insertText: 'container:MSCU1234567',
+    })
+
+    expect(harness.controller.chips()).toEqual([
+      {
+        key: 'container',
+        value: 'MSCU1234567',
+        label: 'Container: MSCU1234567',
+      },
+    ])
+
+    harness.controller.close()
+
+    expect(harness.controller.draft()).toBe('')
+    expect(harness.controller.chips()).toEqual([])
+    expect(harness.controller.results()).toEqual([])
+    expect(harness.controller.suggestions()).toEqual([])
+    expect(harness.controller.uiState()).toBe('empty')
+
+    harness.dispose()
+  })
+
+  it('navigates through the shared navigation adapter and closes search state', () => {
+    const harness = createControllerHarness()
+    harness.controller.open()
+
+    harness.controller.navigateToResult({
+      processId: 'process-1',
+      title: 'CA048-26',
+      supportingId: 'ID do processo: process-1',
+      matchSummary: [],
+      badges: [],
+      meta: [],
+    })
+
+    expect(scheduleIntentPrefetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        processId: 'process-1',
+      }),
+    )
+    expect(navigateToProcessMock).toHaveBeenCalledWith({
+      navigate: navigateMock,
+      processId: 'process-1',
+    })
+    expect(harness.controller.isOpen()).toBe(false)
+
+    harness.dispose()
+  })
+})

--- a/src/capabilities/search/ui/screens/global-search/lib/searchTokenizeInput.service.test.ts
+++ b/src/capabilities/search/ui/screens/global-search/lib/searchTokenizeInput.service.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatSearchComposerChip,
+  tryParseDraftFilterToken,
+} from '~/capabilities/search/ui/screens/global-search/lib/searchTokenizeInput.service'
+
+describe('searchTokenizeInput.service', () => {
+  it('parses supported aliases and trims the value without accepting empty tokens', () => {
+    expect(tryParseDraftFilterToken(' bl : MEDU1234567 ')).toEqual({
+      key: 'bl',
+      value: 'MEDU1234567',
+    })
+    expect(tryParseDraftFilterToken('importer:')).toBeNull()
+    expect(tryParseDraftFilterToken(':value')).toBeNull()
+  })
+
+  it('does not convert unsupported or date-only filter tokens into composer chips', () => {
+    expect(tryParseDraftFilterToken('event_date:2026-04-10')).toBeNull()
+    expect(tryParseDraftFilterToken('unknown:abc')).toBeNull()
+  })
+
+  it('serializes accepted chips using the API filter contract', () => {
+    expect(
+      formatSearchComposerChip({
+        key: 'container',
+        value: 'MSCU1234567',
+      }),
+    ).toBe('container:MSCU1234567')
+  })
+})

--- a/src/capabilities/search/ui/screens/global-search/usecases/fetchGlobalSearch.usecases.test.ts
+++ b/src/capabilities/search/ui/screens/global-search/usecases/fetchGlobalSearch.usecases.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const typedFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('~/shared/api/typedFetch', () => ({
+  typedFetch: typedFetchMock,
+}))
+
+import { fetchGlobalSearchResults } from '~/capabilities/search/ui/screens/global-search/usecases/fetchGlobalSearchResults.usecase'
+import { fetchGlobalSearchSuggestions } from '~/capabilities/search/ui/screens/global-search/usecases/fetchGlobalSearchSuggestions.usecase'
+import { SearchHttpResponseSchema } from '~/capabilities/search/ui/validation/globalSearchApi.validation'
+
+describe('global search UI usecases', () => {
+  beforeEach(() => {
+    typedFetchMock.mockReset()
+  })
+
+  it('fetches search results with free text and repeated filters', async () => {
+    const response = {
+      query: {
+        raw: 'CA048',
+        freeTextTerms: [],
+        filters: [],
+        warnings: [],
+      },
+      results: [],
+      emptyState: {
+        titleKey: 'search.empty.title',
+        descriptionKey: 'search.empty.description',
+        examples: [],
+      },
+    }
+    typedFetchMock.mockResolvedValue(response)
+
+    await expect(
+      fetchGlobalSearchResults({
+        query: 'CA048',
+        filters: ['status:IN_TRANSIT', 'carrier:MSC'],
+      }),
+    ).resolves.toBe(response)
+
+    expect(typedFetchMock).toHaveBeenCalledWith(
+      '/api/search?q=CA048&filter=status%3AIN_TRANSIT&filter=carrier%3AMSC',
+      undefined,
+      SearchHttpResponseSchema,
+    )
+  })
+
+  it('omits empty query text while preserving structured suggestion filters', async () => {
+    const response = {
+      query: {
+        raw: '',
+        freeTextTerms: [],
+        filters: [],
+        warnings: [],
+      },
+      suggestions: [],
+    }
+    typedFetchMock.mockResolvedValue(response)
+
+    await expect(
+      fetchGlobalSearchSuggestions({
+        query: '   ',
+        filters: ['importer:Acme'],
+      }),
+    ).resolves.toBe(response)
+
+    expect(typedFetchMock).toHaveBeenCalledWith(
+      '/api/search/suggestions?filter=importer%3AAcme',
+      undefined,
+      expect.any(Object),
+    )
+  })
+})

--- a/src/capabilities/search/ui/screens/global-search/views/GlobalSearchComposerView.test.tsx
+++ b/src/capabilities/search/ui/screens/global-search/views/GlobalSearchComposerView.test.tsx
@@ -1,0 +1,51 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { GlobalSearchComposerView } from '~/capabilities/search/ui/screens/global-search/views/GlobalSearchComposerView'
+
+vi.mock('~/capabilities/search/ui/SearchOverlay.icons', () => ({
+  SearchIcon: () => <span>search-icon</span>,
+}))
+
+describe('GlobalSearchComposerView', () => {
+  it('renders chips, combobox a11y wiring and clear affordances', () => {
+    const html = renderToString(() =>
+      createComponent(GlobalSearchComposerView, {
+        chips: [
+          {
+            key: 'container',
+            value: 'MSCU1234567',
+            label: 'Container: MSCU1234567',
+          },
+          {
+            key: 'status',
+            value: 'IN_TRANSIT',
+            label: 'Status: Em Trânsito',
+          },
+        ],
+        draft: 'CA048',
+        placeholder: 'Buscar processo, container, BL...',
+        clearLabel: 'Limpar busca',
+        onDraftInput: () => undefined,
+        onKeyDown: () => undefined,
+        onRemoveChip: () => undefined,
+        onClear: () => undefined,
+        setInputRef: () => undefined,
+        expanded: true,
+        listboxId: 'global-search-results-list',
+        activeDescendantId: 'global-search-result-0',
+      }),
+    )
+
+    expect(html).toContain('search-icon')
+    expect(html).toContain('Container: MSCU1234567')
+    expect(html).toContain('Status: Em Trânsito')
+    expect(html).toContain('role="combobox"')
+    expect(html).toContain('aria-controls="global-search-results-list"')
+    expect(html).toContain('aria-activedescendant="global-search-result-0"')
+    expect(html).toContain('placeholder="Buscar processo, container, BL..."')
+    expect(html).toContain('aria-label="Limpar busca"')
+    expect(html).toContain('<kbd')
+    expect(html).toContain('Esc')
+  })
+})

--- a/src/capabilities/search/ui/screens/global-search/views/GlobalSearchViews.test.tsx
+++ b/src/capabilities/search/ui/screens/global-search/views/GlobalSearchViews.test.tsx
@@ -1,0 +1,147 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it } from 'vitest'
+import type {
+  GlobalSearchResultItemVM,
+  GlobalSearchSuggestionVM,
+} from '~/capabilities/search/ui/screens/global-search/types/global-search.vm'
+import { GlobalSearchBodyView } from '~/capabilities/search/ui/screens/global-search/views/GlobalSearchBodyView'
+import { GlobalSearchResultRow } from '~/capabilities/search/ui/screens/global-search/views/GlobalSearchResultRow'
+import { GlobalSearchSuggestionsView } from '~/capabilities/search/ui/screens/global-search/views/GlobalSearchSuggestionsView'
+
+const RESULT_ITEM: GlobalSearchResultItemVM = {
+  processId: 'process-1',
+  title: 'CA048-26',
+  supportingId: 'ID do processo: process-1',
+  badges: ['Em trânsito', 'Alerta de dados'],
+  matchSummary: ['Container MSCU1234567'],
+  meta: [
+    {
+      label: 'Importador',
+      value: 'Flush Logistics',
+    },
+  ],
+}
+
+const SUGGESTIONS: readonly GlobalSearchSuggestionVM[] = [
+  {
+    kind: 'field',
+    fieldKey: 'container',
+    value: null,
+    label: 'Container',
+    description: null,
+    insertText: 'container:',
+  },
+  {
+    kind: 'value',
+    fieldKey: 'status',
+    value: 'IN_TRANSIT',
+    label: 'Em trânsito',
+    description: null,
+    insertText: 'status:IN_TRANSIT',
+  },
+]
+
+function renderBody(overrides: Partial<Parameters<typeof GlobalSearchBodyView>[0]>): string {
+  return renderToString(() =>
+    createComponent(GlobalSearchBodyView, {
+      uiState: 'empty',
+      showDiscoveryState: false,
+      showEmptyState: false,
+      errorLabel: 'Falha ao buscar',
+      discoveryLabel: 'Digite para buscar',
+      emptyTitle: 'Nada encontrado',
+      emptyDescription: 'Tente outro termo',
+      emptyExamples: ['container:MSCU1234567'],
+      loadingLabel: 'Buscando',
+      results: [],
+      activeIndex: -1,
+      onSelect: () => undefined,
+      onHover: () => undefined,
+      onVisiblePrefetch: () => undefined,
+      listLabel: 'Resultados',
+      ...overrides,
+    }),
+  )
+}
+
+describe('global search views', () => {
+  it('renders discovery, loading, error and empty states without leaking stale results', () => {
+    expect(
+      renderBody({
+        showDiscoveryState: true,
+      }),
+    ).toContain('Digite para buscar')
+    expect(
+      renderBody({
+        uiState: 'loading',
+      }),
+    ).toContain('Buscando')
+    expect(
+      renderBody({
+        uiState: 'error',
+      }),
+    ).toContain('Falha ao buscar')
+
+    const emptyHtml = renderBody({
+      showEmptyState: true,
+    })
+    expect(emptyHtml).toContain('Nada encontrado')
+    expect(emptyHtml).toContain('container:MSCU1234567')
+    expect(emptyHtml).not.toContain('CA048-26')
+  })
+
+  it('renders ready results with operational badges, matches and metadata', () => {
+    const html = renderBody({
+      uiState: 'ready',
+      results: [RESULT_ITEM],
+      activeIndex: 0,
+    })
+
+    expect(html).toContain('role="listbox"')
+    expect(html).toContain('CA048-26')
+    expect(html).toContain('Em trânsito')
+    expect(html).toContain('Container MSCU1234567')
+    expect(html).toContain('Flush Logistics')
+  })
+
+  it('marks active result rows and keeps optional sections absent when not provided', () => {
+    const html = renderToString(() =>
+      createComponent(GlobalSearchResultRow, {
+        item: {
+          ...RESULT_ITEM,
+          badges: [],
+          matchSummary: [],
+          meta: [],
+        },
+        index: 2,
+        active: true,
+        onSelect: () => undefined,
+        onHover: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('id="global-search-result-2"')
+    expect(html).toContain('aria-selected="true"')
+    expect(html).toContain('data-search-process-id="process-1"')
+    expect(html).not.toContain('Container MSCU1234567')
+    expect(html).not.toContain('Importador')
+  })
+
+  it('renders suggestions with localized kind labels and active option semantics', () => {
+    const html = renderToString(() =>
+      createComponent(GlobalSearchSuggestionsView, {
+        suggestions: SUGGESTIONS,
+        activeIndex: 1,
+        onSelect: () => undefined,
+        onHover: () => undefined,
+        listLabel: 'Sugestões',
+      }),
+    )
+
+    expect(html).toContain('role="listbox"')
+    expect(html).toContain('Container')
+    expect(html).toContain('Em trânsito')
+    expect(html).toContain('aria-selected="true"')
+  })
+})

--- a/src/modules/container/infrastructure/persistence/tests/container.persistence.mappers.test.ts
+++ b/src/modules/container/infrastructure/persistence/tests/container.persistence.mappers.test.ts
@@ -2,6 +2,42 @@ import { describe, expect, it } from 'vitest'
 import { containerMappers } from '~/modules/container/infrastructure/persistence/container.persistence.mappers'
 
 describe('container persistence mappers', () => {
+  it('maps persistence rows into immutable container entities with value-object fields', () => {
+    const entity = containerMappers.fromRow({
+      id: 'container-1',
+      process_id: 'process-1',
+      container_number: 'MSCU1234567',
+      carrier_code: 'msc',
+      container_size: '40',
+      container_type: 'HC',
+      created_at: '2026-04-10T10:00:00.000Z',
+      removed_at: null,
+    })
+
+    expect(entity.id).toBe('container-1')
+    expect(entity.processId).toBe('process-1')
+    expect(entity.containerNumber).toBe('MSCU1234567')
+    expect(entity.carrierCode).toBe('msc')
+    expect(entity.createdAt.toIsoString()).toBe('2026-04-10T10:00:00.000Z')
+    expect(Object.isFrozen(entity)).toBe(true)
+  })
+
+  it('keeps insert records explicit about unset size/type persistence columns', () => {
+    const row = containerMappers.toInsert({
+      processId: 'process-1',
+      containerNumber: 'MSCU1234567',
+      carrierCode: 'msc',
+    })
+
+    expect(row).toEqual({
+      carrier_code: 'msc',
+      container_number: 'MSCU1234567',
+      process_id: 'process-1',
+      container_size: null,
+      container_type: null,
+    })
+  })
+
   it('does not clear container size or type when mapping update records', () => {
     const row = containerMappers.toUpdate({
       id: 'container-1',

--- a/src/modules/process/ui/components/export-import/ExportImportActions.tsx
+++ b/src/modules/process/ui/components/export-import/ExportImportActions.tsx
@@ -1,79 +1,18 @@
 import { Copy, Download, Upload } from 'lucide-solid'
-import { createMemo, createSignal, For, type JSX, onCleanup, onMount, Show } from 'solid-js'
-import toast from 'solid-toast'
+import { createSignal, For, type JSX, onCleanup, onMount, Show } from 'solid-js'
+import type { ReportFormat } from '~/modules/process/ui/api/export-import.api'
 import {
-  executeSymmetricImportBundle,
-  type ReportFormat,
-  requestOperationalReportExport,
-  requestOperationalReportExportText,
-  requestPortableExport,
-  validateSymmetricImportBundle,
-} from '~/modules/process/ui/api/export-import.api'
+  type ExportType,
+  type ImportValidationState,
+  type PortableFormat,
+  useExportImportActionsController,
+} from '~/modules/process/ui/components/export-import/useExportImportActionsController'
 import { useTranslation } from '~/shared/localization/i18n'
 import { Dialog } from '~/shared/ui/Dialog'
-import { copyToClipboard } from '~/shared/utils/clipboard'
 
 type ExportImportActionsProps = {
   readonly processId: string | null
   readonly showImport: boolean
-}
-
-type ExportType = 'portable' | 'report'
-
-type PortableFormat = 'json' | 'zip'
-
-type ImportValidationState = {
-  readonly canImport: boolean
-  readonly schemaVersion: string | null
-  readonly processCount: number
-  readonly containerCount: number
-  readonly documentCount: number
-  readonly databaseEmpty: boolean
-  readonly errors: readonly string[]
-  readonly warnings: readonly string[]
-}
-
-const HEADER_MENU_BUTTON_CLASS =
-  'inline-flex h-[var(--dashboard-control-height)] min-h-[var(--dashboard-control-height)] cursor-pointer list-none items-center justify-center gap-1.5 rounded-[var(--dashboard-control-radius)] border border-border bg-surface px-2.5 text-sm-ui font-medium text-text-muted transition-colors select-none hover:border-border-strong hover:bg-surface-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
-
-const HEADER_MENU_ITEM_CLASS =
-  'flex w-full items-center gap-2 px-3 py-2 text-left text-sm-ui font-medium text-foreground transition-colors hover:bg-surface-muted focus-visible:bg-surface-muted focus-visible:outline-none'
-
-function readBundleFromFile(file: File): Promise<unknown> {
-  return file.text().then((text) => JSON.parse(text))
-}
-
-function resolveScope(processId: string | null) {
-  if (!processId) {
-    return {
-      scope: 'all_processes' as const,
-      processId: null,
-    }
-  }
-
-  return {
-    scope: 'single_process' as const,
-    processId,
-  }
-}
-
-function parseExportType(value: string): ExportType {
-  if (value === 'report') return 'report'
-  return 'portable'
-}
-
-function parseReportFormat(value: string): ReportFormat {
-  if (value === 'csv') return 'csv'
-  if (value === 'xlsx') return 'xlsx'
-  if (value === 'markdown') return 'markdown'
-  if (value === 'pdf') return 'pdf'
-  if (value === 'trello') return 'trello'
-  return 'json'
-}
-
-function parsePortableFormat(value: string): PortableFormat {
-  if (value === 'zip') return 'zip'
-  return 'json'
 }
 
 type ExportImportMenuProps = {
@@ -83,6 +22,12 @@ type ExportImportMenuProps = {
   readonly onOpenImport: () => void
   readonly onCopyTrello: () => void
 }
+
+const HEADER_MENU_BUTTON_CLASS =
+  'inline-flex h-[var(--dashboard-control-height)] min-h-[var(--dashboard-control-height)] cursor-pointer list-none items-center justify-center gap-1.5 rounded-[var(--dashboard-control-radius)] border border-border bg-surface px-2.5 text-sm-ui font-medium text-text-muted transition-colors select-none hover:border-border-strong hover:bg-surface-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
+
+const HEADER_MENU_ITEM_CLASS =
+  'flex w-full items-center gap-2 px-3 py-2 text-left text-sm-ui font-medium text-foreground transition-colors hover:bg-surface-muted focus-visible:bg-surface-muted focus-visible:outline-none'
 
 function ExportImportMenu(props: ExportImportMenuProps): JSX.Element {
   const { t, keys } = useTranslation()
@@ -508,204 +453,53 @@ function ImportDialog(props: ImportDialogProps): JSX.Element {
 }
 
 export function ExportImportActions(props: ExportImportActionsProps): JSX.Element {
-  const { t, keys } = useTranslation()
-
-  const [isExportDialogOpen, setIsExportDialogOpen] = createSignal(false)
-  const [isImportDialogOpen, setIsImportDialogOpen] = createSignal(false)
-  const [exportType, setExportType] = createSignal<ExportType>('portable')
-  const [portableFormat, setPortableFormat] = createSignal<PortableFormat>('json')
-  const [reportFormat, setReportFormat] = createSignal<ReportFormat>('json')
-  const [includeContainers, setIncludeContainers] = createSignal(true)
-  const [includeAlerts, setIncludeAlerts] = createSignal(true)
-  const [includeTimelineSummary, setIncludeTimelineSummary] = createSignal(true)
-  const [includeExecutiveSummary, setIncludeExecutiveSummary] = createSignal(true)
-  const [exportError, setExportError] = createSignal<string | null>(null)
-  const [isExporting, setIsExporting] = createSignal(false)
-
-  const [selectedBundle, setSelectedBundle] = createSignal<unknown | null>(null)
-  const [validation, setValidation] = createSignal<ImportValidationState | null>(null)
-  const [isValidating, setIsValidating] = createSignal(false)
-  const [isImporting, setIsImporting] = createSignal(false)
-  const [importError, setImportError] = createSignal<string | null>(null)
-  const [importSuccess, setImportSuccess] = createSignal<string | null>(null)
-
-  const scope = createMemo(() => resolveScope(props.processId))
-  const canExecuteImport = createMemo(() => {
-    const currentValidation = validation()
-    if (currentValidation === null) return false
-    return currentValidation.canImport && currentValidation.databaseEmpty
-  })
-
-  const handleExportSubmit = async () => {
-    setExportError(null)
-    setIsExporting(true)
-
-    try {
-      if (exportType() === 'portable') {
-        await requestPortableExport({ scope: scope(), format: portableFormat() })
-      } else {
-        const isTrelloFormat = reportFormat() === 'trello'
-        await requestOperationalReportExport({
-          scope: scope(),
-          format: reportFormat(),
-          options: {
-            includeContainers: isTrelloFormat ? true : includeContainers(),
-            includeAlerts: isTrelloFormat ? true : includeAlerts(),
-            includeTimelineSummary: isTrelloFormat ? true : includeTimelineSummary(),
-            includeExecutiveSummary: isTrelloFormat ? true : includeExecutiveSummary(),
-          },
-        })
-      }
-
-      setIsExportDialogOpen(false)
-    } catch (error) {
-      setExportError(error instanceof Error ? error.message : 'Export failed')
-    } finally {
-      setIsExporting(false)
-    }
-  }
-
-  const handleCopyTrello = async () => {
-    if (props.processId === null) return
-
-    try {
-      const markdown = await requestOperationalReportExportText({
-        scope: scope(),
-        format: 'trello',
-        options: {
-          includeContainers: true,
-          includeAlerts: true,
-          includeTimelineSummary: true,
-          includeExecutiveSummary: true,
-        },
-      })
-      const copied = await copyToClipboard(markdown)
-      if (copied) {
-        toast.success(t(keys.exportImport.copyTrelloSuccess))
-      } else {
-        toast.error(t(keys.exportImport.copyTrelloError))
-      }
-    } catch (error) {
-      console.error('Failed to copy Trello export', error)
-      toast.error(t(keys.exportImport.copyTrelloError))
-    }
-  }
-
-  const handleBundleFileChange = async (event: Event) => {
-    const target = event.currentTarget
-    if (!(target instanceof HTMLInputElement)) return
-
-    const file = target.files?.[0]
-    if (!file) {
-      setSelectedBundle(null)
-      setValidation(null)
-      return
-    }
-
-    try {
-      const bundle = await readBundleFromFile(file)
-      setSelectedBundle(bundle)
-      setValidation(null)
-      setImportError(null)
-      setImportSuccess(null)
-    } catch {
-      setSelectedBundle(null)
-      setValidation(null)
-      setImportError(t(keys.exportImport.importDialog.invalidBundleJson))
-    }
-  }
-
-  const runDryRun = async () => {
-    const bundle = selectedBundle()
-    if (!bundle) return
-
-    setIsValidating(true)
-    setImportError(null)
-    setImportSuccess(null)
-
-    try {
-      const result = await validateSymmetricImportBundle({ bundle })
-      setValidation(result)
-    } catch (error) {
-      setImportError(error instanceof Error ? error.message : 'Import validation failed')
-      setValidation(null)
-    } finally {
-      setIsValidating(false)
-    }
-  }
-
-  const executeImport = async () => {
-    const bundle = selectedBundle()
-    const dryRun = validation()
-    if (!bundle || !dryRun || !dryRun.canImport || !dryRun.databaseEmpty) return
-
-    setIsImporting(true)
-    setImportError(null)
-    setImportSuccess(null)
-
-    try {
-      const result = await executeSymmetricImportBundle({ bundle })
-      setImportSuccess(
-        t(keys.exportImport.importDialog.importSuccess, {
-          processes: result.importedProcesses,
-          containers: result.importedContainers,
-        }),
-      )
-    } catch (error) {
-      setImportError(error instanceof Error ? error.message : 'Import execution failed')
-    } finally {
-      setIsImporting(false)
-    }
-  }
-
-  const IMPORT_DISABLED = true // TODO: enable button when import functionality is tested with stage database
-  // Issue URL: https://github.com/marcuscastelo/container-tracker/issues/239
+  const controller = useExportImportActionsController(props)
 
   return (
     <>
       <ExportImportMenu
-        showImport={props.showImport && !IMPORT_DISABLED}
-        showCopyTrello={props.processId !== null}
-        onOpenExport={() => setIsExportDialogOpen(true)}
-        onOpenImport={() => setIsImportDialogOpen(true)}
-        onCopyTrello={() => void handleCopyTrello()}
+        showImport={controller.showImport()}
+        showCopyTrello={controller.showCopyTrello()}
+        onOpenExport={controller.openExportDialog}
+        onOpenImport={controller.openImportDialog}
+        onCopyTrello={controller.copyTrello}
       />
 
       <ExportDialog
-        open={isExportDialogOpen()}
-        onClose={() => setIsExportDialogOpen(false)}
-        exportType={exportType()}
-        onExportTypeChange={(value) => setExportType(parseExportType(value))}
-        portableFormat={portableFormat()}
-        onPortableFormatChange={(value) => setPortableFormat(parsePortableFormat(value))}
-        reportFormat={reportFormat()}
-        onReportFormatChange={(value) => setReportFormat(parseReportFormat(value))}
-        includeContainers={includeContainers()}
-        onIncludeContainersChange={setIncludeContainers}
-        includeAlerts={includeAlerts()}
-        onIncludeAlertsChange={setIncludeAlerts}
-        includeTimelineSummary={includeTimelineSummary()}
-        onIncludeTimelineSummaryChange={setIncludeTimelineSummary}
-        includeExecutiveSummary={includeExecutiveSummary()}
-        onIncludeExecutiveSummaryChange={setIncludeExecutiveSummary}
-        exportError={exportError()}
-        isExporting={isExporting()}
-        onSubmit={() => void handleExportSubmit()}
+        open={controller.isExportDialogOpen()}
+        onClose={controller.closeExportDialog}
+        exportType={controller.exportType()}
+        onExportTypeChange={controller.setExportTypeFromInput}
+        portableFormat={controller.portableFormat()}
+        onPortableFormatChange={controller.setPortableFormatFromInput}
+        reportFormat={controller.reportFormat()}
+        onReportFormatChange={controller.setReportFormatFromInput}
+        includeContainers={controller.includeContainers()}
+        onIncludeContainersChange={controller.setIncludeContainers}
+        includeAlerts={controller.includeAlerts()}
+        onIncludeAlertsChange={controller.setIncludeAlerts}
+        includeTimelineSummary={controller.includeTimelineSummary()}
+        onIncludeTimelineSummaryChange={controller.setIncludeTimelineSummary}
+        includeExecutiveSummary={controller.includeExecutiveSummary()}
+        onIncludeExecutiveSummaryChange={controller.setIncludeExecutiveSummary}
+        exportError={controller.exportError()}
+        isExporting={controller.isExporting()}
+        onSubmit={controller.submitExport}
       />
 
       <ImportDialog
-        open={isImportDialogOpen()}
-        onClose={() => setIsImportDialogOpen(false)}
-        onFileChange={handleBundleFileChange}
-        onDryRun={() => void runDryRun()}
-        onExecuteImport={() => void executeImport()}
-        isValidating={isValidating()}
-        isImporting={isImporting()}
-        canRunDryRun={selectedBundle() !== null}
-        canExecuteImport={canExecuteImport()}
-        validation={validation()}
-        importError={importError()}
-        importSuccess={importSuccess()}
+        open={controller.isImportDialogOpen()}
+        onClose={controller.closeImportDialog}
+        onFileChange={controller.handleBundleFileChange}
+        onDryRun={controller.runDryRun}
+        onExecuteImport={controller.executeImport}
+        isValidating={controller.isValidating()}
+        isImporting={controller.isImporting()}
+        canRunDryRun={controller.canRunDryRun()}
+        canExecuteImport={controller.canExecuteImport()}
+        validation={controller.validation()}
+        importError={controller.importError()}
+        importSuccess={controller.importSuccess()}
       />
     </>
   )

--- a/src/modules/process/ui/components/export-import/tests/ExportImportActions.view.test.tsx
+++ b/src/modules/process/ui/components/export-import/tests/ExportImportActions.view.test.tsx
@@ -1,0 +1,243 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReportFormat } from '~/modules/process/ui/api/export-import.api'
+import type {
+  ExportType,
+  ImportValidationState,
+  PortableFormat,
+} from '~/modules/process/ui/components/export-import/useExportImportActionsController'
+
+const translationKeys = vi.hoisted(() => ({
+  exportImport: {
+    moreActions: 'More actions',
+    copyTrelloAction: 'Copy Trello',
+    importButton: 'Import bundle',
+    exportButton: 'Export bundle',
+    dialog: {
+      title: 'Export dialog',
+      description: 'Export data',
+      exportType: 'Export type',
+      typePortable: 'Portable',
+      typeReport: 'Report',
+      format: 'Format',
+      formatTrello: 'Trello',
+      includeContainers: 'Include containers',
+      includeAlerts: 'Include alerts',
+      includeTimelineSummary: 'Include timeline summary',
+      includeExecutiveSummary: 'Include executive summary',
+      cancel: 'Cancel',
+      exporting: 'Exporting',
+      confirmExport: 'Confirm export',
+    },
+    importDialog: {
+      title: 'Import dialog',
+      description: 'Import data',
+      warning: 'Import warning',
+      selectBundle: 'Select bundle',
+      validating: 'Validating',
+      runDryRun: 'Run dry run',
+      importing: 'Importing',
+      executeImport: 'Execute import',
+      databaseNotEmpty: 'Database not empty',
+      validation: {
+        schemaVersion: 'Schema version',
+        processes: 'Processes',
+        containers: 'Containers',
+        documents: 'Documents',
+        databaseEmpty: 'Database empty',
+        yes: 'Yes',
+        no: 'No',
+        valueUnavailable: 'Unavailable',
+      },
+    },
+  },
+}))
+
+type ExportImportControllerStub = {
+  isExportDialogOpen: () => boolean
+  openExportDialog: ReturnType<typeof vi.fn>
+  closeExportDialog: ReturnType<typeof vi.fn>
+  exportType: () => ExportType
+  setExportTypeFromInput: ReturnType<typeof vi.fn>
+  portableFormat: () => PortableFormat
+  setPortableFormatFromInput: ReturnType<typeof vi.fn>
+  reportFormat: () => ReportFormat
+  setReportFormatFromInput: ReturnType<typeof vi.fn>
+  includeContainers: () => boolean
+  setIncludeContainers: ReturnType<typeof vi.fn>
+  includeAlerts: () => boolean
+  setIncludeAlerts: ReturnType<typeof vi.fn>
+  includeTimelineSummary: () => boolean
+  setIncludeTimelineSummary: ReturnType<typeof vi.fn>
+  includeExecutiveSummary: () => boolean
+  setIncludeExecutiveSummary: ReturnType<typeof vi.fn>
+  exportError: () => string | null
+  isExporting: () => boolean
+  submitExport: ReturnType<typeof vi.fn>
+  isImportDialogOpen: () => boolean
+  openImportDialog: ReturnType<typeof vi.fn>
+  closeImportDialog: ReturnType<typeof vi.fn>
+  handleBundleFileChange: ReturnType<typeof vi.fn>
+  runDryRun: ReturnType<typeof vi.fn>
+  executeImport: ReturnType<typeof vi.fn>
+  canRunDryRun: () => boolean
+  canExecuteImport: () => boolean
+  validation: () => ImportValidationState | null
+  isValidating: () => boolean
+  isImporting: () => boolean
+  importError: () => string | null
+  importSuccess: () => string | null
+  showCopyTrello: () => boolean
+  showImport: () => boolean
+  copyTrello: ReturnType<typeof vi.fn>
+}
+
+const controllerState = vi.hoisted<ExportImportControllerStub>(() => ({
+  isExportDialogOpen: () => false,
+  openExportDialog: vi.fn(),
+  closeExportDialog: vi.fn(),
+  exportType: () => 'portable',
+  setExportTypeFromInput: vi.fn(),
+  portableFormat: () => 'json',
+  setPortableFormatFromInput: vi.fn(),
+  reportFormat: () => 'json',
+  setReportFormatFromInput: vi.fn(),
+  includeContainers: () => true,
+  setIncludeContainers: vi.fn(),
+  includeAlerts: () => true,
+  setIncludeAlerts: vi.fn(),
+  includeTimelineSummary: () => true,
+  setIncludeTimelineSummary: vi.fn(),
+  includeExecutiveSummary: () => true,
+  setIncludeExecutiveSummary: vi.fn(),
+  exportError: () => null,
+  isExporting: () => false,
+  submitExport: vi.fn(),
+  isImportDialogOpen: () => false,
+  openImportDialog: vi.fn(),
+  closeImportDialog: vi.fn(),
+  handleBundleFileChange: vi.fn(),
+  runDryRun: vi.fn(),
+  executeImport: vi.fn(),
+  canRunDryRun: () => false,
+  canExecuteImport: () => false,
+  validation: () => null,
+  isValidating: () => false,
+  isImporting: () => false,
+  importError: () => null,
+  importSuccess: () => null,
+  showCopyTrello: () => false,
+  showImport: () => false,
+  copyTrello: vi.fn(),
+}))
+
+vi.mock('~/shared/localization/i18n', () => ({
+  useTranslation: () => ({
+    t: (value: string) => value,
+    keys: translationKeys,
+  }),
+}))
+
+vi.mock('~/shared/ui/Dialog', () => ({
+  Dialog: (props: {
+    readonly open: boolean
+    readonly title: string
+    readonly description: string
+    readonly children: import('solid-js').JSX.Element
+  }) => (
+    <section data-open={String(props.open)} data-title={props.title}>
+      <h2>{props.title}</h2>
+      <p>{props.description}</p>
+      {props.children}
+    </section>
+  ),
+}))
+
+vi.mock('~/modules/process/ui/components/export-import/useExportImportActionsController', () => ({
+  useExportImportActionsController: () => controllerState,
+}))
+
+import { ExportImportActions } from '~/modules/process/ui/components/export-import/ExportImportActions'
+
+describe('ExportImportActions view', () => {
+  beforeEach(() => {
+    controllerState.isExportDialogOpen = () => false
+    controllerState.exportType = () => 'portable'
+    controllerState.portableFormat = () => 'json'
+    controllerState.reportFormat = () => 'json'
+    controllerState.includeContainers = () => true
+    controllerState.includeAlerts = () => true
+    controllerState.includeTimelineSummary = () => true
+    controllerState.includeExecutiveSummary = () => true
+    controllerState.exportError = () => null
+    controllerState.isExporting = () => false
+    controllerState.isImportDialogOpen = () => false
+    controllerState.canRunDryRun = () => false
+    controllerState.canExecuteImport = () => false
+    controllerState.validation = () => null
+    controllerState.isValidating = () => false
+    controllerState.isImporting = () => false
+    controllerState.importError = () => null
+    controllerState.importSuccess = () => null
+    controllerState.showCopyTrello = () => false
+    controllerState.showImport = () => false
+  })
+
+  it('renders the menu with export only and portable export controls by default', () => {
+    const html = renderToString(() =>
+      createComponent(ExportImportActions, {
+        processId: null,
+        showImport: false,
+      }),
+    )
+
+    expect(html).toContain('More actions')
+    expect(html).toContain('Export bundle')
+    expect(html).not.toContain('Copy Trello')
+    expect(html).not.toContain('Import bundle')
+    expect(html).toContain('Export dialog')
+    expect(html).toContain('<option value="zip">ZIP</option>')
+    expect(html).toContain('Import dialog')
+  })
+
+  it('renders report and import validation branches from controller state', () => {
+    controllerState.isExportDialogOpen = () => true
+    controllerState.exportType = () => 'report'
+    controllerState.reportFormat = () => 'json'
+    controllerState.exportError = () => 'Export failed'
+    controllerState.isImportDialogOpen = () => true
+    controllerState.canRunDryRun = () => true
+    controllerState.canExecuteImport = () => false
+    controllerState.validation = () => ({
+      canImport: true,
+      schemaVersion: '1.0.0',
+      processCount: 1,
+      containerCount: 2,
+      documentCount: 3,
+      databaseEmpty: false,
+      errors: ['Missing attachment'],
+      warnings: ['Carrier code not recognized'],
+    })
+    controllerState.importError = () => 'Import validation failed'
+    controllerState.importSuccess = () => 'Imported 1 processes and 2 containers'
+    controllerState.showCopyTrello = () => true
+
+    const html = renderToString(() =>
+      createComponent(ExportImportActions, {
+        processId: 'process-1',
+        showImport: true,
+      }),
+    )
+
+    expect(html).toContain('Copy Trello')
+    expect(html).toContain('Include containers')
+    expect(html).toContain('Include alerts')
+    expect(html).toContain('Export failed')
+    expect(html).toContain('Database not empty')
+    expect(html).toContain('Missing attachment')
+    expect(html).toContain('Carrier code not recognized')
+    expect(html).toContain('Import validation failed')
+    expect(html).toContain('Imported 1 processes and 2 containers')
+  })
+})

--- a/src/modules/process/ui/components/export-import/useExportImportActionsController.test.ts
+++ b/src/modules/process/ui/components/export-import/useExportImportActionsController.test.ts
@@ -1,0 +1,311 @@
+import { createRoot } from 'solid-js'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ImportValidationState } from '~/modules/process/ui/components/export-import/useExportImportActionsController'
+
+const requestPortableExportMock = vi.hoisted(() => vi.fn(async () => undefined))
+const requestOperationalReportExportMock = vi.hoisted(() => vi.fn(async () => undefined))
+const requestOperationalReportExportTextMock = vi.hoisted(() => vi.fn(async () => 'trello export'))
+const validateSymmetricImportBundleMock = vi.hoisted(() => vi.fn())
+const executeSymmetricImportBundleMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    importedProcesses: 2,
+    importedContainers: 3,
+  })),
+)
+const copyToClipboardMock = vi.hoisted(() => vi.fn(async () => true))
+const toastSuccessMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+const translationKeys = vi.hoisted(() => ({
+  exportImport: {
+    copyTrelloSuccess: 'Copied Trello export',
+    copyTrelloError: 'Failed to copy Trello export',
+    importDialog: {
+      invalidBundleJson: 'Invalid bundle JSON',
+      importSuccess: 'Imported {processes} processes and {containers} containers',
+    },
+  },
+}))
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+vi.mock('~/modules/process/ui/api/export-import.api', () => ({
+  requestPortableExport: requestPortableExportMock,
+  requestOperationalReportExport: requestOperationalReportExportMock,
+  requestOperationalReportExportText: requestOperationalReportExportTextMock,
+  validateSymmetricImportBundle: validateSymmetricImportBundleMock,
+  executeSymmetricImportBundle: executeSymmetricImportBundleMock,
+}))
+
+vi.mock('~/shared/utils/clipboard', () => ({
+  copyToClipboard: copyToClipboardMock,
+}))
+
+vi.mock('solid-toast', () => ({
+  default: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}))
+
+vi.mock('~/shared/localization/i18n', () => ({
+  useTranslation: () => ({
+    t: (value: string, params?: Record<string, string | number>) => {
+      if (!params) return value
+      return Object.entries(params).reduce(
+        (message, [key, current]) => message.replace(`{${key}}`, String(current)),
+        value,
+      )
+    },
+    keys: translationKeys,
+  }),
+}))
+
+import { useExportImportActionsController } from '~/modules/process/ui/components/export-import/useExportImportActionsController'
+
+type ControllerHarness = ReturnType<typeof useExportImportActionsController> & {
+  readonly dispose: () => void
+}
+
+type OriginalHtmlInputElement = typeof globalThis.HTMLInputElement | undefined
+
+class FakeHtmlInputElement {
+  files: readonly File[] | null = null
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function buildImportValidation(overrides?: Partial<ImportValidationState>): ImportValidationState {
+  return {
+    canImport: true,
+    schemaVersion: '1.0.0',
+    processCount: 1,
+    containerCount: 1,
+    documentCount: 0,
+    databaseEmpty: true,
+    errors: [],
+    warnings: [],
+    ...overrides,
+  }
+}
+
+function mountController(processId: string | null, showImport = true): ControllerHarness {
+  return createRoot((dispose) => {
+    const controller = useExportImportActionsController({
+      processId,
+      showImport,
+    })
+
+    return {
+      ...controller,
+      dispose,
+    }
+  })
+}
+
+function createFileChangeEvent(file: File | null): Event {
+  const input = new FakeHtmlInputElement()
+  input.files = file ? [file] : null
+  const event = new Event('change')
+  Object.defineProperty(event, 'currentTarget', {
+    configurable: true,
+    value: input,
+  })
+  return event
+}
+
+describe('useExportImportActionsController', () => {
+  let originalHtmlInputElement: OriginalHtmlInputElement
+
+  beforeAll(() => {
+    originalHtmlInputElement = globalThis.HTMLInputElement
+    Object.defineProperty(globalThis, 'HTMLInputElement', {
+      configurable: true,
+      value: FakeHtmlInputElement,
+    })
+  })
+
+  afterAll(() => {
+    if (originalHtmlInputElement === undefined) {
+      Reflect.deleteProperty(globalThis, 'HTMLInputElement')
+      return
+    }
+
+    Object.defineProperty(globalThis, 'HTMLInputElement', {
+      configurable: true,
+      value: originalHtmlInputElement,
+    })
+  })
+
+  beforeEach(() => {
+    requestPortableExportMock.mockReset()
+    requestOperationalReportExportMock.mockReset()
+    requestOperationalReportExportTextMock.mockReset()
+    validateSymmetricImportBundleMock.mockReset()
+    executeSymmetricImportBundleMock.mockReset()
+    copyToClipboardMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    requestPortableExportMock.mockResolvedValue(undefined)
+    requestOperationalReportExportMock.mockResolvedValue(undefined)
+    requestOperationalReportExportTextMock.mockResolvedValue('trello export')
+    validateSymmetricImportBundleMock.mockImplementation(async () => buildImportValidation())
+    executeSymmetricImportBundleMock.mockResolvedValue({
+      importedProcesses: 2,
+      importedContainers: 3,
+    })
+    copyToClipboardMock.mockResolvedValue(true)
+  })
+
+  it('skips Trello copy when no process is selected', async () => {
+    const controller = mountController(null)
+
+    await controller.copyTrello()
+
+    expect(requestOperationalReportExportTextMock).not.toHaveBeenCalled()
+    expect(copyToClipboardMock).not.toHaveBeenCalled()
+    controller.dispose()
+  })
+
+  it('copies Trello text and reports clipboard failures', async () => {
+    const controller = mountController('process-1')
+
+    await controller.copyTrello()
+
+    expect(requestOperationalReportExportTextMock).toHaveBeenCalledWith({
+      scope: {
+        scope: 'single_process',
+        processId: 'process-1',
+      },
+      format: 'trello',
+      options: {
+        includeContainers: true,
+        includeAlerts: true,
+        includeTimelineSummary: true,
+        includeExecutiveSummary: true,
+      },
+    })
+    expect(copyToClipboardMock).toHaveBeenCalledWith('trello export')
+    expect(toastSuccessMock).toHaveBeenCalledWith('Copied Trello export')
+
+    copyToClipboardMock.mockResolvedValueOnce(false)
+    await controller.copyTrello()
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Failed to copy Trello export')
+    controller.dispose()
+  })
+
+  it('exports portable bundles with all-process scope by default', async () => {
+    const controller = mountController(null)
+
+    await controller.submitExport()
+
+    expect(requestPortableExportMock).toHaveBeenCalledWith({
+      scope: {
+        scope: 'all_processes',
+        processId: null,
+      },
+      format: 'json',
+    })
+    expect(controller.isExportDialogOpen()).toBe(false)
+    controller.dispose()
+  })
+
+  it('forces Trello report exports to include all report sections', async () => {
+    const controller = mountController('process-9')
+
+    controller.setExportTypeFromInput('report')
+    controller.setIncludeContainers(false)
+    controller.setIncludeAlerts(false)
+    controller.setIncludeTimelineSummary(false)
+    controller.setIncludeExecutiveSummary(false)
+    controller.setReportFormatFromInput('trello')
+    await controller.submitExport()
+
+    expect(requestOperationalReportExportMock).toHaveBeenCalledWith({
+      scope: {
+        scope: 'single_process',
+        processId: 'process-9',
+      },
+      format: 'trello',
+      options: {
+        includeContainers: true,
+        includeAlerts: true,
+        includeTimelineSummary: true,
+        includeExecutiveSummary: true,
+      },
+    })
+    controller.dispose()
+  })
+
+  it('surfaces invalid bundle JSON and keeps import blocked', async () => {
+    const controller = mountController(null)
+
+    await controller.handleBundleFileChange(
+      createFileChangeEvent(new File(['not-json'], 'broken.json', { type: 'application/json' })),
+    )
+
+    expect(controller.importError()).toBe('Invalid bundle JSON')
+    expect(controller.canRunDryRun()).toBe(false)
+    controller.runDryRun()
+    await flushMicrotasks()
+    expect(validateSymmetricImportBundleMock).not.toHaveBeenCalled()
+    controller.dispose()
+  })
+
+  it('validates and executes import when the bundle is accepted', async () => {
+    const controller = mountController(null)
+    const bundle = {
+      processes: [{ id: 'process-1' }],
+    }
+
+    await controller.handleBundleFileChange(
+      createFileChangeEvent(
+        new File([JSON.stringify(bundle)], 'bundle.json', { type: 'application/json' }),
+      ),
+    )
+    await flushMicrotasks()
+
+    await controller.runDryRun()
+
+    expect(validateSymmetricImportBundleMock).toHaveBeenCalledWith({ bundle })
+    expect(controller.validation()).not.toBeNull()
+    expect(controller.canExecuteImport()).toBe(true)
+
+    await controller.executeImport()
+
+    expect(executeSymmetricImportBundleMock).toHaveBeenCalledWith({ bundle })
+    expect(controller.importSuccess()).toBe('Imported 2 processes and 3 containers')
+    controller.dispose()
+  })
+
+  it('blocks import execution when validation says the database is not empty', async () => {
+    validateSymmetricImportBundleMock.mockImplementationOnce(async () =>
+      buildImportValidation({
+        databaseEmpty: false,
+      }),
+    )
+
+    const controller = mountController(null)
+    const bundle = {
+      processes: [{ id: 'process-1' }],
+    }
+
+    await controller.handleBundleFileChange(
+      createFileChangeEvent(
+        new File([JSON.stringify(bundle)], 'bundle.json', { type: 'application/json' }),
+      ),
+    )
+    await flushMicrotasks()
+
+    await controller.runDryRun()
+    await controller.executeImport()
+
+    expect(controller.canExecuteImport()).toBe(false)
+    expect(executeSymmetricImportBundleMock).not.toHaveBeenCalled()
+    controller.dispose()
+  })
+})

--- a/src/modules/process/ui/components/export-import/useExportImportActionsController.ts
+++ b/src/modules/process/ui/components/export-import/useExportImportActionsController.ts
@@ -1,0 +1,263 @@
+import { createMemo, createSignal } from 'solid-js'
+import toast from 'solid-toast'
+import {
+  executeSymmetricImportBundle,
+  type ReportFormat,
+  requestOperationalReportExport,
+  requestOperationalReportExportText,
+  requestPortableExport,
+  validateSymmetricImportBundle,
+} from '~/modules/process/ui/api/export-import.api'
+import { useTranslation } from '~/shared/localization/i18n'
+import { copyToClipboard } from '~/shared/utils/clipboard'
+
+export type ExportType = 'portable' | 'report'
+
+export type PortableFormat = 'json' | 'zip'
+
+export type ImportValidationState = {
+  readonly canImport: boolean
+  readonly schemaVersion: string | null
+  readonly processCount: number
+  readonly containerCount: number
+  readonly documentCount: number
+  readonly databaseEmpty: boolean
+  readonly errors: readonly string[]
+  readonly warnings: readonly string[]
+}
+
+type UseExportImportActionsControllerParams = {
+  readonly processId: string | null
+  readonly showImport: boolean
+}
+
+function readBundleFromFile(file: File): Promise<unknown> {
+  return file.text().then((text) => JSON.parse(text))
+}
+
+function resolveScope(processId: string | null) {
+  if (!processId) {
+    return {
+      scope: 'all_processes' as const,
+      processId: null,
+    }
+  }
+
+  return {
+    scope: 'single_process' as const,
+    processId,
+  }
+}
+
+function parseExportType(value: string): ExportType {
+  if (value === 'report') return 'report'
+  return 'portable'
+}
+
+function parseReportFormat(value: string): ReportFormat {
+  if (value === 'csv') return 'csv'
+  if (value === 'xlsx') return 'xlsx'
+  if (value === 'markdown') return 'markdown'
+  if (value === 'pdf') return 'pdf'
+  if (value === 'trello') return 'trello'
+  return 'json'
+}
+
+function parsePortableFormat(value: string): PortableFormat {
+  if (value === 'zip') return 'zip'
+  return 'json'
+}
+
+export function useExportImportActionsController(params: UseExportImportActionsControllerParams) {
+  const { t, keys } = useTranslation()
+
+  const [isExportDialogOpen, setIsExportDialogOpen] = createSignal(false)
+  const [isImportDialogOpen, setIsImportDialogOpen] = createSignal(false)
+  const [exportType, setExportType] = createSignal<ExportType>('portable')
+  const [portableFormat, setPortableFormat] = createSignal<PortableFormat>('json')
+  const [reportFormat, setReportFormat] = createSignal<ReportFormat>('json')
+  const [includeContainers, setIncludeContainers] = createSignal(true)
+  const [includeAlerts, setIncludeAlerts] = createSignal(true)
+  const [includeTimelineSummary, setIncludeTimelineSummary] = createSignal(true)
+  const [includeExecutiveSummary, setIncludeExecutiveSummary] = createSignal(true)
+  const [exportError, setExportError] = createSignal<string | null>(null)
+  const [isExporting, setIsExporting] = createSignal(false)
+
+  const [selectedBundle, setSelectedBundle] = createSignal<unknown | null>(null)
+  const [validation, setValidation] = createSignal<ImportValidationState | null>(null)
+  const [isValidating, setIsValidating] = createSignal(false)
+  const [isImporting, setIsImporting] = createSignal(false)
+  const [importError, setImportError] = createSignal<string | null>(null)
+  const [importSuccess, setImportSuccess] = createSignal<string | null>(null)
+
+  const scope = createMemo(() => resolveScope(params.processId))
+  const canRunDryRun = createMemo(() => selectedBundle() !== null)
+  const canExecuteImport = createMemo(() => {
+    const currentValidation = validation()
+    if (currentValidation === null) return false
+    return currentValidation.canImport && currentValidation.databaseEmpty
+  })
+
+  const handleExportSubmit = async () => {
+    setExportError(null)
+    setIsExporting(true)
+
+    try {
+      if (exportType() === 'portable') {
+        await requestPortableExport({ scope: scope(), format: portableFormat() })
+      } else {
+        const isTrelloFormat = reportFormat() === 'trello'
+        await requestOperationalReportExport({
+          scope: scope(),
+          format: reportFormat(),
+          options: {
+            includeContainers: isTrelloFormat ? true : includeContainers(),
+            includeAlerts: isTrelloFormat ? true : includeAlerts(),
+            includeTimelineSummary: isTrelloFormat ? true : includeTimelineSummary(),
+            includeExecutiveSummary: isTrelloFormat ? true : includeExecutiveSummary(),
+          },
+        })
+      }
+
+      setIsExportDialogOpen(false)
+    } catch (error) {
+      setExportError(error instanceof Error ? error.message : 'Export failed')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  const handleCopyTrello = async () => {
+    if (params.processId === null) return
+
+    try {
+      const markdown = await requestOperationalReportExportText({
+        scope: scope(),
+        format: 'trello',
+        options: {
+          includeContainers: true,
+          includeAlerts: true,
+          includeTimelineSummary: true,
+          includeExecutiveSummary: true,
+        },
+      })
+      const copied = await copyToClipboard(markdown)
+      if (copied) {
+        toast.success(t(keys.exportImport.copyTrelloSuccess))
+      } else {
+        toast.error(t(keys.exportImport.copyTrelloError))
+      }
+    } catch (error) {
+      console.error('Failed to copy Trello export', error)
+      toast.error(t(keys.exportImport.copyTrelloError))
+    }
+  }
+
+  const handleBundleFileChange = async (event: Event) => {
+    const target = event.currentTarget
+    if (!(target instanceof HTMLInputElement)) return
+
+    const file = target.files?.[0]
+    if (!file) {
+      setSelectedBundle(null)
+      setValidation(null)
+      return
+    }
+
+    try {
+      const bundle = await readBundleFromFile(file)
+      setSelectedBundle(bundle)
+      setValidation(null)
+      setImportError(null)
+      setImportSuccess(null)
+    } catch {
+      setSelectedBundle(null)
+      setValidation(null)
+      setImportError(t(keys.exportImport.importDialog.invalidBundleJson))
+    }
+  }
+
+  const runDryRun = async () => {
+    const bundle = selectedBundle()
+    if (!bundle) return
+
+    setIsValidating(true)
+    setImportError(null)
+    setImportSuccess(null)
+
+    try {
+      const result = await validateSymmetricImportBundle({ bundle })
+      setValidation(result)
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : 'Import validation failed')
+      setValidation(null)
+    } finally {
+      setIsValidating(false)
+    }
+  }
+
+  const executeImport = async () => {
+    const bundle = selectedBundle()
+    const dryRun = validation()
+    if (!bundle || !dryRun || !dryRun.canImport || !dryRun.databaseEmpty) return
+
+    setIsImporting(true)
+    setImportError(null)
+    setImportSuccess(null)
+
+    try {
+      const result = await executeSymmetricImportBundle({ bundle })
+      setImportSuccess(
+        t(keys.exportImport.importDialog.importSuccess, {
+          processes: result.importedProcesses,
+          containers: result.importedContainers,
+        }),
+      )
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : 'Import execution failed')
+    } finally {
+      setIsImporting(false)
+    }
+  }
+
+  const importDisabled = true
+
+  return {
+    isExportDialogOpen,
+    openExportDialog: () => setIsExportDialogOpen(true),
+    closeExportDialog: () => setIsExportDialogOpen(false),
+    exportType,
+    setExportTypeFromInput: (value: string) => setExportType(parseExportType(value)),
+    portableFormat,
+    setPortableFormatFromInput: (value: string) => setPortableFormat(parsePortableFormat(value)),
+    reportFormat,
+    setReportFormatFromInput: (value: string) => setReportFormat(parseReportFormat(value)),
+    includeContainers,
+    setIncludeContainers,
+    includeAlerts,
+    setIncludeAlerts,
+    includeTimelineSummary,
+    setIncludeTimelineSummary,
+    includeExecutiveSummary,
+    setIncludeExecutiveSummary,
+    exportError,
+    isExporting,
+    submitExport: handleExportSubmit,
+    isImportDialogOpen,
+    openImportDialog: () => setIsImportDialogOpen(true),
+    closeImportDialog: () => setIsImportDialogOpen(false),
+    handleBundleFileChange,
+    runDryRun,
+    executeImport,
+    canRunDryRun,
+    canExecuteImport,
+    validation,
+    isValidating,
+    isImporting,
+    importError,
+    importSuccess,
+    showCopyTrello: () => params.processId !== null,
+    showImport: () => params.showImport && !importDisabled,
+    copyTrello: handleCopyTrello,
+  }
+}

--- a/src/modules/process/ui/components/unified/tests/UnifiedChipDropdowns.test.tsx
+++ b/src/modules/process/ui/components/unified/tests/UnifiedChipDropdowns.test.tsx
@@ -1,0 +1,180 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it } from 'vitest'
+import { ImporterChipDropdown } from '~/modules/process/ui/components/unified/ImporterChipDropdown'
+import { MultiSelectChipDropdown } from '~/modules/process/ui/components/unified/MultiSelectChipDropdown'
+import { SingleSelectChipDropdown } from '~/modules/process/ui/components/unified/SingleSelectChipDropdown'
+
+describe('unified chip dropdowns', () => {
+  it('renders empty multi-select dropdown state when no options are available', () => {
+    const html = renderToString(() =>
+      createComponent(MultiSelectChipDropdown<'MSC' | 'ONE'>, {
+        label: 'Armador',
+        allLabel: 'Todos',
+        emptyLabel: 'Nenhuma opção disponível',
+        testId: 'provider-filter',
+        selectedValues: [],
+        options: [],
+        onToggle: () => undefined,
+        toSelectedCountLabel: (count) => `${count} selecionados`,
+      }),
+    )
+
+    expect(html).toContain('data-testid="provider-filter"')
+    expect(html).toContain('Armador')
+    expect(html).toContain('Nenhuma opção disponível')
+    expect(html).toContain('border-control-border')
+  })
+
+  it('shows selected count summary for multi-select dropdowns with multiple active filters', () => {
+    const html = renderToString(() =>
+      createComponent(MultiSelectChipDropdown<'MSC' | 'ONE' | 'MAERSK'>, {
+        label: 'Armador',
+        allLabel: 'Todos',
+        emptyLabel: 'Nenhuma opção disponível',
+        testId: 'provider-filter',
+        selectedValues: ['MSC', 'ONE'],
+        options: [
+          {
+            value: 'MSC',
+            label: 'MSC',
+            count: 3,
+          },
+          {
+            value: 'ONE',
+            label: 'ONE',
+            count: 2,
+          },
+          {
+            value: 'MAERSK',
+            label: 'Maersk',
+            count: 1,
+          },
+        ],
+        onToggle: () => undefined,
+        toSelectedCountLabel: (count) => `${count} selecionados`,
+      }),
+    )
+
+    expect(html).toContain('Armador: 2 selecionados')
+    expect(html).toContain('bg-control-selected-bg')
+    expect(html).toContain('MSC')
+    expect(html).toContain('ONE')
+    expect(html).toContain('Maersk')
+  })
+
+  it('shows the selected label for single-select dropdowns and keeps the all option available', () => {
+    const html = renderToString(() =>
+      createComponent(SingleSelectChipDropdown<'danger' | 'warning'>, {
+        label: 'Severidade',
+        allLabel: 'Todas',
+        testId: 'severity-filter',
+        selectedValue: 'warning',
+        options: [
+          {
+            value: 'danger',
+            label: 'Crítico',
+            count: 2,
+          },
+          {
+            value: 'warning',
+            label: 'Atenção',
+            count: 4,
+          },
+        ],
+        onSelect: () => undefined,
+        toOptionLabel: (value) => value,
+      }),
+    )
+
+    expect(html).toContain('data-testid="severity-filter"')
+    expect(html).toContain('Severidade: Atenção')
+    expect(html).toContain('Todas')
+    expect(html).toContain('Crítico')
+    expect(html).toContain('4')
+    expect(html).toContain('bg-control-selected-bg')
+  })
+
+  it('matches importer selection by importer id and renders the selected chip label', () => {
+    const html = renderToString(() =>
+      createComponent(ImporterChipDropdown, {
+        label: 'Importador',
+        allLabel: 'Todos',
+        emptyLabel: 'Nenhum importador disponível',
+        searchPlaceholder: 'Buscar importador',
+        noMatchesLabel: 'Sem resultados',
+        testId: 'importer-filter',
+        options: [
+          {
+            importerId: 'importer-1',
+            importerName: 'Flush Logistics',
+            label: 'Flush Logistics (importer-1)',
+            count: 3,
+          },
+          {
+            importerId: null,
+            importerName: 'Acme Imports',
+            label: 'Acme Imports',
+            count: 1,
+          },
+        ],
+        selectedImporterId: 'importer-1',
+        selectedImporterName: 'ignored',
+        onSelect: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('data-testid="importer-filter"')
+    expect(html).toContain('Importador: Flush Logistics (importer-1)')
+    expect(html).toContain('Buscar importador')
+    expect(html).toContain('Acme Imports')
+    expect(html).toContain('3')
+  })
+
+  it('falls back to importer name matching when the selected importer has no id', () => {
+    const html = renderToString(() =>
+      createComponent(ImporterChipDropdown, {
+        label: 'Importador',
+        allLabel: 'Todos',
+        emptyLabel: 'Nenhum importador disponível',
+        searchPlaceholder: 'Buscar importador',
+        noMatchesLabel: 'Sem resultados',
+        testId: 'importer-filter',
+        options: [
+          {
+            importerId: null,
+            importerName: 'Acme Imports',
+            label: 'Acme Imports',
+            count: 1,
+          },
+        ],
+        selectedImporterId: null,
+        selectedImporterName: ' acme imports ',
+        onSelect: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('Importador: Acme Imports')
+    expect(html).toContain('bg-control-selected-bg')
+  })
+
+  it('renders explicit empty importer state when there are no importer options', () => {
+    const html = renderToString(() =>
+      createComponent(ImporterChipDropdown, {
+        label: 'Importador',
+        allLabel: 'Todos',
+        emptyLabel: 'Nenhum importador disponível',
+        searchPlaceholder: 'Buscar importador',
+        noMatchesLabel: 'Sem resultados',
+        testId: 'importer-filter',
+        options: [],
+        selectedImporterId: null,
+        selectedImporterName: null,
+        onSelect: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('Nenhum importador disponível')
+    expect(html).toContain('Importador')
+  })
+})

--- a/src/modules/process/ui/components/unified/tests/UnifiedFilterComponents.test.tsx
+++ b/src/modules/process/ui/components/unified/tests/UnifiedFilterComponents.test.tsx
@@ -1,0 +1,88 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { ActiveFiltersPanel } from '~/modules/process/ui/components/unified/ActiveFiltersPanel'
+import { MultiSelectOptionsList } from '~/modules/process/ui/components/unified/MultiSelectOptionsList'
+import { SingleSelectOptionsList } from '~/modules/process/ui/components/unified/SingleSelectOptionsList'
+
+vi.mock('lucide-solid', () => ({
+  Check: () => null,
+}))
+
+describe('unified filter components', () => {
+  it('renders active chips for each selected dashboard filter category', () => {
+    const html = renderToString(() =>
+      createComponent(ActiveFiltersPanel, {
+        selectedSeverity: 'danger',
+        selectedProviders: ['MSC', 'ONE'],
+        selectedStatuses: ['IN_TRANSIT'],
+        selectedImporterChipLabel: 'Flush Logistics',
+        onSeveritySelect: () => undefined,
+        onProviderToggle: () => undefined,
+        onStatusToggle: () => undefined,
+        onImporterSelect: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('Filtros ativos')
+    expect(html).toContain('Severidade: Crítico')
+    expect(html).toContain('Armador: MSC')
+    expect(html).toContain('Armador: ONE')
+    expect(html).toContain('Status: Em Trânsito')
+    expect(html).toContain('Importador: Flush Logistics')
+  })
+
+  it('keeps multi-select options visibly selected and includes counts', () => {
+    const html = renderToString(() =>
+      createComponent(MultiSelectOptionsList<'MSC' | 'ONE'>, {
+        options: [
+          {
+            value: 'MSC',
+            label: 'MSC',
+            count: 3,
+          },
+          {
+            value: 'ONE',
+            label: 'ONE',
+            count: 1,
+          },
+        ],
+        isSelected: (value) => value === 'MSC',
+        onToggle: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('MSC')
+    expect(html).toContain('ONE')
+    expect(html).toContain('3')
+    expect(html).toContain('bg-control-selected-bg')
+  })
+
+  it('renders the all option and selected value for single-select controls', () => {
+    const html = renderToString(() =>
+      createComponent(SingleSelectOptionsList<'danger' | 'warning'>, {
+        allLabel: 'Todas',
+        selectedValue: 'warning',
+        options: [
+          {
+            value: 'danger',
+            label: 'Crítico',
+            count: 2,
+          },
+          {
+            value: 'warning',
+            label: 'Atenção',
+            count: 4,
+          },
+        ],
+        onSelect: () => undefined,
+      }),
+    )
+
+    expect(html).toContain('Todas')
+    expect(html).toContain('Crítico')
+    expect(html).toContain('Atenção')
+    expect(html).toContain('4')
+    expect(html).toContain('bg-control-selected-bg')
+  })
+})

--- a/src/modules/process/ui/hooks/tests/useProcessSyncRealtime.test.ts
+++ b/src/modules/process/ui/hooks/tests/useProcessSyncRealtime.test.ts
@@ -1,15 +1,42 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const subscribeToSyncRequestsRealtimeByContainerRefsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+vi.mock('~/shared/api/sync-requests.realtime.client', () => ({
+  subscribeToSyncRequestsRealtimeByContainerRefs:
+    subscribeToSyncRequestsRealtimeByContainerRefsMock,
+}))
+
+import { createRoot, createSignal } from 'solid-js'
 import {
   deriveProcessSyncStateFromContainerStates,
   pruneUnknownContainers,
   shallowEqualProcessSyncContainerStateMap,
   toProcessSyncStateFromRealtimeStatus,
+  useProcessSyncRealtime,
 } from '~/modules/process/ui/hooks/useProcessSyncRealtime'
 import {
   type ProcessListItemSource,
   toProcessSummaryVMs,
 } from '~/modules/process/ui/mappers/processList.ui-mapper'
-import type { ProcessSyncStatus } from '~/modules/process/ui/viewmodels/process-summary.vm'
+import type {
+  ProcessSummaryVM,
+  ProcessSyncStatus,
+} from '~/modules/process/ui/viewmodels/process-summary.vm'
+import type { SyncRequestRealtimeEvent } from '~/shared/api/sync-requests.realtime.client'
+
+type SubscribeByContainerRefsCommand = {
+  readonly containerNumbers: readonly string[]
+  readonly onEvent: (event: SyncRequestRealtimeEvent) => void
+}
+
+type RecordedRealtimeSubscription = {
+  readonly containerNumbers: readonly string[]
+  readonly onEvent: (event: SyncRequestRealtimeEvent) => void
+  readonly unsubscribe: ReturnType<typeof vi.fn>
+}
 
 function createProcessSyncContainerStateMap(
   input: Readonly<Record<string, Readonly<Record<string, ProcessSyncStatus>>>>,
@@ -28,6 +55,98 @@ function requireAt<T>(items: readonly T[], index: number): T {
     throw new Error(`Expected item at index ${index}`)
   }
   return item
+}
+
+function buildProcess(command: {
+  readonly id: string
+  readonly containerNumbers: readonly string[]
+}): ProcessSummaryVM {
+  return {
+    id: command.id,
+    reference: `REF-${command.id}`,
+    origin: {
+      display_name: 'Shanghai',
+    },
+    destination: {
+      display_name: 'Santos',
+    },
+    importerId: null,
+    importerName: null,
+    exporterName: null,
+    containerCount: command.containerNumbers.length,
+    containerNumbers: command.containerNumbers,
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    statusMicrobadge: null,
+    statusRank: 1,
+    eta: null,
+    etaDisplay: {
+      kind: 'unavailable',
+    },
+    etaMsOrNull: null,
+    carrier: 'MSC',
+    alertsCount: 0,
+    highestAlertSeverity: null,
+    attentionSeverity: null,
+    dominantAlertCreatedAt: null,
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      affectedContainerCount: 0,
+      topIssue: null,
+    },
+    redestinationNumber: null,
+    hasTransshipment: false,
+    lastEventAt: null,
+    syncStatus: 'idle',
+    lastSyncAt: null,
+  }
+}
+
+function buildRealtimeEvent(command: {
+  readonly status: 'PENDING' | 'DONE' | 'FAILED'
+  readonly refValue: string
+}): SyncRequestRealtimeEvent {
+  return {
+    eventType: 'UPDATE',
+    row: {
+      id: '11111111-1111-1111-1111-111111111111',
+      tenant_id: '22222222-2222-2222-2222-222222222222',
+      status: command.status,
+      last_error: null,
+      updated_at: '2026-04-11T12:00:00.000Z',
+      ref_value: command.refValue,
+      leased_by: null,
+      leased_until: null,
+    },
+    oldRow: null,
+  }
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function createHookHarness(command: {
+  readonly initialProcesses: readonly ProcessSummaryVM[]
+  readonly onRealtimeStateChanged?: () => void
+}) {
+  return createRoot((dispose) => {
+    const [processes, setProcesses] = createSignal(command.initialProcesses)
+    const onRealtimeStateChanged = command.onRealtimeStateChanged ?? vi.fn()
+    const processSyncStates = useProcessSyncRealtime({
+      processes,
+      onRealtimeStateChanged,
+    })
+
+    return {
+      processSyncStates,
+      setProcesses,
+      onRealtimeStateChanged,
+      dispose,
+    }
+  })
 }
 
 describe('useProcessSyncRealtime helpers', () => {
@@ -128,5 +247,111 @@ describe('useProcessSyncRealtime helpers', () => {
     })
 
     expect(shallowEqualProcessSyncContainerStateMap(currentState, nextState)).toBe(false)
+  })
+})
+
+describe('useProcessSyncRealtime behavior', () => {
+  let subscriptions: RecordedRealtimeSubscription[]
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    subscriptions = []
+    subscribeToSyncRequestsRealtimeByContainerRefsMock.mockReset()
+    subscribeToSyncRequestsRealtimeByContainerRefsMock.mockImplementation(
+      (command: SubscribeByContainerRefsCommand) => {
+        const unsubscribe = vi.fn()
+        subscriptions.push({
+          containerNumbers: command.containerNumbers,
+          onEvent: command.onEvent,
+          unsubscribe,
+        })
+
+        return { unsubscribe }
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('marks a process as syncing from realtime and reconciles after terminal events', async () => {
+    const onRealtimeStateChanged = vi.fn()
+    const harness = createHookHarness({
+      initialProcesses: [buildProcess({ id: 'process-1', containerNumbers: [' mscu1234567 '] })],
+      onRealtimeStateChanged,
+    })
+
+    await flushAsyncWork()
+
+    expect(subscriptions).toHaveLength(1)
+    expect(subscriptions[0]?.containerNumbers).toEqual(['MSCU1234567'])
+
+    subscriptions[0]?.onEvent(buildRealtimeEvent({ status: 'PENDING', refValue: 'mscu1234567' }))
+    await flushAsyncWork()
+
+    expect(harness.processSyncStates()).toEqual({
+      'process-1': 'syncing',
+    })
+
+    subscriptions[0]?.onEvent(buildRealtimeEvent({ status: 'DONE', refValue: 'MSCU1234567' }))
+    await flushAsyncWork()
+
+    expect(harness.processSyncStates()).toEqual({})
+    expect(onRealtimeStateChanged).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(onRealtimeStateChanged).toHaveBeenCalledTimes(1)
+
+    harness.dispose()
+    expect(subscriptions[0]?.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reconciles terminal events even when no local realtime state changed', async () => {
+    const onRealtimeStateChanged = vi.fn()
+    const harness = createHookHarness({
+      initialProcesses: [buildProcess({ id: 'process-1', containerNumbers: ['MSCU1234567'] })],
+      onRealtimeStateChanged,
+    })
+
+    await flushAsyncWork()
+
+    subscriptions[0]?.onEvent(buildRealtimeEvent({ status: 'FAILED', refValue: 'MSCU1234567' }))
+    await flushAsyncWork()
+
+    expect(harness.processSyncStates()).toEqual({})
+
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(onRealtimeStateChanged).toHaveBeenCalledTimes(1)
+    harness.dispose()
+  })
+
+  it('prunes stale container state and resubscribes when tracked containers change', async () => {
+    const harness = createHookHarness({
+      initialProcesses: [buildProcess({ id: 'process-1', containerNumbers: ['MSCU1234567'] })],
+    })
+
+    await flushAsyncWork()
+
+    subscriptions[0]?.onEvent(buildRealtimeEvent({ status: 'PENDING', refValue: 'MSCU1234567' }))
+    await flushAsyncWork()
+
+    expect(harness.processSyncStates()).toEqual({
+      'process-1': 'syncing',
+    })
+
+    harness.setProcesses([buildProcess({ id: 'process-1', containerNumbers: ['MRKU7654321'] })])
+    await flushAsyncWork()
+
+    expect(subscriptions).toHaveLength(2)
+    expect(subscriptions[0]?.unsubscribe).toHaveBeenCalledTimes(1)
+    expect(subscriptions[1]?.containerNumbers).toEqual(['MRKU7654321'])
+    expect(harness.processSyncStates()).toEqual({})
+
+    harness.dispose()
+    expect(subscriptions[1]?.unsubscribe).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardFilterSortController.test.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardFilterSortController.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const emitDashboardSortChangedTelemetryMock = vi.hoisted(() => vi.fn())
+const readDashboardFiltersFromLocalStorageMock = vi.hoisted(() => vi.fn())
+const writeDashboardFiltersToLocalStorageMock = vi.hoisted(() => vi.fn())
+const readDashboardSortFromLocalStorageMock = vi.hoisted(() => vi.fn())
+const writeDashboardSortToLocalStorageMock = vi.hoisted(() => vi.fn())
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+vi.mock('~/modules/process/ui/telemetry/dashboardSort.telemetry', () => ({
+  emitDashboardSortChangedTelemetry: emitDashboardSortChangedTelemetryMock,
+}))
+
+vi.mock('~/modules/process/ui/validation/dashboardFilterStorage.validation', () => ({
+  readDashboardFiltersFromLocalStorage: readDashboardFiltersFromLocalStorageMock,
+  writeDashboardFiltersToLocalStorage: writeDashboardFiltersToLocalStorageMock,
+}))
+
+vi.mock('~/modules/process/ui/validation/dashboardSortStorage.validation', () => ({
+  readDashboardSortFromLocalStorage: readDashboardSortFromLocalStorageMock,
+  writeDashboardSortToLocalStorage: writeDashboardSortToLocalStorageMock,
+}))
+
+import { createRoot } from 'solid-js'
+import { useDashboardFilterSortController } from '~/modules/process/ui/screens/dashboard/hooks/useDashboardFilterSortController'
+import { DASHBOARD_DEFAULT_FILTER_SELECTION } from '~/modules/process/ui/viewmodels/dashboard-filter.service'
+import { DASHBOARD_DEFAULT_SORT_SELECTION } from '~/modules/process/ui/viewmodels/dashboard-sort.vm'
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function createControllerHarness() {
+  return createRoot((dispose) => ({
+    controller: useDashboardFilterSortController(),
+    dispose,
+  }))
+}
+
+describe('useDashboardFilterSortController', () => {
+  beforeEach(() => {
+    emitDashboardSortChangedTelemetryMock.mockReset()
+    readDashboardFiltersFromLocalStorageMock.mockReset()
+    writeDashboardFiltersToLocalStorageMock.mockReset()
+    readDashboardSortFromLocalStorageMock.mockReset()
+    writeDashboardSortToLocalStorageMock.mockReset()
+    readDashboardSortFromLocalStorageMock.mockReturnValue(DASHBOARD_DEFAULT_SORT_SELECTION)
+    readDashboardFiltersFromLocalStorageMock.mockReturnValue(DASHBOARD_DEFAULT_FILTER_SELECTION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('hydrates sort and filters from local storage on mount', async () => {
+    readDashboardSortFromLocalStorageMock.mockReturnValue({
+      field: 'alerts',
+      direction: 'desc',
+    })
+    readDashboardFiltersFromLocalStorageMock.mockReturnValue({
+      providers: ['MSC'],
+      statuses: ['IN_TRANSIT'],
+      importerId: 'importer-1',
+      importerName: 'Acme Imports',
+      severity: 'warning',
+    })
+    const harness = createControllerHarness()
+
+    await flushAsyncWork()
+
+    expect(harness.controller.isHydrated()).toBe(true)
+    expect(harness.controller.sortSelection()).toEqual({
+      field: 'alerts',
+      direction: 'desc',
+    })
+    expect(harness.controller.filterSelection()).toEqual({
+      providers: ['MSC'],
+      statuses: ['IN_TRANSIT'],
+      importerId: 'importer-1',
+      importerName: 'Acme Imports',
+      severity: 'warning',
+    })
+
+    harness.dispose()
+  })
+
+  it('persists sort changes and emits telemetry with the next selection', async () => {
+    const harness = createControllerHarness()
+
+    await flushAsyncWork()
+
+    harness.controller.handleSortToggle('eta')
+
+    expect(harness.controller.sortSelection()).toEqual({
+      field: 'eta',
+      direction: 'asc',
+    })
+    expect(emitDashboardSortChangedTelemetryMock).toHaveBeenCalledWith('user', 'eta', {
+      field: 'eta',
+      direction: 'asc',
+    })
+    expect(writeDashboardSortToLocalStorageMock).toHaveBeenCalledWith({
+      field: 'eta',
+      direction: 'asc',
+    })
+
+    harness.dispose()
+  })
+
+  it('persists filter toggles, selects, and clear-all without inventing extra state', async () => {
+    const harness = createControllerHarness()
+
+    await flushAsyncWork()
+
+    harness.controller.handleProviderFilterToggle('MSC')
+    expect(writeDashboardFiltersToLocalStorageMock).toHaveBeenLastCalledWith({
+      providers: ['MSC'],
+      statuses: [],
+      importerId: null,
+      importerName: null,
+      severity: null,
+    })
+
+    harness.controller.handleStatusFilterToggle('IN_TRANSIT')
+    expect(writeDashboardFiltersToLocalStorageMock).toHaveBeenLastCalledWith({
+      providers: ['MSC'],
+      statuses: ['IN_TRANSIT'],
+      importerId: null,
+      importerName: null,
+      severity: null,
+    })
+
+    harness.controller.handleImporterFilterSelect({
+      importerId: 'importer-1',
+      importerName: 'Acme Imports',
+    })
+    expect(writeDashboardFiltersToLocalStorageMock).toHaveBeenLastCalledWith({
+      providers: ['MSC'],
+      statuses: ['IN_TRANSIT'],
+      importerId: 'importer-1',
+      importerName: 'Acme Imports',
+      severity: null,
+    })
+
+    harness.controller.handleSeverityFilterSelect('danger')
+    expect(writeDashboardFiltersToLocalStorageMock).toHaveBeenLastCalledWith({
+      providers: ['MSC'],
+      statuses: ['IN_TRANSIT'],
+      importerId: 'importer-1',
+      importerName: 'Acme Imports',
+      severity: 'danger',
+    })
+
+    harness.controller.handleClearAllFilters()
+    expect(harness.controller.filterSelection()).toEqual(DASHBOARD_DEFAULT_FILTER_SELECTION)
+    expect(writeDashboardFiltersToLocalStorageMock).toHaveBeenLastCalledWith(
+      DASHBOARD_DEFAULT_FILTER_SELECTION,
+    )
+
+    harness.dispose()
+  })
+})

--- a/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.behavior.test.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.behavior.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProcessSummaryVM } from '~/modules/process/ui/viewmodels/process-summary.vm'
+
+const fetchProcessesSyncStatusMock = vi.hoisted(() => vi.fn())
+const syncAllProcessesRequestMock = vi.hoisted(() => vi.fn())
+const syncProcessRequestMock = vi.hoisted(() => vi.fn())
+const refreshDashboardDataMock = vi.hoisted(() => vi.fn())
+const realtimeState = vi.hoisted(() => ({
+  current: {},
+}))
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+vi.mock('~/modules/process/ui/api/processSync.api', () => ({
+  fetchProcessesSyncStatus: fetchProcessesSyncStatusMock,
+  syncAllProcessesRequest: syncAllProcessesRequestMock,
+  syncProcessRequest: syncProcessRequestMock,
+}))
+
+vi.mock('~/modules/process/ui/hooks/useProcessSyncRealtime', () => ({
+  useProcessSyncRealtime: () => () => realtimeState.current,
+}))
+
+vi.mock('~/modules/process/ui/utils/dashboard-refresh', () => ({
+  refreshDashboardData: refreshDashboardDataMock,
+}))
+
+import { createRoot } from 'solid-js'
+import { useDashboardSyncController } from '~/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController'
+
+type Deferred<T> = {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T) => void
+  readonly reject: (reason: unknown) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveDeferred: ((value: T) => void) | undefined
+  let rejectDeferred: ((reason: unknown) => void) | undefined
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveDeferred = resolve
+    rejectDeferred = reject
+  })
+
+  if (resolveDeferred === undefined || rejectDeferred === undefined) {
+    throw new Error('Failed to create deferred promise')
+  }
+
+  return {
+    promise,
+    resolve: resolveDeferred,
+    reject: rejectDeferred,
+  }
+}
+
+function buildProcess(id: string, syncStatus: ProcessSummaryVM['syncStatus']): ProcessSummaryVM {
+  return {
+    id,
+    reference: `REF-${id}`,
+    origin: {
+      display_name: 'Shanghai',
+    },
+    destination: {
+      display_name: 'Santos',
+    },
+    importerId: null,
+    importerName: null,
+    exporterName: null,
+    containerCount: 1,
+    containerNumbers: ['MSCU1234567'],
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    statusMicrobadge: null,
+    statusRank: 1,
+    eta: null,
+    etaDisplay: {
+      kind: 'unavailable',
+    },
+    etaMsOrNull: null,
+    carrier: 'MSC',
+    alertsCount: 0,
+    highestAlertSeverity: null,
+    attentionSeverity: null,
+    dominantAlertCreatedAt: null,
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      affectedContainerCount: 0,
+      topIssue: null,
+    },
+    redestinationNumber: null,
+    hasTransshipment: false,
+    lastEventAt: null,
+    syncStatus,
+    lastSyncAt: null,
+  }
+}
+
+function createControllerHarness(processes: readonly ProcessSummaryVM[]) {
+  return createRoot((dispose) => {
+    const refetchProcesses = vi.fn()
+    const controller = useDashboardSyncController({
+      allProcesses: () => processes,
+      sortedProcesses: () => processes,
+      refetchProcesses,
+      refetchGlobalAlerts: vi.fn(),
+      refetchDashboardKpis: vi.fn(),
+      refetchDashboardProcessesCreatedByMonth: vi.fn(),
+    })
+
+    return {
+      controller,
+      refetchProcesses,
+      dispose,
+    }
+  })
+}
+
+describe('useDashboardSyncController behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    fetchProcessesSyncStatusMock.mockReset()
+    syncAllProcessesRequestMock.mockReset()
+    syncProcessRequestMock.mockReset()
+    refreshDashboardDataMock.mockReset()
+    realtimeState.current = {}
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('shows process-level syncing immediately, then success, then expires local feedback', async () => {
+    const syncDeferred = createDeferred<void>()
+    syncProcessRequestMock.mockReturnValue(syncDeferred.promise)
+    const harness = createControllerHarness([buildProcess('process-1', 'idle')])
+
+    const syncPromise = harness.controller.handleProcessSync('process-1')
+
+    expect(harness.controller.processesWithSyncFeedback()[0]?.syncStatus).toBe('syncing')
+
+    syncDeferred.resolve()
+    await syncPromise
+
+    expect(syncProcessRequestMock).toHaveBeenCalledWith('process-1')
+    expect(harness.refetchProcesses).toHaveBeenCalledTimes(1)
+    expect(harness.controller.processesWithSyncFeedback()[0]?.syncStatus).toBe('success')
+
+    await vi.advanceTimersByTimeAsync(2_600)
+
+    expect(harness.controller.processesWithSyncFeedback()[0]?.syncStatus).toBe('idle')
+    harness.dispose()
+  })
+
+  it('marks all current rows with transient success after dashboard refresh', async () => {
+    refreshDashboardDataMock.mockResolvedValue(undefined)
+    const harness = createControllerHarness([
+      buildProcess('process-1', 'idle'),
+      buildProcess('process-2', 'idle'),
+    ])
+
+    await harness.controller.handleDashboardRefresh()
+
+    expect(refreshDashboardDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        syncAllProcesses: syncAllProcessesRequestMock,
+      }),
+    )
+    expect(
+      harness.controller.processesWithSyncFeedback().map((process) => process.syncStatus),
+    ).toEqual(['success', 'success'])
+
+    await vi.advanceTimersByTimeAsync(2_600)
+
+    expect(
+      harness.controller.processesWithSyncFeedback().map((process) => process.syncStatus),
+    ).toEqual(['idle', 'idle'])
+    harness.dispose()
+  })
+
+  it('keeps server state authoritative after process sync failure and exposes transient error feedback', async () => {
+    syncProcessRequestMock.mockRejectedValue(new Error('sync failed'))
+    const harness = createControllerHarness([buildProcess('process-1', 'idle')])
+
+    await harness.controller.handleProcessSync('process-1')
+
+    expect(harness.refetchProcesses).toHaveBeenCalledTimes(1)
+    expect(harness.controller.processesWithSyncFeedback()[0]?.syncStatus).toBe('error')
+
+    await vi.advanceTimersByTimeAsync(2_600)
+
+    expect(harness.controller.processesWithSyncFeedback()[0]?.syncStatus).toBe('idle')
+    harness.dispose()
+  })
+})

--- a/src/modules/process/ui/screens/shipment/ShipmentScreen.test.tsx
+++ b/src/modules/process/ui/screens/shipment/ShipmentScreen.test.tsx
@@ -1,0 +1,441 @@
+import { createComponent, createMemo } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AlertDisplayVM } from '~/modules/process/ui/viewmodels/alert.vm'
+import type { ShipmentDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
+
+const locationState = vi.hoisted(() => ({
+  search: '?container=mscu7654321',
+  state: null,
+}))
+const navigateMock = vi.hoisted(() => vi.fn())
+const preloadRouteMock = vi.hoisted(() => vi.fn())
+const useShipmentScreenResourceMock = vi.hoisted(() => vi.fn())
+const useShipmentSelectedContainerMock = vi.hoisted(() => vi.fn())
+const useTrackingTimeTravelControllerMock = vi.hoisted(() => vi.fn())
+const useShipmentRefreshControllerMock = vi.hoisted(() => vi.fn())
+const useShipmentDialogsControllerMock = vi.hoisted(() => vi.fn())
+const useShipmentAlertActionsControllerMock = vi.hoisted(() => vi.fn())
+const useShipmentAlertNavigationMock = vi.hoisted(() => vi.fn())
+const scheduleDashboardPrefetchMock = vi.hoisted(() => vi.fn())
+const prefetchDashboardDataMock = vi.hoisted(() => vi.fn())
+const hasDashboardNavigationStateMock = vi.hoisted(() => vi.fn(() => true))
+
+type ShipmentContainersViewProps = {
+  readonly activeAlerts: () => readonly AlertDisplayVM[]
+  readonly alertIncidents: () => ShipmentDetailVM['alertIncidents']
+  readonly selectedContainerId: () => string
+  readonly onAcknowledgeAlert: (alertIds: readonly string[]) => void
+  readonly onUnacknowledgeAlert: (alertIds: readonly string[]) => void
+  readonly onTriggerRefresh: () => void
+  readonly onSelectContainer: (id: string) => void
+  readonly onOpenEditForShipment: (
+    shipment: ShipmentDetailVM,
+    focus?: 'reference' | 'carrier' | null | undefined,
+  ) => void
+}
+
+type ShipmentScreenLayoutProps = {
+  readonly preserveDashboardScroll: boolean
+  readonly onOpenCreateProcess: () => void
+  readonly onDashboardIntent: () => void
+  readonly actionsSlot: import('solid-js').JSX.Element
+  readonly banners: import('solid-js').JSX.Element
+  readonly dialogs: import('solid-js').JSX.Element
+  readonly content: import('solid-js').JSX.Element
+}
+
+const capturedShipmentInteractions = vi.hoisted<{
+  openCreate: (() => () => void) | undefined
+  dashboardIntent: (() => () => void) | undefined
+  selectContainer: (() => (id: string) => void) | undefined
+  triggerRefresh: (() => () => void) | undefined
+  acknowledgeAlerts: (() => (alertIds: readonly string[]) => void) | undefined
+  unacknowledgeAlerts: (() => (alertIds: readonly string[]) => void) | undefined
+  openEditForShipment:
+    | (() => (
+        shipment: ShipmentDetailVM,
+        focus?: 'reference' | 'carrier' | null | undefined,
+      ) => void)
+    | undefined
+}>(() => ({
+  openCreate: undefined,
+  dashboardIntent: undefined,
+  selectContainer: undefined,
+  triggerRefresh: undefined,
+  acknowledgeAlerts: undefined,
+  unacknowledgeAlerts: undefined,
+  openEditForShipment: undefined,
+}))
+
+vi.mock('@solidjs/router', () => ({
+  useLocation: () => locationState,
+  useNavigate: () => navigateMock,
+  usePreloadRoute: () => preloadRouteMock,
+}))
+
+vi.mock('~/modules/process/ui/api/process.api', () => ({
+  prefetchDashboardData: prefetchDashboardDataMock,
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/hooks/useShipmentScreenResource', () => ({
+  useShipmentScreenResource: useShipmentScreenResourceMock,
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/hooks/useShipmentSelectedContainer', () => ({
+  useShipmentSelectedContainer: useShipmentSelectedContainerMock,
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/hooks/useTrackingTimeTravelController', () => ({
+  useTrackingTimeTravelController: useTrackingTimeTravelControllerMock,
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/hooks/useShipmentRefreshController', () => ({
+  useShipmentRefreshController: useShipmentRefreshControllerMock,
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/hooks/useShipmentDialogsController', () => ({
+  useShipmentDialogsController: useShipmentDialogsControllerMock,
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/hooks/useShipmentAlertActionsController', () => ({
+  useShipmentAlertActionsController: useShipmentAlertActionsControllerMock,
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/hooks/useShipmentAlertNavigation', () => ({
+  useShipmentAlertNavigation: useShipmentAlertNavigationMock,
+}))
+
+vi.mock('~/modules/process/ui/utils/dashboard-navigation-state', () => ({
+  hasDashboardNavigationState: hasDashboardNavigationStateMock,
+}))
+
+vi.mock('~/shared/ui/navigation/app-navigation', () => ({
+  readProcessContainerNavigationState: vi.fn(() => null),
+  readProcessContainerNavigationStateFromSearch: vi.fn(() => null),
+  scheduleDashboardPrefetch: scheduleDashboardPrefetchMock,
+}))
+
+vi.mock('~/modules/process/ui/components/export-import/ExportImportActions', () => ({
+  ExportImportActions: (props: {
+    readonly processId: string | null
+    readonly showImport: boolean
+  }) => (
+    <div>
+      export-import:{props.processId ?? 'null'}:{String(props.showImport)}
+    </div>
+  ),
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/components/ShipmentRefreshStatusView', () => ({
+  ShipmentRefreshStatusView: (props: { readonly refreshError: () => string | null }) => (
+    <div>refresh-status:{props.refreshError() ?? 'none'}</div>
+  ),
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/components/ShipmentAlertActionFeedback', () => ({
+  ShipmentAlertActionFeedback: (props: { readonly alertActionError: () => string | null }) => (
+    <div>alert-feedback:{props.alertActionError() ?? 'none'}</div>
+  ),
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/components/ShipmentDialogsHost', () => ({
+  ShipmentDialogsHost: (props: {
+    readonly isEditOpen: () => boolean
+    readonly isCreateDialogOpen: () => boolean
+  }) => (
+    <div>
+      dialogs:{String(props.isEditOpen())}:{String(props.isCreateDialogOpen())}
+    </div>
+  ),
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/components/ShipmentContainersView', () => ({
+  ShipmentContainersView: (props: ShipmentContainersViewProps) => {
+    capturedShipmentInteractions.selectContainer = createMemo(() => props.onSelectContainer)
+    capturedShipmentInteractions.triggerRefresh = createMemo(() => props.onTriggerRefresh)
+    capturedShipmentInteractions.acknowledgeAlerts = createMemo(() => props.onAcknowledgeAlert)
+    capturedShipmentInteractions.unacknowledgeAlerts = createMemo(() => props.onUnacknowledgeAlert)
+    capturedShipmentInteractions.openEditForShipment = createMemo(() => props.onOpenEditForShipment)
+
+    return (
+      <div>
+        containers:{props.selectedContainerId()}:{props.activeAlerts().length}:
+        {props.alertIncidents().summary.activeIncidents}
+      </div>
+    )
+  },
+}))
+
+vi.mock('~/modules/process/ui/screens/shipment/components/ShipmentScreenLayout', () => ({
+  ShipmentScreenLayout: (props: ShipmentScreenLayoutProps) => {
+    capturedShipmentInteractions.openCreate = createMemo(() => props.onOpenCreateProcess)
+    capturedShipmentInteractions.dashboardIntent = createMemo(() => props.onDashboardIntent)
+
+    return (
+      <div>
+        layout:{String(props.preserveDashboardScroll)}
+        {props.actionsSlot}
+        {props.banners}
+        {props.dialogs}
+        {props.content}
+      </div>
+    )
+  },
+}))
+
+import { ShipmentScreen } from '~/modules/process/ui/screens/shipment/ShipmentScreen'
+
+function normalizeSsrHtml(html: string): string {
+  return html.replaceAll('<!--$-->', '').replaceAll('<!--/-->', '')
+}
+
+function buildShipment(): ShipmentDetailVM {
+  return {
+    id: 'process-1',
+    trackingFreshnessToken: 'freshness-1',
+    processRef: 'REF-1',
+    reference: 'REF-1',
+    carrier: 'MSC',
+    bill_of_lading: null,
+    booking_number: null,
+    importer_name: null,
+    exporter_name: null,
+    reference_importer: null,
+    depositary: null,
+    product: null,
+    redestination_number: null,
+    origin: 'Shanghai',
+    destination: 'Santos',
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    statusMicrobadge: null,
+    eta: null,
+    processEtaDisplayVm: {
+      kind: 'unavailable',
+    },
+    processEtaSecondaryVm: {
+      visible: false,
+      date: null,
+      withEta: 0,
+      total: 1,
+      incomplete: false,
+    },
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      affectedContainerCount: 0,
+      topIssue: null,
+    },
+    containers: [],
+    alerts: [
+      {
+        id: 'alert-1',
+        type: 'info',
+        severity: 'warning',
+        containerNumber: 'MSCU7654321',
+        messageKey: 'alerts.transshipmentDetected',
+        messageParams: {
+          port: 'KRPUS',
+          fromVessel: 'MSC IRIS',
+          toVessel: 'MSC BIANCA SILVIA',
+        },
+        timestamp: '2026-04-10T10:00:00.000Z',
+        triggeredAtIso: '2026-04-10T10:00:00.000Z',
+        ackedAtIso: null,
+        lifecycleState: 'ACTIVE',
+        category: 'fact',
+        retroactive: false,
+      },
+    ],
+    alertIncidents: {
+      summary: {
+        activeIncidents: 1,
+        affectedContainers: 1,
+        recognizedIncidents: 0,
+      },
+      active: [],
+      recognized: [],
+    },
+  }
+}
+
+function buildHookState() {
+  const shipment = buildShipment()
+  return {
+    resource: {
+      shipment: (): ShipmentDetailVM | null | undefined => shipment,
+      latestShipment: (): ShipmentDetailVM | null | undefined => shipment,
+      loading: () => false,
+      error: () => null,
+      refetch: vi.fn(),
+      mutate: vi.fn(),
+      processResourceKey: () => ['process-1', 'pt-BR'] as const,
+      reconcileTrackingView: vi.fn(() => Promise.resolve()),
+    },
+    selection: {
+      selectedContainerId: () => 'container-1',
+      setSelectedContainerId: vi.fn(),
+      selectedContainer: () => null,
+      selectedContainerEtaVm: () => null,
+    },
+    trackingTimeTravel: {
+      isActive: () => false,
+      isLoading: () => false,
+      errorMessage: () => null,
+      value: () => null,
+      selectedSync: () => null,
+      isDebugOpen: () => false,
+      isDebugLoading: () => false,
+      debugErrorMessage: () => null,
+      debugValue: () => null,
+      debugPayload: () => null,
+      open: vi.fn(),
+      close: vi.fn(),
+      toggleDebug: vi.fn(),
+      selectSnapshot: vi.fn(),
+      selectPrevious: vi.fn(),
+      selectNext: vi.fn(),
+    },
+    refresh: {
+      isRefreshing: () => false,
+      refreshRetry: () => null,
+      refreshError: () => 'refresh failed',
+      refreshHint: () => null,
+      syncNow: () => ({ toIsoString: () => '2026-04-10T10:00:00.000Z' }),
+      triggerRefresh: vi.fn(() => Promise.resolve()),
+      clearRefreshError: vi.fn(),
+      resetRefreshState: vi.fn(),
+      cleanupRealtime: vi.fn(),
+    },
+    dialogs: {
+      openCreateDialog: vi.fn(),
+      isEditOpen: () => true,
+      closeEditDialog: vi.fn(),
+      editInitialData: () => null,
+      focusFieldOnOpen: () => null,
+      handleEditSubmit: vi.fn(() => Promise.resolve()),
+      isCreateDialogOpen: () => false,
+      closeCreateDialog: vi.fn(),
+      handleCreateSubmit: vi.fn(() => Promise.resolve()),
+      hasCreateError: () => false,
+      createErrorMessage: () => null,
+      createErrorExisting: () => false,
+      clearCreateError: vi.fn(),
+      openEditForShipment: vi.fn(),
+    },
+    alertActions: {
+      busyAlertIds: () => new Set<string>(),
+      acknowledgeAlerts: vi.fn(),
+      unacknowledgeAlerts: vi.fn(),
+      alertActionError: () => 'ack failed',
+      clearAlertActionError: vi.fn(),
+    },
+  }
+}
+
+describe('ShipmentScreen', () => {
+  beforeEach(() => {
+    const state = buildHookState()
+    useShipmentScreenResourceMock.mockReturnValue(state.resource)
+    useShipmentSelectedContainerMock.mockReturnValue(state.selection)
+    useTrackingTimeTravelControllerMock.mockReturnValue(state.trackingTimeTravel)
+    useShipmentRefreshControllerMock.mockReturnValue(state.refresh)
+    useShipmentDialogsControllerMock.mockReturnValue(state.dialogs)
+    useShipmentAlertActionsControllerMock.mockReturnValue(state.alertActions)
+    useShipmentAlertNavigationMock.mockReset()
+    prefetchDashboardDataMock.mockReset()
+    scheduleDashboardPrefetchMock.mockReset()
+    capturedShipmentInteractions.openCreate = undefined
+    capturedShipmentInteractions.dashboardIntent = undefined
+    capturedShipmentInteractions.selectContainer = undefined
+    capturedShipmentInteractions.triggerRefresh = undefined
+    capturedShipmentInteractions.acknowledgeAlerts = undefined
+    capturedShipmentInteractions.unacknowledgeAlerts = undefined
+    capturedShipmentInteractions.openEditForShipment = undefined
+  })
+
+  it('wires shipment hooks and passes rendered slots into the layout', () => {
+    const html = normalizeSsrHtml(
+      renderToString(() =>
+        createComponent(ShipmentScreen, {
+          processId: () => 'process-1',
+          searchSlot: <div>search-slot</div>,
+        }),
+      ),
+    )
+
+    expect(useShipmentScreenResourceMock).toHaveBeenCalled()
+    expect(useShipmentSelectedContainerMock).toHaveBeenCalled()
+    expect(useShipmentSelectedContainerMock.mock.calls[0]?.[0].preferredContainerNumber()).toBe(
+      'MSCU7654321',
+    )
+    expect(useShipmentAlertNavigationMock).toHaveBeenCalled()
+    expect(html).toContain('layout:true')
+    expect(html).toContain('export-import:process-1:false')
+    expect(html).toContain('refresh-status:refresh failed')
+    expect(html).toContain('alert-feedback:ack failed')
+    expect(html).toContain('dialogs:true:false')
+    expect(html).toContain('containers:container-1:1:1')
+  })
+
+  it('falls back to empty alert incident summary when shipment data is unavailable', () => {
+    const state = buildHookState()
+    state.resource.latestShipment = () => null
+    state.resource.shipment = () => null
+    useShipmentScreenResourceMock.mockReturnValue(state.resource)
+
+    const html = normalizeSsrHtml(
+      renderToString(() =>
+        createComponent(ShipmentScreen, {
+          processId: () => 'process-2',
+        }),
+      ),
+    )
+
+    expect(html).toContain('containers:container-1:0:0')
+  })
+
+  it('forwards dashboard and container actions to the appropriate controllers', async () => {
+    const state = buildHookState()
+    useShipmentScreenResourceMock.mockReturnValue(state.resource)
+    useShipmentSelectedContainerMock.mockReturnValue(state.selection)
+    useTrackingTimeTravelControllerMock.mockReturnValue(state.trackingTimeTravel)
+    useShipmentRefreshControllerMock.mockReturnValue(state.refresh)
+    useShipmentDialogsControllerMock.mockReturnValue(state.dialogs)
+    useShipmentAlertActionsControllerMock.mockReturnValue(state.alertActions)
+
+    renderToString(() =>
+      createComponent(ShipmentScreen, {
+        processId: () => 'process-1',
+      }),
+    )
+
+    capturedShipmentInteractions.openCreate?.()()
+    capturedShipmentInteractions.dashboardIntent?.()()
+    capturedShipmentInteractions.selectContainer?.()('container-2')
+    capturedShipmentInteractions.triggerRefresh?.()()
+    capturedShipmentInteractions.acknowledgeAlerts?.()(['alert-1'])
+    capturedShipmentInteractions.unacknowledgeAlerts?.()(['alert-1'])
+
+    const shipment = state.resource.latestShipment()
+    if (shipment) {
+      capturedShipmentInteractions.openEditForShipment?.()(shipment, 'carrier')
+    }
+
+    expect(state.dialogs.openCreateDialog).toHaveBeenCalledTimes(1)
+    expect(scheduleDashboardPrefetchMock).toHaveBeenCalledTimes(1)
+    expect(scheduleDashboardPrefetchMock.mock.calls[0]?.[0].priority).toBe('intent')
+
+    await scheduleDashboardPrefetchMock.mock.calls[0]?.[0].preloadData()
+
+    expect(prefetchDashboardDataMock).toHaveBeenCalledWith({
+      windowSize: 6,
+    })
+    expect(state.selection.setSelectedContainerId).toHaveBeenCalledWith('container-2')
+    expect(state.refresh.triggerRefresh).toHaveBeenCalledTimes(1)
+    expect(state.alertActions.acknowledgeAlerts).toHaveBeenCalledWith(['alert-1'])
+    expect(state.alertActions.unacknowledgeAlerts).toHaveBeenCalledWith(['alert-1'])
+    expect(state.dialogs.openEditForShipment).toHaveBeenCalledWith(shipment, 'carrier')
+  })
+})

--- a/src/modules/process/ui/screens/shipment/components/ShipmentScreenLayout.test.tsx
+++ b/src/modules/process/ui/screens/shipment/components/ShipmentScreenLayout.test.tsx
@@ -1,0 +1,114 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { ShipmentScreenLayout } from '~/modules/process/ui/screens/shipment/components/ShipmentScreenLayout'
+import type { ShipmentDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
+
+vi.mock('@solidjs/router', () => ({
+  A: (props: { readonly children?: unknown }) => <>{props.children}</>,
+}))
+
+vi.mock('~/shared/ui/AppHeader', () => ({
+  AppHeader: () => <header>App header</header>,
+}))
+
+function renderLayout(command: {
+  readonly data: ShipmentDetailVM | null | undefined
+  readonly loading: boolean
+  readonly error: unknown
+  readonly content?: string
+}): string {
+  return renderToString(() =>
+    createComponent(ShipmentScreenLayout, {
+      shipmentData: () => command.data,
+      shipmentLoading: () => command.loading,
+      shipmentError: () => command.error,
+      onOpenCreateProcess: () => undefined,
+      onDashboardIntent: () => undefined,
+      preserveDashboardScroll: false,
+      banners: <div>banner slot</div>,
+      dialogs: <div>dialog slot</div>,
+      content: <section>{command.content ?? 'timeline-first content'}</section>,
+    }),
+  )
+}
+
+describe('ShipmentScreenLayout', () => {
+  it('renders the loading skeleton before shipment data exists', () => {
+    const html = renderLayout({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    })
+
+    expect(html).toContain('shipment-container-skeleton-1')
+    expect(html).not.toContain('timeline-first content')
+  })
+
+  it('renders explicit error and not-found states instead of stale content', () => {
+    const errorHtml = renderLayout({
+      data: undefined,
+      loading: false,
+      error: new Error('load failed'),
+    })
+    const notFoundHtml = renderLayout({
+      data: null,
+      loading: false,
+      error: undefined,
+    })
+
+    expect(errorHtml).toContain('Falha ao carregar detalhes do processo')
+    expect(errorHtml).not.toContain('timeline-first content')
+    expect(notFoundHtml).toContain('Processo não encontrado')
+    expect(notFoundHtml).not.toContain('timeline-first content')
+  })
+
+  it('renders provided shipment content only when ready', () => {
+    const html = renderLayout({
+      data: {
+        id: 'process-1',
+        trackingFreshnessToken: 'freshness-1',
+        processRef: 'REF-1',
+        origin: 'Shanghai',
+        destination: 'Santos',
+        status: 'in-transit',
+        statusCode: 'IN_TRANSIT',
+        statusMicrobadge: null,
+        eta: null,
+        processEtaDisplayVm: {
+          kind: 'unavailable',
+        },
+        processEtaSecondaryVm: {
+          visible: false,
+          date: null,
+          withEta: 0,
+          total: 0,
+          incomplete: false,
+        },
+        trackingValidation: {
+          hasIssues: false,
+          highestSeverity: null,
+          affectedContainerCount: 0,
+          topIssue: null,
+        },
+        containers: [],
+        alerts: [],
+        alertIncidents: {
+          summary: {
+            activeIncidents: 0,
+            affectedContainers: 0,
+            recognizedIncidents: 0,
+          },
+          active: [],
+          recognized: [],
+        },
+      },
+      loading: false,
+      error: undefined,
+      content: 'container selector before timeline',
+    })
+
+    expect(html).toContain('container selector before timeline')
+    expect(html).not.toContain('shipment-container-skeleton-1')
+  })
+})

--- a/src/modules/process/ui/screens/shipment/hooks/useShipmentRefreshController.test.ts
+++ b/src/modules/process/ui/screens/shipment/hooks/useShipmentRefreshController.test.ts
@@ -1,0 +1,195 @@
+import { createRoot, createSignal } from 'solid-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ShipmentDetailVM } from '~/modules/process/ui/viewmodels/shipment.vm'
+import { Instant } from '~/shared/time/instant'
+
+const refreshShipmentTrackingMock = vi.hoisted(() => vi.fn())
+const useSyncRealtimeCoordinatorMock = vi.hoisted(() => vi.fn(() => () => Instant.fromEpochMs(0)))
+
+vi.mock('~/modules/process/ui/screens/shipment/usecases/refreshShipmentTracking.usecase', () => ({
+  refreshShipmentTracking: refreshShipmentTrackingMock,
+}))
+
+vi.mock('~/modules/process/ui/utils/sync-realtime-coordinator', () => ({
+  useSyncRealtimeCoordinator: useSyncRealtimeCoordinatorMock,
+}))
+
+import { useShipmentRefreshController } from '~/modules/process/ui/screens/shipment/hooks/useShipmentRefreshController'
+
+function emptyAlertIncidents(): ShipmentDetailVM['alertIncidents'] {
+  return {
+    summary: {
+      activeIncidents: 0,
+      affectedContainers: 0,
+      recognizedIncidents: 0,
+    },
+    active: [],
+    recognized: [],
+  }
+}
+
+function buildShipment(): ShipmentDetailVM {
+  return {
+    id: 'process-1',
+    trackingFreshnessToken: 'freshness-1',
+    processRef: 'REF-1',
+    reference: 'REF-1',
+    carrier: 'MSC',
+    bill_of_lading: null,
+    booking_number: null,
+    importer_name: null,
+    exporter_name: null,
+    reference_importer: null,
+    depositary: null,
+    product: null,
+    redestination_number: null,
+    origin: 'Shanghai',
+    destination: 'Santos',
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    statusMicrobadge: null,
+    eta: null,
+    processEtaDisplayVm: {
+      kind: 'unavailable',
+    },
+    processEtaSecondaryVm: {
+      visible: false,
+      date: null,
+      withEta: 0,
+      total: 0,
+      incomplete: false,
+    },
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      affectedContainerCount: 0,
+      topIssue: null,
+    },
+    containers: [],
+    alerts: [],
+    alertIncidents: emptyAlertIncidents(),
+  }
+}
+
+function createRefreshHarness() {
+  return createRoot((dispose) => {
+    const [shipment, setShipment] = createSignal<ShipmentDetailVM | null | undefined>(
+      buildShipment(),
+    )
+    const reconcileTrackingView = vi.fn(() => Promise.resolve())
+    const controller = useShipmentRefreshController({
+      shipment,
+      reconcileTrackingView,
+    })
+
+    return {
+      controller,
+      setShipment,
+      reconcileTrackingView,
+      dispose,
+    }
+  })
+}
+
+describe('useShipmentRefreshController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-10T10:00:00.000Z'))
+    refreshShipmentTrackingMock.mockReset()
+    useSyncRealtimeCoordinatorMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('delegates refresh orchestration and soft-blocks repeated refreshes after a recent completion', async () => {
+    refreshShipmentTrackingMock.mockImplementation(
+      async (command: { readonly setLastRefreshDoneAt: (value: Instant | null) => void }) => {
+        command.setLastRefreshDoneAt(Instant.fromEpochMs(Date.now()))
+      },
+    )
+    const harness = createRefreshHarness()
+
+    await harness.controller.triggerRefresh()
+
+    expect(refreshShipmentTrackingMock).toHaveBeenCalledTimes(1)
+    expect(refreshShipmentTrackingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: buildShipment(),
+        refreshTrackingData: harness.reconcileTrackingView,
+      }),
+    )
+
+    vi.setSystemTime(new Date('2026-04-10T10:00:20.000Z'))
+    await harness.controller.triggerRefresh()
+
+    expect(refreshShipmentTrackingMock).toHaveBeenCalledTimes(1)
+    expect(harness.controller.refreshHint()).not.toBeNull()
+    expect(harness.controller.refreshError()).toBeNull()
+
+    harness.dispose()
+  })
+
+  it('clears active realtime cleanup when reset or explicit cleanup is requested', async () => {
+    const realtimeCleanup = vi.fn()
+    refreshShipmentTrackingMock.mockImplementation(
+      async (command: {
+        readonly setRefreshError: (value: string | null) => void
+        readonly setRefreshHint: (value: string | null) => void
+        readonly setRefreshRetry: (
+          value: { readonly current: number; readonly total: number } | null,
+        ) => void
+        readonly setRealtimeCleanup: (cleanup: (() => void) | null) => void
+      }) => {
+        command.setRefreshError('temporary failure')
+        command.setRefreshHint('temporary hint')
+        command.setRefreshRetry({ current: 1, total: 5 })
+        command.setRealtimeCleanup(realtimeCleanup)
+      },
+    )
+    const harness = createRefreshHarness()
+
+    await harness.controller.triggerRefresh()
+    expect(harness.controller.refreshError()).toBe('temporary failure')
+    expect(harness.controller.refreshHint()).toBe('temporary hint')
+    expect(harness.controller.refreshRetry()).toEqual({ current: 1, total: 5 })
+
+    harness.controller.resetRefreshState()
+
+    expect(realtimeCleanup).toHaveBeenCalledTimes(1)
+    expect(harness.controller.refreshError()).toBeNull()
+    expect(harness.controller.refreshHint()).toBeNull()
+    expect(harness.controller.refreshRetry()).toBeNull()
+    expect(harness.controller.isRefreshing()).toBe(false)
+
+    await harness.controller.triggerRefresh()
+    harness.controller.cleanupRealtime()
+
+    expect(realtimeCleanup).toHaveBeenCalledTimes(2)
+
+    harness.dispose()
+  })
+
+  it('clears error and hint without changing shipment data or realtime state', async () => {
+    refreshShipmentTrackingMock.mockImplementation(
+      async (command: {
+        readonly setRefreshError: (value: string | null) => void
+        readonly setRefreshHint: (value: string | null) => void
+      }) => {
+        command.setRefreshError('failed')
+        command.setRefreshHint('hint')
+      },
+    )
+    const harness = createRefreshHarness()
+
+    await harness.controller.triggerRefresh()
+    harness.controller.clearRefreshError()
+
+    expect(harness.controller.refreshError()).toBeNull()
+    expect(harness.controller.refreshHint()).toBeNull()
+
+    harness.dispose()
+  })
+})

--- a/src/modules/process/ui/screens/shipment/hooks/useShipmentSelectedContainer.test.ts
+++ b/src/modules/process/ui/screens/shipment/hooks/useShipmentSelectedContainer.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+import { createRoot, createSignal } from 'solid-js'
+import { useShipmentSelectedContainer } from '~/modules/process/ui/screens/shipment/hooks/useShipmentSelectedContainer'
+import type {
+  ContainerDetailVM,
+  ShipmentDetailVM,
+} from '~/modules/process/ui/viewmodels/shipment.vm'
+
+function emptyAlertIncidents(): ShipmentDetailVM['alertIncidents'] {
+  return {
+    summary: {
+      activeIncidents: 0,
+      affectedContainers: 0,
+      recognizedIncidents: 0,
+    },
+    active: [],
+    recognized: [],
+  }
+}
+
+function buildContainer(command: {
+  readonly id: string
+  readonly number: string
+  readonly etaDate: string
+}): ContainerDetailVM {
+  return {
+    id: command.id,
+    number: command.number,
+    carrierCode: 'MSC',
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    sync: {
+      containerNumber: command.number,
+      carrier: 'MSC',
+      state: 'ok',
+      relativeTimeAt: null,
+      isStale: false,
+    },
+    eta: command.etaDate,
+    etaChipVm: {
+      state: 'ACTIVE_EXPECTED',
+      tone: 'informative',
+      date: command.etaDate,
+    },
+    selectedEtaVm: {
+      state: 'ACTIVE_EXPECTED',
+      tone: 'informative',
+      date: command.etaDate,
+      type: 'ARRIVAL',
+    },
+    currentContext: {
+      locationCode: null,
+      locationDisplay: null,
+      vesselName: null,
+      voyage: null,
+      vesselVisible: false,
+    },
+    nextLocation: null,
+    tsChipVm: {
+      visible: false,
+      count: 0,
+      portsTooltip: null,
+    },
+    dataIssueChipVm: {
+      visible: false,
+    },
+    trackingContainment: null,
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      findingCount: 0,
+      activeIssues: [],
+    },
+    transshipment: {
+      hasTransshipment: false,
+      count: 0,
+      ports: [],
+    },
+    timeline: [],
+  }
+}
+
+function buildShipment(command: {
+  readonly id: string
+  readonly containers: readonly ContainerDetailVM[]
+}): ShipmentDetailVM {
+  return {
+    id: command.id,
+    trackingFreshnessToken: `freshness-${command.id}`,
+    processRef: `REF-${command.id}`,
+    reference: `REF-${command.id}`,
+    carrier: 'MSC',
+    bill_of_lading: null,
+    booking_number: null,
+    importer_name: null,
+    exporter_name: null,
+    reference_importer: null,
+    depositary: null,
+    product: null,
+    redestination_number: null,
+    origin: 'Shanghai',
+    destination: 'Santos',
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    statusMicrobadge: null,
+    eta: null,
+    processEtaDisplayVm: {
+      kind: 'unavailable',
+    },
+    processEtaSecondaryVm: {
+      visible: false,
+      date: null,
+      withEta: 0,
+      total: command.containers.length,
+      incomplete: command.containers.length > 0,
+    },
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      affectedContainerCount: 0,
+      topIssue: null,
+    },
+    containers: command.containers,
+    alerts: [],
+    alertIncidents: emptyAlertIncidents(),
+  }
+}
+
+function createSelectionHarness(command: {
+  readonly shipment: ShipmentDetailVM | null | undefined
+  readonly preferredContainerNumber: string | null
+}) {
+  return createRoot((dispose) => {
+    const [shipment, setShipment] = createSignal(command.shipment)
+    const [preferredContainerNumber, setPreferredContainerNumber] = createSignal(
+      command.preferredContainerNumber,
+    )
+    const controller = useShipmentSelectedContainer({
+      shipment,
+      preferredContainerNumber,
+    })
+
+    return {
+      controller,
+      setShipment,
+      setPreferredContainerNumber,
+      dispose,
+    }
+  })
+}
+
+describe('useShipmentSelectedContainer', () => {
+  it('selects the first container after shipment data loads and allows operator selection changes', async () => {
+    const first = buildContainer({
+      id: 'container-1',
+      number: 'MSCU1234567',
+      etaDate: '2026-04-10',
+    })
+    const second = buildContainer({
+      id: 'container-2',
+      number: 'MSCU7654321',
+      etaDate: '2026-04-12',
+    })
+    const harness = createSelectionHarness({
+      shipment: undefined,
+      preferredContainerNumber: null,
+    })
+
+    expect(harness.controller.selectedContainer()).toBeNull()
+
+    harness.setShipment(
+      buildShipment({
+        id: 'process-1',
+        containers: [first, second],
+      }),
+    )
+    await Promise.resolve()
+
+    expect(harness.controller.selectedContainerId()).toBe('container-1')
+    expect(harness.controller.selectedContainer()?.number).toBe('MSCU1234567')
+
+    harness.controller.setSelectedContainerId('container-2')
+
+    expect(harness.controller.selectedContainer()?.number).toBe('MSCU7654321')
+    expect(harness.controller.selectedContainerEtaVm()).toEqual({
+      state: 'ACTIVE_EXPECTED',
+      tone: 'informative',
+      date: '2026-04-12',
+      type: 'ARRIVAL',
+    })
+
+    harness.dispose()
+  })
+
+  it('applies a preferred container number once per shipment and preserves selection on invalid preference', async () => {
+    const first = buildContainer({
+      id: 'container-1',
+      number: 'MSCU1234567',
+      etaDate: '2026-04-10',
+    })
+    const second = buildContainer({
+      id: 'container-2',
+      number: 'MSCU7654321',
+      etaDate: '2026-04-12',
+    })
+    const harness = createSelectionHarness({
+      shipment: buildShipment({
+        id: 'process-1',
+        containers: [first, second],
+      }),
+      preferredContainerNumber: ' mscu7654321 ',
+    })
+
+    await Promise.resolve()
+
+    expect(harness.controller.selectedContainerId()).toBe('container-2')
+    expect(harness.controller.selectedContainer()?.number).toBe('MSCU7654321')
+
+    harness.controller.setSelectedContainerId('container-1')
+    harness.setPreferredContainerNumber('unknown-container')
+    await Promise.resolve()
+
+    expect(harness.controller.selectedContainerId()).toBe('container-1')
+    expect(harness.controller.selectedContainer()?.number).toBe('MSCU1234567')
+
+    harness.dispose()
+  })
+
+  it('falls back to the first container when selected id is stale after shipment replacement', async () => {
+    const harness = createSelectionHarness({
+      shipment: buildShipment({
+        id: 'process-1',
+        containers: [
+          buildContainer({
+            id: 'container-1',
+            number: 'MSCU1234567',
+            etaDate: '2026-04-10',
+          }),
+        ],
+      }),
+      preferredContainerNumber: null,
+    })
+
+    await Promise.resolve()
+    harness.controller.setSelectedContainerId('container-removed')
+    harness.setShipment(
+      buildShipment({
+        id: 'process-2',
+        containers: [
+          buildContainer({
+            id: 'container-3',
+            number: 'MSCU3333333',
+            etaDate: '2026-05-01',
+          }),
+        ],
+      }),
+    )
+    await Promise.resolve()
+
+    expect(harness.controller.selectedContainer()?.number).toBe('MSCU3333333')
+    expect(harness.controller.selectedContainerEtaVm()?.date).toBe('2026-05-01')
+
+    harness.dispose()
+  })
+})

--- a/src/modules/process/ui/screens/shipment/usecases/refreshShipmentTracking.usecase.test.ts
+++ b/src/modules/process/ui/screens/shipment/usecases/refreshShipmentTracking.usecase.test.ts
@@ -1,0 +1,408 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RefreshRetryState } from '~/modules/process/ui/screens/shipment/types/shipmentScreen.types'
+import type {
+  ContainerDetailVM,
+  ShipmentDetailVM,
+} from '~/modules/process/ui/viewmodels/shipment.vm'
+import { Instant } from '~/shared/time/instant'
+
+const fetchWithHttpDegradationReportingMock = vi.hoisted(() => vi.fn())
+const pollRefreshSyncStatusMock = vi.hoisted(() => vi.fn())
+const realtimeUnsubscribeMock = vi.hoisted(() => vi.fn())
+const subscribeToSyncRequestsRealtimeByIdsMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    unsubscribe: realtimeUnsubscribeMock,
+  })),
+)
+
+vi.mock('~/shared/api/httpDegradationReporter', () => ({
+  fetchWithHttpDegradationReporting: fetchWithHttpDegradationReportingMock,
+}))
+
+vi.mock('~/modules/process/ui/utils/refresh-sync-polling', () => ({
+  pollRefreshSyncStatus: pollRefreshSyncStatusMock,
+}))
+
+vi.mock('~/shared/api/sync-requests.realtime.client', () => ({
+  subscribeToSyncRequestsRealtimeByIds: subscribeToSyncRequestsRealtimeByIdsMock,
+}))
+
+import { refreshShipmentTracking } from '~/modules/process/ui/screens/shipment/usecases/refreshShipmentTracking.usecase'
+
+const SYNC_REQUEST_ID_1 = '11111111-1111-4111-8111-111111111111'
+const SYNC_REQUEST_ID_2 = '22222222-2222-4222-8222-222222222222'
+
+function emptyAlertIncidents(): ShipmentDetailVM['alertIncidents'] {
+  return {
+    summary: {
+      activeIncidents: 0,
+      affectedContainers: 0,
+      recognizedIncidents: 0,
+    },
+    active: [],
+    recognized: [],
+  }
+}
+
+function buildContainer(command: {
+  readonly id: string
+  readonly number: string
+}): ContainerDetailVM {
+  return {
+    id: command.id,
+    number: command.number,
+    carrierCode: 'MSC',
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    sync: {
+      containerNumber: command.number,
+      carrier: 'MSC',
+      state: 'ok',
+      relativeTimeAt: null,
+      isStale: false,
+    },
+    eta: null,
+    etaChipVm: {
+      state: 'UNAVAILABLE',
+      tone: 'neutral',
+      date: null,
+    },
+    selectedEtaVm: null,
+    currentContext: {
+      locationCode: null,
+      locationDisplay: null,
+      vesselName: null,
+      voyage: null,
+      vesselVisible: false,
+    },
+    nextLocation: null,
+    tsChipVm: {
+      visible: false,
+      count: 0,
+      portsTooltip: null,
+    },
+    dataIssueChipVm: {
+      visible: false,
+    },
+    trackingContainment: null,
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      findingCount: 0,
+      activeIssues: [],
+    },
+    transshipment: {
+      hasTransshipment: false,
+      count: 0,
+      ports: [],
+    },
+    timeline: [],
+  }
+}
+
+function buildShipment(containers: readonly ContainerDetailVM[]): ShipmentDetailVM {
+  return {
+    id: 'process-1',
+    trackingFreshnessToken: 'freshness-1',
+    processRef: 'REF-1',
+    reference: 'REF-1',
+    carrier: 'MSC',
+    bill_of_lading: null,
+    booking_number: null,
+    importer_name: null,
+    exporter_name: null,
+    reference_importer: null,
+    depositary: null,
+    product: null,
+    redestination_number: null,
+    origin: 'Shanghai',
+    destination: 'Santos',
+    status: 'in-transit',
+    statusCode: 'IN_TRANSIT',
+    statusMicrobadge: null,
+    eta: null,
+    processEtaDisplayVm: {
+      kind: 'unavailable',
+    },
+    processEtaSecondaryVm: {
+      visible: false,
+      date: null,
+      withEta: 0,
+      total: containers.length,
+      incomplete: containers.length > 0,
+    },
+    trackingValidation: {
+      hasIssues: false,
+      highestSeverity: null,
+      affectedContainerCount: 0,
+      topIssue: null,
+    },
+    containers,
+    alerts: [],
+    alertIncidents: emptyAlertIncidents(),
+  }
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'content-type': 'application/json',
+    },
+    ...init,
+  })
+}
+
+function buildCommand(data: ShipmentDetailVM | null | undefined) {
+  return {
+    data,
+    setIsRefreshing: vi.fn(),
+    setRefreshError: vi.fn(),
+    setRefreshHint: vi.fn(),
+    setRefreshRetry: vi.fn<(value: RefreshRetryState | null) => void>(),
+    setLastRefreshDoneAt: vi.fn<(value: Instant | null) => void>(),
+    setRealtimeCleanup: vi.fn<(cleanup: (() => void) | null) => void>(),
+    refreshTrackingData: vi.fn(() => Promise.resolve()),
+    isDisposed: vi.fn(() => false),
+    toTimeoutMessage: (totalRetries: number) => `timeout:${totalRetries}`,
+    toFailedMessage: (failedCount: number, firstError: string) =>
+      `failed:${failedCount}:${firstError}`,
+  }
+}
+
+function enqueueResponse(command: {
+  readonly container: string
+  readonly syncRequestId: string
+}): Response {
+  return jsonResponse({
+    ok: true,
+    container: command.container,
+    syncRequestId: command.syncRequestId,
+    queued: true,
+    deduped: false,
+  })
+}
+
+function statusResponse(command: {
+  readonly allTerminal: boolean
+  readonly requests: readonly {
+    readonly syncRequestId: string
+    readonly status: 'PENDING' | 'LEASED' | 'DONE' | 'FAILED' | 'NOT_FOUND'
+    readonly lastError: string | null
+    readonly updatedAt: string | null
+    readonly refValue: string | null
+  }[]
+}): Response {
+  return jsonResponse({
+    ok: true,
+    allTerminal: command.allTerminal,
+    requests: command.requests,
+  })
+}
+
+describe('refreshShipmentTracking', () => {
+  beforeEach(() => {
+    fetchWithHttpDegradationReportingMock.mockReset()
+    pollRefreshSyncStatusMock.mockReset()
+    realtimeUnsubscribeMock.mockReset()
+    subscribeToSyncRequestsRealtimeByIdsMock.mockClear()
+  })
+
+  it('enqueues each container, waits for terminal sync status and reconciles before and after completion', async () => {
+    fetchWithHttpDegradationReportingMock
+      .mockResolvedValueOnce(
+        enqueueResponse({
+          container: 'MSCU1234567',
+          syncRequestId: SYNC_REQUEST_ID_1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        enqueueResponse({
+          container: 'MSCU7654321',
+          syncRequestId: SYNC_REQUEST_ID_2,
+        }),
+      )
+      .mockResolvedValueOnce(
+        statusResponse({
+          allTerminal: true,
+          requests: [
+            {
+              syncRequestId: SYNC_REQUEST_ID_1,
+              status: 'DONE',
+              lastError: null,
+              updatedAt: '2026-04-10T10:00:00.000Z',
+              refValue: 'MSCU1234567',
+            },
+            {
+              syncRequestId: SYNC_REQUEST_ID_2,
+              status: 'DONE',
+              lastError: null,
+              updatedAt: '2026-04-10T10:05:00.000Z',
+              refValue: 'MSCU7654321',
+            },
+          ],
+        }),
+      )
+    const command = buildCommand(
+      buildShipment([
+        buildContainer({
+          id: 'container-1',
+          number: 'MSCU1234567',
+        }),
+        buildContainer({
+          id: 'container-2',
+          number: 'MSCU7654321',
+        }),
+      ]),
+    )
+
+    await refreshShipmentTracking(command)
+
+    expect(fetchWithHttpDegradationReportingMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/refresh',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ container: 'MSCU1234567', carrier: 'MSC' }),
+      }),
+    )
+    expect(fetchWithHttpDegradationReportingMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/refresh',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ container: 'MSCU7654321', carrier: 'MSC' }),
+      }),
+    )
+    expect(fetchWithHttpDegradationReportingMock).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`sync_request_id=${encodeURIComponent(SYNC_REQUEST_ID_1)}`),
+      expect.objectContaining({
+        cache: 'no-store',
+      }),
+    )
+    expect(command.refreshTrackingData).toHaveBeenCalledTimes(2)
+    expect(command.setRefreshError).toHaveBeenLastCalledWith(null)
+    expect(command.setLastRefreshDoneAt).toHaveBeenCalledWith(
+      Instant.fromIso('2026-04-10T10:05:00.000Z'),
+    )
+    expect(command.setIsRefreshing).toHaveBeenLastCalledWith(false)
+    expect(command.setRefreshRetry).toHaveBeenLastCalledWith(null)
+  })
+
+  it('surfaces enqueue failures without inventing successful sync requests', async () => {
+    fetchWithHttpDegradationReportingMock.mockResolvedValue(
+      jsonResponse(
+        {
+          error: 'carrier down',
+        },
+        {
+          status: 500,
+          statusText: 'Internal Server Error',
+        },
+      ),
+    )
+    const command = buildCommand(
+      buildShipment([
+        buildContainer({
+          id: 'container-1',
+          number: 'MSCU1234567',
+        }),
+      ]),
+    )
+
+    await refreshShipmentTracking(command)
+
+    expect(subscribeToSyncRequestsRealtimeByIdsMock).not.toHaveBeenCalled()
+    expect(command.setRefreshError).toHaveBeenCalledWith('failed:1:carrier down')
+    expect(command.refreshTrackingData).toHaveBeenCalledTimes(1)
+    expect(command.setLastRefreshDoneAt).not.toHaveBeenCalled()
+  })
+
+  it('surfaces terminal failed statuses after a successful enqueue', async () => {
+    fetchWithHttpDegradationReportingMock
+      .mockResolvedValueOnce(
+        enqueueResponse({
+          container: 'MSCU1234567',
+          syncRequestId: SYNC_REQUEST_ID_1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        statusResponse({
+          allTerminal: true,
+          requests: [
+            {
+              syncRequestId: SYNC_REQUEST_ID_1,
+              status: 'FAILED',
+              lastError: 'provider rejected request',
+              updatedAt: '2026-04-10T10:00:00.000Z',
+              refValue: 'MSCU1234567',
+            },
+          ],
+        }),
+      )
+    const command = buildCommand(
+      buildShipment([
+        buildContainer({
+          id: 'container-1',
+          number: 'MSCU1234567',
+        }),
+      ]),
+    )
+
+    await refreshShipmentTracking(command)
+
+    expect(command.setRefreshError).toHaveBeenCalledWith('failed:1:provider rejected request')
+    expect(command.setLastRefreshDoneAt).not.toHaveBeenCalled()
+    expect(command.refreshTrackingData).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports timeout when sync requests never reach a terminal status', async () => {
+    fetchWithHttpDegradationReportingMock
+      .mockResolvedValueOnce(
+        enqueueResponse({
+          container: 'MSCU1234567',
+          syncRequestId: SYNC_REQUEST_ID_1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        statusResponse({
+          allTerminal: false,
+          requests: [
+            {
+              syncRequestId: SYNC_REQUEST_ID_1,
+              status: 'PENDING',
+              lastError: null,
+              updatedAt: '2026-04-10T10:00:00.000Z',
+              refValue: 'MSCU1234567',
+            },
+          ],
+        }),
+      )
+    pollRefreshSyncStatusMock.mockResolvedValue({
+      kind: 'timeout',
+      attempts: 5,
+      lastResponse: null,
+    })
+    const command = buildCommand(
+      buildShipment([
+        buildContainer({
+          id: 'container-1',
+          number: 'MSCU1234567',
+        }),
+      ]),
+    )
+
+    await refreshShipmentTracking(command)
+
+    expect(pollRefreshSyncStatusMock).toHaveBeenCalled()
+    expect(command.setRefreshError).toHaveBeenCalledWith('timeout:5')
+    expect(command.setLastRefreshDoneAt).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when shipment or containers are absent', async () => {
+    await refreshShipmentTracking(buildCommand(null))
+    await refreshShipmentTracking(buildCommand(buildShipment([])))
+
+    expect(fetchWithHttpDegradationReportingMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/modules/tracking/infrastructure/bootstrap/tracking.bootstrap.test.ts
+++ b/src/modules/tracking/infrastructure/bootstrap/tracking.bootstrap.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createTrackingUseCasesMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    getLatestSnapshot: vi.fn(),
+  })),
+)
+
+const snapshotRepository = vi.hoisted(() => ({
+  insert: vi.fn(),
+  findLatestByContainerId: vi.fn(),
+  findAllByContainerId: vi.fn(),
+}))
+const observationRepository = vi.hoisted(() => ({
+  insertMany: vi.fn(),
+  findAllByContainerId: vi.fn(),
+  findAllByContainerIds: vi.fn(),
+  findFingerprintsByContainerId: vi.fn(),
+  listSearchObservations: vi.fn(),
+}))
+const trackingAlertRepository = vi.hoisted(() => ({
+  insertMany: vi.fn(),
+  findActiveByContainerId: vi.fn(),
+  findActiveByContainerIds: vi.fn(),
+  findByContainerId: vi.fn(),
+  findAlertDerivationStateByContainerId: vi.fn(),
+  findContainerNumbersByIds: vi.fn(),
+  findActiveTypesByContainerId: vi.fn(),
+  listActiveAlertReadModel: vi.fn(),
+  acknowledge: vi.fn(),
+  unacknowledge: vi.fn(),
+  autoResolveMany: vi.fn(),
+}))
+const syncMetadataRepository = vi.hoisted(() => ({
+  listByContainerNumbers: vi.fn(),
+}))
+const trackingContainmentRepository = vi.hoisted(() => ({
+  findActiveByContainerId: vi.fn(),
+  findActiveByContainerIds: vi.fn(),
+  activate: vi.fn(),
+}))
+const trackingValidationLifecycleRepository = vi.hoisted(() => ({
+  findActiveStatesByContainerId: vi.fn(),
+  insertMany: vi.fn(),
+}))
+
+vi.mock('~/modules/tracking/application/tracking.usecases', () => ({
+  createTrackingUseCases: createTrackingUseCasesMock,
+}))
+
+vi.mock('~/modules/tracking/infrastructure/persistence/supabaseSnapshotRepository', () => ({
+  supabaseSnapshotRepository: snapshotRepository,
+}))
+
+vi.mock('~/modules/tracking/infrastructure/persistence/supabaseObservationRepository', () => ({
+  supabaseObservationRepository: observationRepository,
+}))
+
+vi.mock('~/modules/tracking/infrastructure/persistence/supabaseTrackingAlertRepository', () => ({
+  supabaseTrackingAlertRepository: trackingAlertRepository,
+}))
+
+vi.mock('~/modules/tracking/infrastructure/persistence/supabaseSyncMetadataRepository', () => ({
+  supabaseSyncMetadataRepository: syncMetadataRepository,
+}))
+
+vi.mock(
+  '~/modules/tracking/infrastructure/persistence/supabaseTrackingContainmentRepository',
+  () => ({
+    supabaseTrackingContainmentRepository: trackingContainmentRepository,
+  }),
+)
+
+vi.mock(
+  '~/modules/tracking/infrastructure/persistence/supabaseTrackingValidationLifecycleRepository',
+  () => ({
+    supabaseTrackingValidationLifecycleRepository: trackingValidationLifecycleRepository,
+  }),
+)
+
+import { bootstrapTrackingModule } from '~/modules/tracking/infrastructure/bootstrap/tracking.bootstrap'
+
+describe('bootstrapTrackingModule', () => {
+  beforeEach(() => {
+    createTrackingUseCasesMock.mockClear()
+  })
+
+  it('wires default infrastructure repositories into tracking application usecases', () => {
+    const module = bootstrapTrackingModule()
+
+    expect(module.trackingUseCases).toEqual({
+      getLatestSnapshot: expect.any(Function),
+    })
+    expect(createTrackingUseCasesMock).toHaveBeenCalledWith({
+      snapshotRepository,
+      observationRepository,
+      trackingAlertRepository,
+      syncMetadataRepository,
+      trackingContainmentRepository,
+      trackingValidationLifecycleRepository,
+    })
+  })
+
+  it('allows explicit repository overrides for local integration tests and alternate composition roots', () => {
+    const overrideSnapshotRepository = {
+      insert: vi.fn(),
+      findLatestByContainerId: vi.fn(),
+      findAllByContainerId: vi.fn(),
+    }
+
+    bootstrapTrackingModule({
+      snapshotRepository: overrideSnapshotRepository,
+    })
+
+    expect(createTrackingUseCasesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshotRepository: overrideSnapshotRepository,
+        observationRepository,
+      }),
+    )
+  })
+})

--- a/src/shared/api/sync.bootstrap/tests/sync.bootstrap.ports.test.ts
+++ b/src/shared/api/sync.bootstrap/tests/sync.bootstrap.ports.test.ts
@@ -6,25 +6,28 @@ type ProcessSyncCandidateRow = {
 }
 
 type QueryOperation = {
-  readonly method: 'select' | 'is' | 'or' | 'in'
+  readonly method: 'select' | 'is' | 'or' | 'in' | 'eq' | 'rpc'
   readonly args: readonly unknown[]
 }
 
 type MockQuery = {
-  readonly rows: readonly ProcessSyncCandidateRow[]
+  readonly rows: readonly unknown[]
   select: (columns: string) => MockQuery
   is: (column: string, value: null) => MockQuery
   or: (filter: string) => MockQuery
+  eq: (column: string, value: string) => MockQuery
   in: (column: string, values: readonly string[]) => MockQuery
 }
 
 const supabaseMock = vi.hoisted(() => {
   const state: {
-    rows: readonly ProcessSyncCandidateRow[]
+    rows: readonly unknown[]
+    rpcRows: readonly unknown[]
     operations: QueryOperation[]
     tables: string[]
   } = {
     rows: [],
+    rpcRows: [],
     operations: [],
     tables: [],
   }
@@ -55,6 +58,13 @@ const supabaseMock = vi.hoisted(() => {
         })
         return query
       },
+      eq(column, value) {
+        state.operations.push({
+          method: 'eq',
+          args: [column, value],
+        })
+        return query
+      },
       in(column, values) {
         state.operations.push({
           method: 'in',
@@ -70,6 +80,17 @@ const supabaseMock = vi.hoisted(() => {
   return {
     reset(rows: readonly ProcessSyncCandidateRow[]) {
       state.rows = rows
+      state.rpcRows = []
+      state.operations = []
+      state.tables = []
+    },
+    setRows(rows: readonly unknown[]) {
+      state.rows = rows
+      state.operations = []
+      state.tables = []
+    },
+    setRpcRows(rows: readonly unknown[]) {
+      state.rpcRows = rows
       state.operations = []
       state.tables = []
     },
@@ -78,13 +99,21 @@ const supabaseMock = vi.hoisted(() => {
       state.tables.push(table)
       return createQuery()
     }),
-    unwrap: vi.fn((result: { readonly rows: readonly ProcessSyncCandidateRow[] }) => result.rows),
+    rpc: vi.fn((name: string, params: Readonly<Record<string, unknown>>) => {
+      state.operations.push({
+        method: 'rpc',
+        args: [name, params],
+      })
+      return { rows: state.rpcRows }
+    }),
+    unwrap: vi.fn((result: { readonly rows: readonly unknown[] }) => result.rows),
   }
 })
 
 vi.mock('~/shared/supabase/supabase.server', () => ({
   supabaseServer: {
     from: supabaseMock.from,
+    rpc: supabaseMock.rpc,
   },
 }))
 
@@ -92,7 +121,12 @@ vi.mock('~/shared/supabase/unwrapSupabaseResult', () => ({
   unwrapSupabaseResultOrThrow: supabaseMock.unwrap,
 }))
 
-import { createSyncStatusReadPort } from '~/shared/api/sync.bootstrap/sync.bootstrap.ports'
+import {
+  createRefreshProcessDeps,
+  createSyncQueuePort,
+  createSyncStatusReadPort,
+  createSyncTargetReadPort,
+} from '~/shared/api/sync.bootstrap/sync.bootstrap.ports'
 
 describe('createSyncStatusReadPort', () => {
   beforeEach(() => {
@@ -184,5 +218,177 @@ describe('createSyncStatusReadPort', () => {
 
     expect(candidates).toEqual([])
     expect(supabaseMock.from).not.toHaveBeenCalled()
+  })
+
+  it('normalizes container sync-request lookup and preserves requested status order', async () => {
+    supabaseMock.setRows([
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        status: 'DONE',
+        last_error: null,
+        updated_at: '2026-04-10T10:00:00.000Z',
+        ref_value: 'MSCU1234567',
+      },
+    ])
+    const queuePort = createSyncQueuePort({
+      defaultTenantId: 'tenant-1',
+    })
+
+    const result = await queuePort.getSyncRequestStatuses({
+      syncRequestIds: [
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+        '11111111-1111-4111-8111-111111111111',
+      ],
+    })
+
+    expect(result).toEqual({
+      allTerminal: true,
+      requests: [
+        {
+          syncRequestId: '11111111-1111-4111-8111-111111111111',
+          status: 'DONE',
+          lastError: null,
+          updatedAt: '2026-04-10T10:00:00.000Z',
+          refValue: 'MSCU1234567',
+        },
+        {
+          syncRequestId: '22222222-2222-4222-8222-222222222222',
+          status: 'NOT_FOUND',
+          lastError: 'sync_request_not_found',
+          updatedAt: null,
+          refValue: null,
+        },
+        {
+          syncRequestId: '11111111-1111-4111-8111-111111111111',
+          status: 'DONE',
+          lastError: null,
+          updatedAt: '2026-04-10T10:00:00.000Z',
+          refValue: 'MSCU1234567',
+        },
+      ],
+    })
+    expect(supabaseMock.state.operations).toContainEqual({
+      method: 'in',
+      args: [
+        'id',
+        ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'],
+      ],
+    })
+  })
+
+  it('enqueues normalized container sync requests through the queue port', async () => {
+    supabaseMock.setRpcRows([
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        status: 'PENDING',
+        is_new: true,
+      },
+    ])
+    const queuePort = createSyncQueuePort({
+      defaultTenantId: 'tenant-1',
+    })
+
+    const result = await queuePort.enqueueContainerSyncRequest({
+      tenantId: 'tenant-2',
+      provider: 'msc',
+      containerNumber: ' mscu1234567 ',
+      mode: 'backfill',
+    })
+
+    expect(result).toEqual({
+      id: '11111111-1111-4111-8111-111111111111',
+      status: 'PENDING',
+      isNew: true,
+    })
+    expect(supabaseMock.state.operations).toContainEqual({
+      method: 'rpc',
+      args: [
+        'enqueue_sync_request',
+        {
+          p_tenant_id: 'tenant-2',
+          p_provider: 'msc',
+          p_ref_type: 'container',
+          p_ref_value: 'MSCU1234567',
+          p_priority: -1,
+        },
+      ],
+    })
+  })
+})
+
+describe('createSyncTargetReadPort', () => {
+  it('maps container application results into sync target records without exposing entities', async () => {
+    const port = createSyncTargetReadPort({
+      processUseCases: {
+        findProcessById: vi.fn(),
+      },
+      containerUseCases: {
+        listByProcessId: vi.fn(),
+        listByProcessIds: vi.fn(async () => ({
+          containersByProcessId: new Map([
+            [
+              'process-1',
+              [
+                {
+                  processId: 'process-1',
+                  containerNumber: 'MSCU1234567',
+                  carrierCode: 'MSC',
+                },
+              ],
+            ],
+          ]),
+        })),
+        findByNumbers: vi.fn(),
+      },
+    })
+
+    const result = await port.listContainersByProcessIds({
+      processIds: ['process-1'],
+    })
+
+    expect(result.containersByProcessId.get('process-1')).toEqual([
+      {
+        processId: 'process-1',
+        containerNumber: 'MSCU1234567',
+        carrierCode: 'MSC',
+      },
+    ])
+  })
+})
+
+describe('createRefreshProcessDeps', () => {
+  it('injects tenant and manual mode while delegating provider/container facts to queue port', async () => {
+    const queuePort = {
+      enqueueContainerSyncRequest: vi.fn(async () => ({
+        id: '11111111-1111-4111-8111-111111111111',
+        status: 'PENDING' as const,
+        isNew: true,
+      })),
+      getSyncRequestStatuses: vi.fn(),
+    }
+    const deps = createRefreshProcessDeps({
+      targetReadPort: {
+        fetchProcessById: vi.fn(),
+        listActiveProcessIds: vi.fn(),
+        listContainersByProcessId: vi.fn(),
+        listContainersByProcessIds: vi.fn(),
+        findContainersByNumber: vi.fn(),
+      },
+      queuePort,
+      defaultTenantId: 'tenant-1',
+    })
+
+    await deps.enqueueContainerSyncRequest({
+      provider: 'msc',
+      containerNumber: 'MSCU1234567',
+    })
+
+    expect(queuePort.enqueueContainerSyncRequest).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      mode: 'manual',
+      provider: 'msc',
+      containerNumber: 'MSCU1234567',
+    })
   })
 })

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -34,7 +34,7 @@ export function EmptyState(props: Props): JSX.Element {
             {(onAction) => (
               <button
                 type="button"
-                onClick={onAction()}
+                onClick={() => onAction()}
                 class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm-ui font-medium text-primary-foreground transition-colors hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-ring/40"
               >
                 {actionLabel()}

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -30,7 +30,7 @@ export function EmptyState(props: Props): JSX.Element {
       <p class="mb-6 max-w-sm text-md-ui text-text-muted">{props.description}</p>
       <Show when={props.actionLabel}>
         {(actionLabel) => (
-          <Show when={props.onAction}>
+          <Show when={props.onAction} keyed>
             {(onAction) => (
               <button
                 type="button"

--- a/src/shared/ui/navbar-alerts/NavbarAlertsButton.tsx
+++ b/src/shared/ui/navbar-alerts/NavbarAlertsButton.tsx
@@ -1,38 +1,29 @@
-import { useNavigate } from '@solidjs/router'
 import clsx from 'clsx'
-import { createEffect, createSignal, type JSX, onCleanup, Show } from 'solid-js'
+import { createEffect, type JSX, onCleanup, Show } from 'solid-js'
 import { useTranslation } from '~/shared/localization/i18n'
 import { NavbarAlertsPanel } from '~/shared/ui/navbar-alerts/NavbarAlertsPanel'
-import { useNavbarAlerts } from '~/shared/ui/navbar-alerts/useNavbarAlerts'
-import {
-  navigateToProcess,
-  navigateToProcessContainer,
-  type ProcessContainerNavigationState,
-} from '~/shared/ui/navigation/app-navigation'
+import { useNavbarAlertsButtonController } from '~/shared/ui/navbar-alerts/useNavbarAlertsButtonController'
 
 export function NavbarAlertsButton(): JSX.Element {
   const { t, keys } = useTranslation()
-  const navigate = useNavigate()
-  const navbarAlerts = useNavbarAlerts()
-  const [isOpen, setIsOpen] = createSignal(false)
+  const controller = useNavbarAlertsButtonController()
   const panelId = 'navbar-alerts-panel'
-  let containerNavigationRequestCounter = 0
   let rootRef: HTMLDivElement | undefined
 
   createEffect(() => {
-    if (!isOpen()) return
+    if (!controller.isOpen()) return
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return
       event.preventDefault()
-      setIsOpen(false)
+      controller.closePanel()
     }
 
     const handleDocumentPointerDown = (event: MouseEvent) => {
       const target = event.target
       if (!(target instanceof Node)) return
       if (rootRef?.contains(target)) return
-      setIsOpen(false)
+      controller.closePanel()
     }
 
     document.addEventListener('keydown', handleEscape)
@@ -44,75 +35,23 @@ export function NavbarAlertsButton(): JSX.Element {
     })
   })
 
-  const totalAlerts = () => navbarAlerts.state().totalAlerts
-
-  const togglePanel = () => {
-    const nextOpenState = !isOpen()
-    setIsOpen(nextOpenState)
-    if (nextOpenState && (!navbarAlerts.hasResolved() || navbarAlerts.state().error !== null)) {
-      void navbarAlerts.refresh()
-    }
-  }
-
-  const closePanel = () => {
-    setIsOpen(false)
-  }
-
-  const openDashboard = () => {
-    closePanel()
-    void navigate('/')
-  }
-
-  const openProcess = (processId: string) => {
-    closePanel()
-    navigateToProcess({
-      navigate,
-      processId,
-    })
-  }
-
-  const openContainer = (processId: string, containerNumber: string) => {
-    closePanel()
-
-    containerNavigationRequestCounter += 1
-    const navigationState: ProcessContainerNavigationState = {
-      source: 'navbar-alerts',
-      focusSection: 'current-status',
-      revealLiveStatus: true,
-      requestKey: `navbar-alert-${containerNavigationRequestCounter}`,
-    }
-
-    navigateToProcessContainer({
-      navigate,
-      processId,
-      containerNumber,
-      navigationState,
-      state: navigationState,
-    })
-  }
-
-  const buttonTitle = () =>
-    totalAlerts() > 0
-      ? t(keys.header.alertsActiveTooltip, { count: totalAlerts() })
-      : t(keys.header.alertsPanel.empty)
-
   return (
     <div ref={rootRef} class="relative flex items-center">
       <button
         type="button"
-        onClick={togglePanel}
+        onClick={controller.togglePanel}
         aria-haspopup="dialog"
-        aria-expanded={isOpen()}
+        aria-expanded={controller.isOpen()}
         aria-controls={panelId}
-        aria-label={t(keys.header.alertsBadge, { count: totalAlerts() })}
-        title={buttonTitle()}
+        aria-label={t(keys.header.alertsBadge, { count: controller.totalAlerts() })}
+        title={controller.buttonTitle()}
         class={clsx(
           'inline-flex h-[var(--dashboard-control-height)] min-h-[var(--dashboard-control-height)] items-center gap-1.5 whitespace-nowrap rounded-full border px-3 text-xs-ui font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
           {
             'border-tone-danger-border bg-tone-danger-bg text-tone-danger-fg hover:border-tone-danger-strong':
-              totalAlerts() > 0,
+              controller.totalAlerts() > 0,
             'border-border bg-surface text-text-muted hover:border-border-strong hover:bg-surface-muted':
-              totalAlerts() === 0,
+              controller.totalAlerts() === 0,
           },
         )}
       >
@@ -130,24 +69,22 @@ export function NavbarAlertsButton(): JSX.Element {
             d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
           />
         </svg>
-        <span>{totalAlerts()}</span>
+        <span>{controller.totalAlerts()}</span>
         <span class="hidden min-[1280px]:inline">{t(keys.header.alertsLabel)}</span>
       </button>
 
-      <Show when={isOpen()}>
+      <Show when={controller.isOpen()}>
         <NavbarAlertsPanel
           panelId={panelId}
-          totalAlerts={totalAlerts()}
-          processes={navbarAlerts.state().processes}
-          loading={navbarAlerts.state().loading}
-          error={navbarAlerts.state().error}
-          onRetry={() => {
-            void navbarAlerts.refresh()
-          }}
-          onClose={closePanel}
-          onOpenDashboard={openDashboard}
-          onOpenProcess={openProcess}
-          onOpenContainer={openContainer}
+          totalAlerts={controller.totalAlerts()}
+          processes={controller.state().processes}
+          loading={controller.state().loading}
+          error={controller.state().error}
+          onRetry={controller.retry}
+          onClose={controller.closePanel}
+          onOpenDashboard={controller.openDashboard}
+          onOpenProcess={controller.openProcess}
+          onOpenContainer={controller.openContainer}
         />
       </Show>
     </div>

--- a/src/shared/ui/navbar-alerts/tests/NavbarAlertsButton.render.test.tsx
+++ b/src/shared/ui/navbar-alerts/tests/NavbarAlertsButton.render.test.tsx
@@ -1,0 +1,105 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NavbarProcessAlertGroupVM } from '~/shared/ui/navbar-alerts/navbar-alerts.vm'
+
+type NavbarControllerStub = {
+  isOpen: () => boolean
+  totalAlerts: () => number
+  state: () => {
+    totalAlerts: number
+    processes: readonly NavbarProcessAlertGroupVM[]
+    loading: boolean
+    error: string | null
+  }
+  togglePanel: ReturnType<typeof vi.fn>
+  closePanel: ReturnType<typeof vi.fn>
+  retry: ReturnType<typeof vi.fn>
+  openDashboard: ReturnType<typeof vi.fn>
+  openProcess: ReturnType<typeof vi.fn>
+  openContainer: ReturnType<typeof vi.fn>
+  buttonTitle: () => string
+}
+
+const emptyProcesses: readonly NavbarProcessAlertGroupVM[] = []
+
+const controllerState = vi.hoisted<NavbarControllerStub>(() => ({
+  isOpen: () => false,
+  totalAlerts: () => 0,
+  state: () => ({
+    totalAlerts: 0,
+    processes: emptyProcesses,
+    loading: false,
+    error: null,
+  }),
+  togglePanel: vi.fn(),
+  closePanel: vi.fn(),
+  retry: vi.fn(),
+  openDashboard: vi.fn(),
+  openProcess: vi.fn(),
+  openContainer: vi.fn(),
+  buttonTitle: () => 'No alerts',
+}))
+
+vi.mock('~/shared/ui/navbar-alerts/useNavbarAlertsButtonController', () => ({
+  useNavbarAlertsButtonController: () => controllerState,
+}))
+
+vi.mock('~/shared/ui/navbar-alerts/NavbarAlertsPanel', () => ({
+  NavbarAlertsPanel: (props: {
+    readonly panelId: string
+    readonly totalAlerts: number
+    readonly loading: boolean
+    readonly error: string | null
+  }) => (
+    <div>
+      panel:{props.panelId}:{props.totalAlerts}:{String(props.loading)}:{props.error ?? 'none'}
+    </div>
+  ),
+}))
+
+import { NavbarAlertsButton } from '~/shared/ui/navbar-alerts/NavbarAlertsButton'
+
+function normalizeSsrHtml(html: string): string {
+  return html.replaceAll('<!--$-->', '').replaceAll('<!--/-->', '')
+}
+
+describe('NavbarAlertsButton render', () => {
+  beforeEach(() => {
+    controllerState.isOpen = () => false
+    controllerState.totalAlerts = () => 0
+    controllerState.state = () => ({
+      totalAlerts: 0,
+      processes: emptyProcesses,
+      loading: false,
+      error: null,
+    })
+    controllerState.buttonTitle = () => 'No alerts'
+  })
+
+  it('renders the closed badge state', () => {
+    const html = normalizeSsrHtml(renderToString(() => createComponent(NavbarAlertsButton, {})))
+
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toContain('>0<')
+    expect(html).not.toContain('panel:')
+  })
+
+  it('renders the open panel state with forwarded alert data', () => {
+    controllerState.isOpen = () => true
+    controllerState.totalAlerts = () => 3
+    controllerState.state = () => ({
+      totalAlerts: 3,
+      processes: [],
+      loading: true,
+      error: 'failed',
+    })
+    controllerState.buttonTitle = () => '3 alerts active'
+
+    const html = normalizeSsrHtml(renderToString(() => createComponent(NavbarAlertsButton, {})))
+
+    expect(html).toContain('aria-expanded="true"')
+    expect(html).toContain('>3<')
+    expect(html).toContain('panel:navbar-alerts-panel:3:true:failed')
+  })
+})

--- a/src/shared/ui/navbar-alerts/tests/NavbarAlertsPanel.test.tsx
+++ b/src/shared/ui/navbar-alerts/tests/NavbarAlertsPanel.test.tsx
@@ -1,0 +1,96 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it } from 'vitest'
+import { NavbarAlertsPanel } from '~/shared/ui/navbar-alerts/NavbarAlertsPanel'
+import type { NavbarProcessAlertGroupVM } from '~/shared/ui/navbar-alerts/navbar-alerts.vm'
+
+function buildProcessAlertGroup(): NavbarProcessAlertGroupVM {
+  return {
+    processId: 'process-1',
+    processReference: 'CA048-26',
+    carrier: 'MSC',
+    routeSummary: 'Shanghai -> Santos',
+    activeAlertsCount: 1,
+    dominantSeverity: 'warning',
+    latestAlertAt: '2026-04-10T10:00:00.000Z',
+    containers: [
+      {
+        containerId: 'container-1',
+        containerNumber: 'MSCU1234567',
+        status: 'IN_TRANSIT',
+        eta: {
+          kind: 'date',
+          value: '2026-04-20',
+          timezone: 'UTC',
+        },
+        activeAlertsCount: 1,
+        dominantSeverity: 'warning',
+        latestAlertAt: '2026-04-10T10:00:00.000Z',
+        alerts: [
+          {
+            alertId: 'alert-1',
+            severity: 'warning',
+            category: 'fact',
+            messageKey: 'alerts.transshipmentDetected',
+            messageParams: {
+              port: 'KRPUS',
+              fromVessel: 'MSC IRIS',
+              toVessel: 'MSC BIANCA SILVIA',
+            },
+            occurredAt: '2026-04-10T10:00:00.000Z',
+            retroactive: true,
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function renderPanel(overrides: Partial<Parameters<typeof NavbarAlertsPanel>[0]>): string {
+  return renderToString(() =>
+    createComponent(NavbarAlertsPanel, {
+      panelId: 'alerts-panel',
+      totalAlerts: 0,
+      processes: [],
+      loading: false,
+      error: null,
+      onRetry: () => undefined,
+      onClose: () => undefined,
+      onOpenDashboard: () => undefined,
+      onOpenProcess: () => undefined,
+      onOpenContainer: () => undefined,
+      ...overrides,
+    }),
+  )
+}
+
+describe('NavbarAlertsPanel', () => {
+  it('renders loading, error, and empty states explicitly', () => {
+    const loadingHtml = renderPanel({
+      loading: true,
+    })
+    const errorHtml = renderPanel({
+      error: 'failed',
+    })
+    const emptyHtml = renderPanel({})
+
+    expect(loadingHtml).toContain('animate-pulse')
+    expect(errorHtml).toContain('Falha ao carregar alertas')
+    expect(errorHtml).toContain('Tentar novamente')
+    expect(emptyHtml).toContain('Nenhum alerta ativo')
+  })
+
+  it('renders process, container and retroactive alert information without deriving alert meaning', () => {
+    const html = renderPanel({
+      totalAlerts: 1,
+      processes: [buildProcessAlertGroup()],
+    })
+
+    expect(html).toContain('CA048-26')
+    expect(html).toContain('MSC')
+    expect(html).toContain('Shanghai -> Santos')
+    expect(html).toContain('MSCU1234567')
+    expect(html).toContain('Transbordo detectado em KRPUS')
+    expect(html).toContain('Retroativo')
+  })
+})

--- a/src/shared/ui/navbar-alerts/tests/navbar-alerts.mapper.test.ts
+++ b/src/shared/ui/navbar-alerts/tests/navbar-alerts.mapper.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import type { NavbarAlertsSummaryData } from '~/shared/api/navbar-alerts/navbar-alerts.contract'
+import { temporalDtoFromCanonical } from '~/shared/time/tests/helpers'
+import { toNavbarAlertsVM } from '~/shared/ui/navbar-alerts/navbar-alerts.mapper'
+
+function buildNavbarAlertsSummaryData(): NavbarAlertsSummaryData {
+  return {
+    generated_at: '2026-04-11T12:00:00.000Z',
+    total_active_alerts: 2,
+    processes: [
+      {
+        process_id: 'process-1',
+        process_reference: 'REF-001',
+        carrier: 'MSC',
+        route_summary: 'Shanghai -> Santos',
+        active_alerts_count: 2,
+        dominant_severity: 'warning',
+        latest_alert_at: '2026-04-10T09:00:00.000Z',
+        containers: [
+          {
+            container_id: 'container-1',
+            container_number: 'MSCU1234567',
+            status: 'IN_TRANSIT',
+            eta: temporalDtoFromCanonical('2026-04-20T00:00:00.000Z'),
+            active_alerts_count: 2,
+            dominant_severity: 'warning',
+            latest_alert_at: '2026-04-10T09:00:00.000Z',
+            alerts: [
+              {
+                alert_id: 'alert-1',
+                severity: 'warning',
+                category: 'monitoring',
+                message_key: 'alerts.etaPassed',
+                message_params: {},
+                occurred_at: '2026-04-10T09:00:00.000Z',
+                retroactive: false,
+              },
+              {
+                alert_id: 'alert-2',
+                severity: 'info',
+                category: 'fact',
+                message_key: 'alerts.transshipmentDetected',
+                message_params: {
+                  port: 'Sines',
+                  fromVessel: 'MSC Irina',
+                  toVessel: 'MSC Celestino',
+                },
+                occurred_at: '2026-04-09T18:30:00.000Z',
+                retroactive: true,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('toNavbarAlertsVM', () => {
+  it('maps nested backend summary data into the navbar alert view model without reinterpretation', () => {
+    expect(toNavbarAlertsVM(buildNavbarAlertsSummaryData())).toEqual({
+      totalAlerts: 2,
+      processes: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-001',
+          carrier: 'MSC',
+          routeSummary: 'Shanghai -> Santos',
+          activeAlertsCount: 2,
+          dominantSeverity: 'warning',
+          latestAlertAt: '2026-04-10T09:00:00.000Z',
+          containers: [
+            {
+              containerId: 'container-1',
+              containerNumber: 'MSCU1234567',
+              status: 'IN_TRANSIT',
+              eta: temporalDtoFromCanonical('2026-04-20T00:00:00.000Z'),
+              activeAlertsCount: 2,
+              dominantSeverity: 'warning',
+              latestAlertAt: '2026-04-10T09:00:00.000Z',
+              alerts: [
+                {
+                  alertId: 'alert-1',
+                  severity: 'warning',
+                  category: 'monitoring',
+                  messageKey: 'alerts.etaPassed',
+                  messageParams: {},
+                  occurredAt: '2026-04-10T09:00:00.000Z',
+                  retroactive: false,
+                },
+                {
+                  alertId: 'alert-2',
+                  severity: 'info',
+                  category: 'fact',
+                  messageKey: 'alerts.transshipmentDetected',
+                  messageParams: {
+                    port: 'Sines',
+                    fromVessel: 'MSC Irina',
+                    toVessel: 'MSC Celestino',
+                  },
+                  occurredAt: '2026-04-09T18:30:00.000Z',
+                  retroactive: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/src/shared/ui/navbar-alerts/tests/useNavbarAlerts.test.ts
+++ b/src/shared/ui/navbar-alerts/tests/useNavbarAlerts.test.ts
@@ -1,8 +1,85 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchNavbarAlertsSummaryMock = vi.hoisted(() => vi.fn())
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+vi.mock('~/shared/api/navbar-alerts/navbar-alerts.api', () => ({
+  fetchNavbarAlertsSummary: fetchNavbarAlertsSummaryMock,
+}))
+
+import { createRoot } from 'solid-js'
+import type { NavbarAlertsSummaryData } from '~/shared/api/navbar-alerts/navbar-alerts.contract'
+import { temporalDtoFromCanonical } from '~/shared/time/tests/helpers'
 import {
   hasResolvedNavbarAlertsResource,
   toNavbarAlertsState,
+  useNavbarAlerts,
 } from '~/shared/ui/navbar-alerts/useNavbarAlerts'
+
+type Deferred<T> = {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveDeferred: ((value: T) => void) | undefined
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve
+  })
+
+  if (resolveDeferred === undefined) {
+    throw new Error('Failed to create deferred promise')
+  }
+
+  return {
+    promise,
+    resolve: resolveDeferred,
+  }
+}
+
+function buildNavbarAlertsSummaryData(command?: {
+  readonly totalActiveAlerts?: number
+  readonly processId?: string
+}): NavbarAlertsSummaryData {
+  return {
+    generated_at: '2026-04-11T12:00:00.000Z',
+    total_active_alerts: command?.totalActiveAlerts ?? 1,
+    processes: [
+      {
+        process_id: command?.processId ?? 'process-1',
+        process_reference: 'REF-001',
+        carrier: 'MSC',
+        route_summary: 'Shanghai -> Santos',
+        active_alerts_count: command?.totalActiveAlerts ?? 1,
+        dominant_severity: 'warning',
+        latest_alert_at: '2026-04-10T09:00:00.000Z',
+        containers: [
+          {
+            container_id: 'container-1',
+            container_number: 'MSCU1234567',
+            status: 'IN_TRANSIT',
+            eta: temporalDtoFromCanonical('2026-04-20T00:00:00.000Z'),
+            active_alerts_count: command?.totalActiveAlerts ?? 1,
+            dominant_severity: 'warning',
+            latest_alert_at: '2026-04-10T09:00:00.000Z',
+            alerts: [
+              {
+                alert_id: 'alert-1',
+                severity: 'warning',
+                category: 'monitoring',
+                message_key: 'alerts.etaPassed',
+                message_params: {},
+                occurred_at: '2026-04-10T09:00:00.000Z',
+                retroactive: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
 
 function buildErroredNavbarAlertsResource(): Parameters<typeof toNavbarAlertsState>[0] {
   return {
@@ -13,6 +90,18 @@ function buildErroredNavbarAlertsResource(): Parameters<typeof toNavbarAlertsSta
       throw new Error('navbar alerts resource latest should not be read')
     },
   }
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function createHookHarness() {
+  return createRoot((dispose) => ({
+    hook: useNavbarAlerts(),
+    dispose,
+  }))
 }
 
 describe('useNavbarAlerts helpers', () => {
@@ -26,5 +115,69 @@ describe('useNavbarAlerts helpers', () => {
       error: 'navbar failed',
     })
     expect(hasResolvedNavbarAlertsResource(resource)).toBe(true)
+  })
+})
+
+describe('useNavbarAlerts', () => {
+  beforeEach(() => {
+    fetchNavbarAlertsSummaryMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('loads alerts with cached preference first, then refreshes against the server snapshot', async () => {
+    const initialLoad = createDeferred<NavbarAlertsSummaryData>()
+    fetchNavbarAlertsSummaryMock
+      .mockReturnValueOnce(initialLoad.promise)
+      .mockResolvedValueOnce(buildNavbarAlertsSummaryData({ totalActiveAlerts: 2 }))
+    const harness = createHookHarness()
+
+    await flushAsyncWork()
+
+    expect(fetchNavbarAlertsSummaryMock).toHaveBeenNthCalledWith(1, { preferCached: true })
+    expect(harness.hook.state().loading).toBe(true)
+    expect(harness.hook.hasResolved()).toBe(false)
+
+    initialLoad.resolve(buildNavbarAlertsSummaryData())
+    await flushAsyncWork()
+
+    expect(harness.hook.state()).toMatchObject({
+      totalAlerts: 1,
+      loading: false,
+      error: null,
+    })
+    expect(harness.hook.state().processes[0]?.processId).toBe('process-1')
+    expect(harness.hook.hasResolved()).toBe(true)
+
+    await harness.hook.refresh()
+    await flushAsyncWork()
+
+    expect(fetchNavbarAlertsSummaryMock).toHaveBeenNthCalledWith(2, { preferCached: false })
+    expect(harness.hook.state()).toMatchObject({
+      totalAlerts: 2,
+      loading: false,
+      error: null,
+    })
+
+    harness.dispose()
+  })
+
+  it('exposes backend failures as an explicit error state and marks the resource as resolved', async () => {
+    fetchNavbarAlertsSummaryMock.mockRejectedValueOnce(new Error('network down'))
+    const harness = createHookHarness()
+
+    await flushAsyncWork()
+
+    expect(harness.hook.state()).toEqual({
+      totalAlerts: 0,
+      processes: [],
+      loading: false,
+      error: 'network down',
+    })
+    expect(harness.hook.hasResolved()).toBe(true)
+
+    harness.dispose()
   })
 })

--- a/src/shared/ui/navbar-alerts/tests/useNavbarAlertsButtonController.test.ts
+++ b/src/shared/ui/navbar-alerts/tests/useNavbarAlertsButtonController.test.ts
@@ -1,0 +1,176 @@
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NavbarProcessAlertGroupVM } from '~/shared/ui/navbar-alerts/navbar-alerts.vm'
+
+const navigateMock = vi.hoisted(() => vi.fn())
+const refreshMock = vi.hoisted(() => vi.fn(async () => undefined))
+const navigateToProcessMock = vi.hoisted(() => vi.fn())
+const navigateToProcessContainerMock = vi.hoisted(() => vi.fn())
+
+type NavbarAlertsStateSnapshot = {
+  readonly totalAlerts: number
+  readonly processes: readonly NavbarProcessAlertGroupVM[]
+  readonly loading: boolean
+  readonly error: string | null
+}
+
+const emptyProcesses: readonly NavbarProcessAlertGroupVM[] = []
+
+const navbarAlertsState = vi.hoisted<{
+  state: () => NavbarAlertsStateSnapshot
+  hasResolved: () => boolean
+}>(() => ({
+  state: () => ({
+    totalAlerts: 0,
+    processes: emptyProcesses,
+    loading: false,
+    error: null,
+  }),
+  hasResolved: () => false,
+}))
+
+vi.mock('solid-js', async () => vi.importActual('solid-js/dist/solid.js'))
+
+vi.mock('@solidjs/router', () => ({
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock('~/shared/ui/navbar-alerts/useNavbarAlerts', () => ({
+  useNavbarAlerts: () => ({
+    state: navbarAlertsState.state,
+    hasResolved: navbarAlertsState.hasResolved,
+    refresh: refreshMock,
+  }),
+}))
+
+vi.mock('~/shared/ui/navigation/app-navigation', () => ({
+  navigateToProcess: navigateToProcessMock,
+  navigateToProcessContainer: navigateToProcessContainerMock,
+}))
+
+import { useNavbarAlertsButtonController } from '~/shared/ui/navbar-alerts/useNavbarAlertsButtonController'
+
+type ControllerHarness = ReturnType<typeof useNavbarAlertsButtonController> & {
+  readonly dispose: () => void
+}
+
+function buildProcessAlertGroup(): NavbarProcessAlertGroupVM {
+  return {
+    processId: 'process-1',
+    processReference: 'CA048-26',
+    carrier: 'MSC',
+    routeSummary: 'Shanghai -> Santos',
+    activeAlertsCount: 1,
+    dominantSeverity: 'warning',
+    latestAlertAt: '2026-04-10T10:00:00.000Z',
+    containers: [
+      {
+        containerId: 'container-1',
+        containerNumber: 'MSCU1234567',
+        status: 'IN_TRANSIT',
+        eta: null,
+        activeAlertsCount: 1,
+        dominantSeverity: 'warning',
+        latestAlertAt: '2026-04-10T10:00:00.000Z',
+        alerts: [],
+      },
+    ],
+  }
+}
+
+function mountController(): ControllerHarness {
+  return createRoot((dispose) => ({
+    ...useNavbarAlertsButtonController(),
+    dispose,
+  }))
+}
+
+describe('useNavbarAlertsButtonController', () => {
+  beforeEach(() => {
+    navigateMock.mockReset()
+    refreshMock.mockReset()
+    navigateToProcessMock.mockReset()
+    navigateToProcessContainerMock.mockReset()
+    navbarAlertsState.state = () => ({
+      totalAlerts: 0,
+      processes: [],
+      loading: false,
+      error: null,
+    })
+    navbarAlertsState.hasResolved = () => false
+  })
+
+  it('opens the panel and refreshes unresolved data', () => {
+    const controller = mountController()
+
+    controller.togglePanel()
+
+    expect(controller.isOpen()).toBe(true)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+    controller.dispose()
+  })
+
+  it('does not refresh again when data is already resolved and clean', () => {
+    navbarAlertsState.hasResolved = () => true
+    const controller = mountController()
+
+    controller.togglePanel()
+
+    expect(controller.isOpen()).toBe(true)
+    expect(refreshMock).not.toHaveBeenCalled()
+    controller.dispose()
+  })
+
+  it('keeps the retry action separate from open-close state', () => {
+    navbarAlertsState.hasResolved = () => true
+    const controller = mountController()
+
+    controller.togglePanel()
+    controller.retry()
+
+    expect(controller.isOpen()).toBe(true)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+    controller.dispose()
+  })
+
+  it('routes dashboard, process, and container actions through navigation helpers', () => {
+    navbarAlertsState.state = () => ({
+      totalAlerts: 2,
+      processes: [buildProcessAlertGroup()],
+      loading: false,
+      error: 'failed',
+    })
+
+    const controller = mountController()
+    controller.togglePanel()
+    controller.openDashboard()
+    controller.openProcess('process-1')
+    controller.openContainer('process-1', 'MSCU1234567')
+    controller.openContainer('process-1', 'MSCU1234567')
+
+    expect(navigateMock).toHaveBeenCalledWith('/')
+    expect(navigateToProcessMock).toHaveBeenCalledWith({
+      navigate: navigateMock,
+      processId: 'process-1',
+    })
+
+    const firstCall = navigateToProcessContainerMock.mock.calls[0]?.[0]
+    const secondCall = navigateToProcessContainerMock.mock.calls[1]?.[0]
+
+    expect(firstCall?.navigationState).toEqual({
+      source: 'navbar-alerts',
+      focusSection: 'current-status',
+      revealLiveStatus: true,
+      requestKey: 'navbar-alert-1',
+    })
+    expect(secondCall?.navigationState).toEqual({
+      source: 'navbar-alerts',
+      focusSection: 'current-status',
+      revealLiveStatus: true,
+      requestKey: 'navbar-alert-2',
+    })
+    expect(firstCall?.state).toEqual(firstCall?.navigationState)
+    expect(secondCall?.state).toEqual(secondCall?.navigationState)
+    controller.dispose()
+  })
+})

--- a/src/shared/ui/navbar-alerts/useNavbarAlertsButtonController.ts
+++ b/src/shared/ui/navbar-alerts/useNavbarAlertsButtonController.ts
@@ -1,0 +1,86 @@
+import { useNavigate } from '@solidjs/router'
+import { createSignal } from 'solid-js'
+import { useTranslation } from '~/shared/localization/i18n'
+import { useNavbarAlerts } from '~/shared/ui/navbar-alerts/useNavbarAlerts'
+import {
+  navigateToProcess,
+  navigateToProcessContainer,
+  type ProcessContainerNavigationState,
+} from '~/shared/ui/navigation/app-navigation'
+
+export function useNavbarAlertsButtonController() {
+  const { t, keys } = useTranslation()
+  const navigate = useNavigate()
+  const navbarAlerts = useNavbarAlerts()
+  const [isOpen, setIsOpen] = createSignal(false)
+  let containerNavigationRequestCounter = 0
+
+  const totalAlerts = () => navbarAlerts.state().totalAlerts
+
+  const togglePanel = () => {
+    const nextOpenState = !isOpen()
+    setIsOpen(nextOpenState)
+    if (nextOpenState && (!navbarAlerts.hasResolved() || navbarAlerts.state().error !== null)) {
+      void navbarAlerts.refresh()
+    }
+  }
+
+  const closePanel = () => {
+    setIsOpen(false)
+  }
+
+  const retry = () => {
+    void navbarAlerts.refresh()
+  }
+
+  const openDashboard = () => {
+    closePanel()
+    void navigate('/')
+  }
+
+  const openProcess = (processId: string) => {
+    closePanel()
+    navigateToProcess({
+      navigate,
+      processId,
+    })
+  }
+
+  const openContainer = (processId: string, containerNumber: string) => {
+    closePanel()
+
+    containerNavigationRequestCounter += 1
+    const navigationState: ProcessContainerNavigationState = {
+      source: 'navbar-alerts',
+      focusSection: 'current-status',
+      revealLiveStatus: true,
+      requestKey: `navbar-alert-${containerNavigationRequestCounter}`,
+    }
+
+    navigateToProcessContainer({
+      navigate,
+      processId,
+      containerNumber,
+      navigationState,
+      state: navigationState,
+    })
+  }
+
+  const buttonTitle = () =>
+    totalAlerts() > 0
+      ? t(keys.header.alertsActiveTooltip, { count: totalAlerts() })
+      : t(keys.header.alertsPanel.empty)
+
+  return {
+    isOpen,
+    totalAlerts,
+    state: navbarAlerts.state,
+    togglePanel,
+    closePanel,
+    retry,
+    openDashboard,
+    openProcess,
+    openContainer,
+    buttonTitle,
+  }
+}

--- a/src/shared/ui/tests/AppHeader.test.tsx
+++ b/src/shared/ui/tests/AppHeader.test.tsx
@@ -1,0 +1,175 @@
+import { createComponent, type JSX } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type MockLocationState = {
+  pathname: string
+}
+
+type MockThemeState = {
+  current: 'light' | 'dark'
+}
+
+const locationState = vi.hoisted<MockLocationState>(() => ({
+  pathname: '/',
+}))
+
+const themeState = vi.hoisted<MockThemeState>(() => ({
+  current: 'light',
+}))
+
+const translationKeys = vi.hoisted(() => ({
+  header: {
+    nav: {
+      dashboard: 'header.nav.dashboard',
+      agents: 'header.nav.agents',
+    },
+    createProcess: 'header.createProcess',
+    theme: {
+      switchToLight: 'header.theme.switchToLight',
+      switchToDark: 'header.theme.switchToDark',
+    },
+  },
+}))
+
+function translate(value: string): string {
+  switch (value) {
+    case 'header.nav.dashboard':
+      return 'Dashboard'
+    case 'header.nav.agents':
+      return 'Agents'
+    case 'header.createProcess':
+      return 'Create process'
+    case 'header.theme.switchToLight':
+      return 'Switch to light theme'
+    case 'header.theme.switchToDark':
+      return 'Switch to dark theme'
+    default:
+      return value
+  }
+}
+
+function normalizeSsrHtml(html: string): string {
+  return html.replaceAll('<!--$-->', '').replaceAll('<!--/-->', '')
+}
+
+vi.mock('@solidjs/router', () => ({
+  A: (props: {
+    readonly href: string
+    readonly children?: JSX.Element
+    readonly class?: string
+    readonly end?: boolean
+    readonly noScroll?: boolean
+    readonly 'aria-label'?: string
+  }) => (
+    <a
+      href={props.href}
+      class={props.class}
+      aria-label={props['aria-label']}
+      data-end={props.end ? 'true' : undefined}
+      data-no-scroll={props.noScroll ? 'true' : undefined}
+    >
+      {props.children}
+    </a>
+  ),
+  useLocation: () => locationState,
+}))
+
+vi.mock('lucide-solid', () => ({
+  Moon: (props: {
+    readonly class?: string
+    readonly 'aria-hidden'?: boolean | 'true' | 'false'
+  }) => <svg data-icon="moon" class={props.class} aria-hidden={props['aria-hidden']} />,
+  Sun: (props: {
+    readonly class?: string
+    readonly 'aria-hidden'?: boolean | 'true' | 'false'
+  }) => <svg data-icon="sun" class={props.class} aria-hidden={props['aria-hidden']} />,
+}))
+
+vi.mock('~/lib/theme', () => ({
+  getTheme: () => themeState.current,
+  toggleTheme: () => {
+    themeState.current = themeState.current === 'dark' ? 'light' : 'dark'
+    return themeState.current
+  },
+}))
+
+vi.mock('~/shared/localization/i18n', () => ({
+  useTranslation: () => ({
+    t: translate,
+    keys: translationKeys,
+  }),
+}))
+
+vi.mock('~/shared/ui/navbar-alerts/NavbarAlertsButton', () => ({
+  NavbarAlertsButton: () => <div>mock-navbar-alerts</div>,
+}))
+
+import { AppHeader } from '~/shared/ui/AppHeader'
+
+describe('AppHeader', () => {
+  beforeEach(() => {
+    locationState.pathname = '/'
+    themeState.current = 'light'
+  })
+
+  it('renders brand, active dashboard navigation, and optional slots', () => {
+    const html = normalizeSsrHtml(
+      renderToString(() =>
+        createComponent(AppHeader, {
+          preserveDashboardScroll: true,
+          onCreateProcess: () => undefined,
+          onDashboardIntent: () => undefined,
+          searchSlot: (
+            <button type="button" data-search-trigger="true">
+              Search shipments
+            </button>
+          ),
+          syncSlot: <div>Sync status</div>,
+          actionsSlot: <button type="button">Open menu</button>,
+        }),
+      ),
+    )
+
+    expect(html).toContain('Container Tracker')
+    expect(html).toContain('Castro Aduaneira')
+    expect(html).toContain('/branding/logo-light.png')
+    expect(html).toContain('/branding/logo-dark.png')
+    expect(html).toContain('aria-label="Castro Aduaneira — Container Tracker"')
+    expect(html).toMatch(/href="\/"[^>]*before:bg-primary/)
+    expect(html).toContain('Search shipments')
+    expect(html).toContain('Sync status')
+    expect(html).toContain('Open menu')
+    expect(html).toContain('Create process')
+    expect(html).toContain('mock-navbar-alerts')
+    expect(html).toContain('aria-label="Switch to dark theme"')
+    expect(html).toContain('data-icon="moon"')
+    expect(html.match(/data-no-scroll="true"/g)?.length ?? 0).toBe(2)
+  })
+
+  it('renders dark theme controls and omits optional slots when they are absent', () => {
+    locationState.pathname = '/agents'
+    themeState.current = 'dark'
+
+    const html = normalizeSsrHtml(
+      renderToString(() =>
+        createComponent(AppHeader, {
+          searchSlot: undefined,
+          syncSlot: undefined,
+          actionsSlot: undefined,
+        }),
+      ),
+    )
+
+    expect(html).toContain('Dashboard')
+    expect(html).toMatch(/href="\/agents"[^>]*before:bg-primary/)
+    expect(html).toContain('mock-navbar-alerts')
+    expect(html).toContain('aria-label="Switch to light theme"')
+    expect(html).toContain('data-icon="sun"')
+    expect(html).not.toContain('Search shipments')
+    expect(html).not.toContain('Sync status')
+    expect(html).not.toContain('Open menu')
+    expect(html).not.toContain('Create process')
+    expect(html).not.toContain('data-no-scroll="true"')
+  })
+})

--- a/src/shared/ui/tests/Dialog.test.tsx
+++ b/src/shared/ui/tests/Dialog.test.tsx
@@ -1,0 +1,80 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { Dialog } from '~/shared/ui/Dialog'
+
+const translationKeys = vi.hoisted(() => ({
+  dialog: {
+    close: 'dialog.close',
+  },
+}))
+
+vi.mock('solid-js/web', async () => {
+  const actual = await vi.importActual<typeof import('solid-js/web')>('solid-js/web')
+
+  return {
+    ...actual,
+    Portal: (props: { readonly children?: unknown }) => <>{props.children}</>,
+  }
+})
+
+vi.mock('~/shared/localization/i18n', () => ({
+  useTranslation: () => ({
+    t: (value: string) => {
+      if (value === 'dialog.close') return 'Close dialog'
+      return value
+    },
+    keys: translationKeys,
+  }),
+}))
+
+describe('Dialog', () => {
+  it('renders nothing when closed', () => {
+    const html = renderToString(() =>
+      createComponent(Dialog, {
+        open: false,
+        onClose: () => undefined,
+        title: 'Export data',
+        children: <div>Dialog body</div>,
+      }),
+    )
+
+    expect(html).toBe('')
+  })
+
+  it('renders title, description, content, and width class when open', () => {
+    const html = renderToString(() =>
+      createComponent(Dialog, {
+        open: true,
+        onClose: () => undefined,
+        title: 'Export data',
+        description: 'Choose the export format',
+        maxWidth: '2xl',
+        children: <div>Dialog body</div>,
+      }),
+    )
+
+    expect(html).toContain('role="dialog"')
+    expect(html).toContain('Export data')
+    expect(html).toContain('Choose the export format')
+    expect(html).toContain('Dialog body')
+    expect(html).toContain('aria-label="Close dialog"')
+    expect(html).toContain('max-w-2xl')
+  })
+
+  it('falls back to lg width and omits description when not provided', () => {
+    const html = renderToString(() =>
+      createComponent(Dialog, {
+        open: true,
+        onClose: () => undefined,
+        title: 'Import bundle',
+        children: <div>Import body</div>,
+      }),
+    )
+
+    expect(html).toContain('Import bundle')
+    expect(html).toContain('Import body')
+    expect(html).toContain('max-w-lg')
+    expect(html).not.toContain('mt-1 text-md-ui text-text-muted')
+  })
+})

--- a/src/shared/ui/tests/EmptyState.test.tsx
+++ b/src/shared/ui/tests/EmptyState.test.tsx
@@ -1,0 +1,48 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { EmptyState } from '~/shared/ui/EmptyState'
+
+describe('EmptyState', () => {
+  it('renders title and description without an action button by default', () => {
+    const html = renderToString(() =>
+      createComponent(EmptyState, {
+        title: 'No results found',
+        description: 'Try a different search term',
+      }),
+    )
+
+    expect(html).toContain('No results found')
+    expect(html).toContain('Try a different search term')
+    expect(html).not.toContain('<button')
+  })
+
+  it('renders an action button only when both label and callback are provided', () => {
+    const onAction = vi.fn()
+    const html = renderToString(() =>
+      createComponent(EmptyState, {
+        title: 'No shipments yet',
+        description: 'Create your first shipment to get started',
+        actionLabel: 'Create shipment',
+        onAction,
+      }),
+    )
+
+    expect(html).toContain('Create shipment')
+    expect(html).toContain('<button')
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it('does not render an action button when the label exists without a callback', () => {
+    const html = renderToString(() =>
+      createComponent(EmptyState, {
+        title: 'Nothing here',
+        description: 'Waiting for data',
+        actionLabel: 'Retry',
+      }),
+    )
+
+    expect(html).toContain('Nothing here')
+    expect(html).not.toContain('<button')
+  })
+})

--- a/src/shared/ui/tests/ExistingProcessError.test.tsx
+++ b/src/shared/ui/tests/ExistingProcessError.test.tsx
@@ -1,0 +1,108 @@
+import { createComponent, type JSX } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { ExistingProcessError } from '~/shared/ui/ExistingProcessError'
+
+const locationState = vi.hoisted(() => ({
+  pathname: '/',
+}))
+
+const translationKeys = vi.hoisted(() => ({
+  createProcess: {
+    action: {
+      existingProcessSame: 'createProcess.action.existingProcessSame',
+      existingProcessError: 'createProcess.action.existingProcessError',
+      existingProcessLink: 'createProcess.action.existingProcessLink',
+      dismiss: 'createProcess.action.dismiss',
+    },
+  },
+}))
+
+vi.mock('@solidjs/router', () => ({
+  A: (props: { readonly href: string; readonly children?: JSX.Element }) => (
+    <a href={props.href}>{props.children}</a>
+  ),
+  useLocation: () => ({
+    pathname: locationState.pathname,
+    search: '',
+    hash: '',
+    state: null,
+    query: {},
+  }),
+}))
+
+vi.mock('~/shared/localization/i18n', () => ({
+  useTranslation: () => ({
+    t: (value: string, params?: Readonly<Record<string, unknown>>) => {
+      if (value === 'createProcess.action.existingProcessSame') {
+        return `same:${String(params?.container ?? '')}`
+      }
+      if (value === 'createProcess.action.existingProcessError') {
+        return `existing:${String(params?.container ?? '')}`
+      }
+      if (value === 'createProcess.action.existingProcessLink') {
+        return 'Open existing process'
+      }
+      if (value === 'createProcess.action.dismiss') {
+        return 'Dismiss duplicate warning'
+      }
+      return value
+    },
+    keys: translationKeys,
+  }),
+}))
+
+vi.mock('~/shared/ui/navigation/app-navigation', () => ({
+  toInternalAppPathname: (value: string) => value.split('?')[0]?.split('#')[0] ?? '',
+}))
+
+describe('ExistingProcessError', () => {
+  it('renders the same-process message and hides the link when already on the target page', () => {
+    locationState.pathname = '/shipments/process-1'
+
+    const html = renderToString(() =>
+      createComponent(ExistingProcessError, {
+        existing: {
+          processId: 'process-1',
+          containerNumber: 'MSCU1234567',
+          link: '/shipments/process-1?tab=alerts',
+        },
+      }),
+    )
+
+    expect(html).toContain('same:MSCU1234567')
+    expect(html).toContain('aria-label="Dismiss duplicate warning"')
+    expect(html).not.toContain('Open existing process')
+  })
+
+  it('renders the existing-process message with extracted container number and link to the other process', () => {
+    locationState.pathname = '/shipments/current'
+
+    const html = renderToString(() =>
+      createComponent(ExistingProcessError, {
+        message: 'Container MSCU7654321 already belongs to another shipment.',
+        existing: {
+          processId: 'process-2',
+        },
+      }),
+    )
+
+    expect(html).toContain('existing:MSCU7654321')
+    expect(html).toContain('href="/shipments/process-2"')
+    expect(html).toContain('Open existing process')
+  })
+
+  it('falls back to the raw message when no existing container context is available', () => {
+    locationState.pathname = '/shipments/current'
+
+    const html = renderToString(() =>
+      createComponent(ExistingProcessError, {
+        message: 'Duplicate shipment detected.',
+        existing: null,
+      }),
+    )
+
+    expect(html).toContain('Duplicate shipment detected.')
+    expect(html).not.toContain('Open existing process')
+  })
+})

--- a/src/shared/ui/tests/FormFields.test.tsx
+++ b/src/shared/ui/tests/FormFields.test.tsx
@@ -1,0 +1,103 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it } from 'vitest'
+import { FormInput, FormSelect } from '~/shared/ui/FormFields'
+
+describe('FormInput', () => {
+  it('renders helper text, required marker, and descriptive attributes', () => {
+    const html = renderToString(() =>
+      createComponent(FormInput, {
+        label: 'Container',
+        name: 'containerNumber',
+        value: 'MSCU1234567',
+        onInput: () => undefined,
+        onBlur: () => undefined,
+        onPaste: () => undefined,
+        placeholder: 'Enter container',
+        helperText: 'Use the exact carrier number',
+        required: true,
+      }),
+    )
+
+    expect(html).toContain('Container')
+    expect(html).toContain('for="containerNumber"')
+    expect(html).toContain('placeholder="Enter container"')
+    expect(html).toContain('Use the exact carrier number')
+    expect(html).toContain('aria-invalid="false"')
+    expect(html).toContain('aria-describedby="containerNumber-description"')
+    expect(html).toContain('focus:border-control-selected-border')
+    expect(html).toContain('text-tone-danger-strong')
+    expect(html).not.toContain('role="alert"')
+  })
+
+  it('renders the error branch and disables the field when requested', () => {
+    const html = renderToString(() =>
+      createComponent(FormInput, {
+        label: 'Weight',
+        name: 'weight',
+        value: 'abc',
+        type: 'number',
+        onInput: () => undefined,
+        error: 'Invalid number',
+        helperText: 'Ignored while error is visible',
+        disabled: true,
+      }),
+    )
+
+    expect(html).toContain('type="number"')
+    expect(html).toMatch(/<input[^>]*\sdisabled(?=\s|>)/)
+    expect(html).toContain('aria-invalid="true"')
+    expect(html).toContain('role="alert"')
+    expect(html).toContain('Invalid number')
+    expect(html).toContain('border-tone-danger-border')
+    expect(html).not.toContain('Ignored while error is visible')
+  })
+})
+
+describe('FormSelect', () => {
+  it('renders placeholder, helper text, and options', () => {
+    const html = renderToString(() =>
+      createComponent(FormSelect, {
+        label: 'Carrier',
+        name: 'carrier',
+        value: '',
+        onInput: () => undefined,
+        placeholder: 'Choose carrier',
+        helperText: 'Select the source carrier',
+        required: true,
+        options: [
+          { value: 'maersk', label: 'Maersk' },
+          { value: 'msc', label: 'MSC' },
+        ],
+      }),
+    )
+
+    expect(html).toContain('Carrier')
+    expect(html).toContain('for="carrier"')
+    expect(html).toContain('Choose carrier')
+    expect(html).toContain('Select the source carrier')
+    expect(html).toContain('value="maersk"')
+    expect(html).toContain('Maersk')
+    expect(html).toContain('value="msc"')
+    expect(html).toContain('MSC')
+    expect(html).toMatch(/<select[^>]*\srequired(?=\s|>)/)
+  })
+
+  it('omits placeholder and helper text when they are not provided', () => {
+    const html = renderToString(() =>
+      createComponent(FormSelect, {
+        label: 'Transport mode',
+        name: 'mode',
+        value: 'sea',
+        onInput: () => undefined,
+        options: [{ value: 'sea', label: 'Sea' }],
+      }),
+    )
+
+    expect(html).toContain('Transport mode')
+    expect(html).toContain('Sea')
+    expect(html).not.toContain('Choose carrier')
+    expect(html).not.toContain('text-xs-ui text-text-muted')
+    expect(html).not.toMatch(/<select[^>]*\srequired(?=\s|>)/)
+  })
+})

--- a/src/shared/ui/tests/Layout.test.tsx
+++ b/src/shared/ui/tests/Layout.test.tsx
@@ -1,0 +1,66 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it } from 'vitest'
+import { Panel } from '~/shared/ui/layout/Panel'
+import { Stack } from '~/shared/ui/layout/Stack'
+
+describe('Panel', () => {
+  it('renders header metadata and header slot when provided', () => {
+    const html = renderToString(() =>
+      createComponent(Panel, {
+        title: 'Overview',
+        subtitle: 'Shipment metadata',
+        class: 'outer-shell',
+        bodyClass: 'panel-body',
+        headerSlot: <button type="button">Refresh</button>,
+        children: <div>Body content</div>,
+      }),
+    )
+
+    expect(html).toContain('Overview')
+    expect(html).toContain('Shipment metadata')
+    expect(html).toContain('Refresh')
+    expect(html).toContain('Body content')
+    expect(html).toContain('outer-shell')
+    expect(html).toContain('panel-body')
+    expect(html).toContain('border-b border-border/70')
+  })
+
+  it('omits the header wrapper when no header content exists', () => {
+    const html = renderToString(() =>
+      createComponent(Panel, {
+        children: <div>Only body</div>,
+      }),
+    )
+
+    expect(html).toContain('Only body')
+    expect(html).not.toContain('border-b border-border/70')
+    expect(html).not.toContain('text-micro font-semibold uppercase')
+  })
+})
+
+describe('Stack', () => {
+  it('uses the default medium gap', () => {
+    const html = renderToString(() =>
+      createComponent(Stack, {
+        children: <div>First</div>,
+      }),
+    )
+
+    expect(html).toContain('flex flex-col gap-4')
+    expect(html).toContain('First')
+  })
+
+  it('uses the requested gap size and custom class', () => {
+    const html = renderToString(() =>
+      createComponent(Stack, {
+        gap: 'lg',
+        class: 'stack-shell',
+        children: <div>Second</div>,
+      }),
+    )
+
+    expect(html).toContain('flex flex-col gap-6 stack-shell')
+    expect(html).toContain('Second')
+  })
+})

--- a/src/shared/ui/tests/StatusBadge.test.tsx
+++ b/src/shared/ui/tests/StatusBadge.test.tsx
@@ -1,0 +1,94 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { StatusBadge } from '~/shared/ui/StatusBadge'
+
+vi.mock('lucide-solid', () => ({
+  Check: () => '<check-icon />',
+  Circle: () => '<circle-icon />',
+  CircleDot: () => '<circle-dot-icon />',
+  Minus: () => '<minus-icon />',
+}))
+
+describe('StatusBadge', () => {
+  it('renders transit variants with the operational transit color group', () => {
+    const html = renderToString(() =>
+      createComponent(StatusBadge, {
+        variant: 'in-transit',
+        label: 'Em trânsito',
+      }),
+    )
+
+    expect(html).toContain('Em trânsito')
+    expect(html).toContain('--color-status-in-transit-bg')
+    expect(html).toContain('circle-icon')
+  })
+
+  it('renders delivered variants with the cleared color group and check icon', () => {
+    const html = renderToString(() =>
+      createComponent(StatusBadge, {
+        variant: 'delivered',
+        label: 'Entregue',
+      }),
+    )
+
+    expect(html).toContain('Entregue')
+    expect(html).toContain('--color-status-cleared-bg')
+    expect(html).toContain('check-icon')
+  })
+
+  it('renders partial variants with the discharged color group and partial icon', () => {
+    const html = renderToString(() =>
+      createComponent(StatusBadge, {
+        variant: 'partial',
+        label: 'Parcial',
+      }),
+    )
+
+    expect(html).toContain('Parcial')
+    expect(html).toContain('--color-status-discharged-bg')
+    expect(html).toContain('circle-dot-icon')
+  })
+
+  it('renders unknown variants with neutral fallback classes and dash icon', () => {
+    const html = renderToString(() =>
+      createComponent(StatusBadge, {
+        variant: 'unknown',
+        label: 'Desconhecido',
+      }),
+    )
+
+    expect(html).toContain('Desconhecido')
+    expect(html).toContain('border-border bg-surface-muted text-text-muted')
+    expect(html).toContain('minus-icon')
+  })
+
+  it('supports micro badges and hidden icons for compact layouts', () => {
+    const html = renderToString(() =>
+      createComponent(StatusBadge, {
+        variant: 'delayed',
+        label: 'Atrasado',
+        size: 'micro',
+        hideIcon: true,
+      }),
+    )
+
+    expect(html).toContain('Atrasado')
+    expect(html).toContain('text-micro')
+    expect(html).toContain('truncate max-w-[11rem]')
+    expect(html).not.toContain('icon')
+  })
+
+  it('lets neutral mode override semantic colors without dropping the icon', () => {
+    const html = renderToString(() =>
+      createComponent(StatusBadge, {
+        variant: 'delivered',
+        label: 'Entregue',
+        neutral: true,
+      }),
+    )
+
+    expect(html).toContain('border-border bg-surface-muted text-text-muted')
+    expect(html).toContain('check-icon')
+  })
+})


### PR DESCRIPTION
## Summary
- Added broad coverage for the global search dialog, controller, token parsing, API use cases, and search view states.
- Added tests for export/import actions controller and view behavior, plus navbar alerts, shipment screen, dashboard sync, and process refresh flows.
- Tightened persistence mapper coverage for container row/entity transformations.
- Refactored `ExportImportActions` to move interaction logic into a dedicated controller while preserving the existing UI contract.

## Testing
- Not run (tests added/updated only).
- Concrete checks added in this change:
  - global search open/close, suggestion, and result interaction wiring
  - debounce, stale-response, empty-state, and navigation behavior in the search controller
  - search query/suggestion API URL construction
  - render coverage for composer, body, suggestions, and result rows
  - container persistence mapper round-trips and explicit null insert fields
  - navbar alerts, shipment screen, dashboard sync, and export/import controller/view behavior