### PR TITLE
Enable partial dashboard sync results

### DIFF
--- a/src/capabilities/sync/application/ports/sync-target-read.port.ts
+++ b/src/capabilities/sync/application/ports/sync-target-read.port.ts
@@ -8,6 +8,12 @@ export type SyncTargetReadPort = {
   readonly fetchProcessById: (command: {
     readonly processId: string
   }) => Promise<{ readonly id: string } | null>
+  readonly listActiveProcessesForDashboardSync: () => Promise<
+    readonly {
+      readonly processId: string
+      readonly processReference: string | null
+    }[]
+  >
   readonly listActiveProcessIds: () => Promise<readonly string[]>
   readonly listContainersByProcessId: (command: { readonly processId: string }) => Promise<{
     readonly containers: readonly SyncTargetContainerRecord[]

--- a/src/capabilities/sync/application/services/sync-dashboard-enqueue.service.ts
+++ b/src/capabilities/sync/application/services/sync-dashboard-enqueue.service.ts
@@ -70,29 +70,30 @@ export function createSyncDashboardEnqueueService(deps: {
       const uniqueOutcomes = await Promise.all(
         Array.from(firstTargetByKey.entries()).map(
           async ([key, target]): Promise<readonly [string, UniqueEnqueueOutcome]> => {
-          try {
-            const enqueueResult = await deps.queuePort.enqueueContainerSyncRequest({
-              tenantId: command.tenantId,
-              mode: command.mode,
-              provider: target.provider,
-              containerNumber: target.containerNumber,
-            })
+            try {
+              const enqueueResult = await deps.queuePort.enqueueContainerSyncRequest({
+                tenantId: command.tenantId,
+                mode: command.mode,
+                provider: target.provider,
+                containerNumber: target.containerNumber,
+              })
 
-            if (!enqueueResult.isNew) {
-              return [key, { kind: 'skipped' }] as const
+              if (!enqueueResult.isNew) {
+                return [key, { kind: 'skipped' }] as const
+              }
+
+              return [
+                key,
+                {
+                  kind: 'enqueued',
+                  syncRequestId: enqueueResult.id,
+                },
+              ] as const
+            } catch {
+              return [key, { kind: 'failed' }] as const
             }
-
-            return [
-              key,
-              {
-                kind: 'enqueued',
-                syncRequestId: enqueueResult.id,
-              },
-            ] as const
-          } catch {
-            return [key, { kind: 'failed' }] as const
-          }
-        }),
+          },
+        ),
       )
 
       const outcomeByKey = new Map<string, UniqueEnqueueOutcome>(uniqueOutcomes)

--- a/src/capabilities/sync/application/services/sync-dashboard-enqueue.service.ts
+++ b/src/capabilities/sync/application/services/sync-dashboard-enqueue.service.ts
@@ -1,0 +1,177 @@
+import type { SyncMode } from '~/capabilities/sync/application/commands/enqueue-sync.command'
+import type { SyncQueuePort } from '~/capabilities/sync/application/ports/sync-queue.port'
+import type { DashboardSyncEligibleTarget } from '~/capabilities/sync/application/services/sync-dashboard-targets.service'
+import type {
+  SyncDashboardEnqueuedTarget,
+  SyncDashboardFailedTarget,
+  SyncDashboardSkippedTarget,
+} from '~/capabilities/sync/application/usecases/sync-dashboard-batch-result'
+
+const DUPLICATE_OPEN_REQUEST_MESSAGE =
+  'Target already has an open sync request or was already included in this batch.'
+const ENQUEUE_FAILED_MESSAGE = 'Failed to enqueue dashboard sync request.'
+
+type SyncDashboardEnqueueResult = {
+  readonly enqueuedTargets: readonly SyncDashboardEnqueuedTarget[]
+  readonly skippedTargets: readonly SyncDashboardSkippedTarget[]
+  readonly failedTargets: readonly SyncDashboardFailedTarget[]
+  readonly newSyncRequestIds: readonly string[]
+}
+
+type SyncDashboardEnqueueService = {
+  readonly enqueue: (command: {
+    readonly tenantId: string
+    readonly mode: SyncMode
+    readonly targets: readonly DashboardSyncEligibleTarget[]
+  }) => Promise<SyncDashboardEnqueueResult>
+}
+
+type UniqueEnqueueOutcome =
+  | {
+      readonly kind: 'enqueued'
+      readonly syncRequestId: string
+    }
+  | {
+      readonly kind: 'skipped'
+    }
+  | {
+      readonly kind: 'failed'
+    }
+
+function toTargetKey(target: DashboardSyncEligibleTarget): string {
+  return `${target.provider}:${target.containerNumber}`
+}
+
+export function createSyncDashboardEnqueueService(deps: {
+  readonly queuePort: SyncQueuePort
+}): SyncDashboardEnqueueService {
+  return {
+    async enqueue(command) {
+      if (command.targets.length === 0) {
+        return {
+          enqueuedTargets: [],
+          skippedTargets: [],
+          failedTargets: [],
+          newSyncRequestIds: [],
+        }
+      }
+
+      const firstTargetByKey = new Map<string, DashboardSyncEligibleTarget>()
+
+      for (const target of command.targets) {
+        const key = toTargetKey(target)
+        if (firstTargetByKey.has(key)) {
+          continue
+        }
+
+        firstTargetByKey.set(key, target)
+      }
+
+      const uniqueOutcomes = await Promise.all(
+        Array.from(firstTargetByKey.entries()).map(
+          async ([key, target]): Promise<readonly [string, UniqueEnqueueOutcome]> => {
+          try {
+            const enqueueResult = await deps.queuePort.enqueueContainerSyncRequest({
+              tenantId: command.tenantId,
+              mode: command.mode,
+              provider: target.provider,
+              containerNumber: target.containerNumber,
+            })
+
+            if (!enqueueResult.isNew) {
+              return [key, { kind: 'skipped' }] as const
+            }
+
+            return [
+              key,
+              {
+                kind: 'enqueued',
+                syncRequestId: enqueueResult.id,
+              },
+            ] as const
+          } catch {
+            return [key, { kind: 'failed' }] as const
+          }
+        }),
+      )
+
+      const outcomeByKey = new Map<string, UniqueEnqueueOutcome>(uniqueOutcomes)
+      const duplicateCountByKey = new Map<string, number>()
+      const enqueuedTargets: SyncDashboardEnqueuedTarget[] = []
+      const skippedTargets: SyncDashboardSkippedTarget[] = []
+      const failedTargets: SyncDashboardFailedTarget[] = []
+
+      for (const target of command.targets) {
+        const key = toTargetKey(target)
+        const firstOccurrenceCount = duplicateCountByKey.get(key) ?? 0
+        duplicateCountByKey.set(key, firstOccurrenceCount + 1)
+
+        if (firstOccurrenceCount > 0) {
+          skippedTargets.push({
+            processId: target.processId,
+            processReference: target.processReference,
+            containerNumber: target.containerNumber,
+            provider: target.provider,
+            reasonCode: 'DUPLICATE_OPEN_REQUEST',
+            reasonMessage: DUPLICATE_OPEN_REQUEST_MESSAGE,
+          })
+          continue
+        }
+
+        const outcome = outcomeByKey.get(key)
+        if (outcome === undefined) {
+          failedTargets.push({
+            processId: target.processId,
+            processReference: target.processReference,
+            containerNumber: target.containerNumber,
+            provider: target.provider,
+            reasonCode: 'UNEXPECTED_ERROR',
+            reasonMessage: ENQUEUE_FAILED_MESSAGE,
+          })
+          continue
+        }
+
+        if (outcome.kind === 'skipped') {
+          skippedTargets.push({
+            processId: target.processId,
+            processReference: target.processReference,
+            containerNumber: target.containerNumber,
+            provider: target.provider,
+            reasonCode: 'DUPLICATE_OPEN_REQUEST',
+            reasonMessage: DUPLICATE_OPEN_REQUEST_MESSAGE,
+          })
+          continue
+        }
+
+        if (outcome.kind === 'failed') {
+          failedTargets.push({
+            processId: target.processId,
+            processReference: target.processReference,
+            containerNumber: target.containerNumber,
+            provider: target.provider,
+            reasonCode: 'ENQUEUE_FAILED',
+            reasonMessage: ENQUEUE_FAILED_MESSAGE,
+          })
+          continue
+        }
+
+        enqueuedTargets.push({
+          processId: target.processId,
+          processReference: target.processReference,
+          containerNumber: target.containerNumber,
+          provider: target.provider,
+          syncRequestId: outcome.syncRequestId,
+        })
+      }
+
+      return {
+        enqueuedTargets,
+        skippedTargets,
+        failedTargets,
+        newSyncRequestIds: enqueuedTargets.map((target) => target.syncRequestId),
+      }
+    },
+  }
+}
+
+export type { SyncDashboardEnqueueService }

--- a/src/capabilities/sync/application/services/sync-dashboard-targets.service.ts
+++ b/src/capabilities/sync/application/services/sync-dashboard-targets.service.ts
@@ -1,0 +1,113 @@
+import type { SupportedSyncProvider } from '~/capabilities/sync/application/ports/sync-queue.port'
+import type { SyncTargetReadPort } from '~/capabilities/sync/application/ports/sync-target-read.port'
+import {
+  normalizeContainerNumber,
+  toNormalizedProviderKey,
+  toSupportedProvider,
+} from '~/capabilities/sync/application/services/sync-provider-resolution.utils'
+import type { SyncDashboardSkippedTarget } from '~/capabilities/sync/application/usecases/sync-dashboard-batch-result'
+
+const MISSING_REQUIRED_DATA_MESSAGE =
+  'Missing container number or provider required for dashboard manual sync.'
+const UNSUPPORTED_PROVIDER_MESSAGE = 'Provider is not supported for dashboard manual sync.'
+
+export type DashboardSyncEligibleTarget = {
+  readonly processId: string
+  readonly processReference: string | null
+  readonly containerNumber: string
+  readonly provider: SupportedSyncProvider
+}
+
+export type SyncDashboardTargetsResult = {
+  readonly requestedProcesses: number
+  readonly requestedContainers: number
+  readonly eligibleTargets: readonly DashboardSyncEligibleTarget[]
+  readonly skippedTargets: readonly SyncDashboardSkippedTarget[]
+}
+
+type SyncDashboardTargetsService = {
+  readonly resolveTargets: () => Promise<SyncDashboardTargetsResult>
+}
+
+export function createSyncDashboardTargetsService(deps: {
+  readonly targetReadPort: SyncTargetReadPort
+}): SyncDashboardTargetsService {
+  return {
+    async resolveTargets() {
+      const activeProcesses = await deps.targetReadPort.listActiveProcessesForDashboardSync()
+      if (activeProcesses.length === 0) {
+        return {
+          requestedProcesses: 0,
+          requestedContainers: 0,
+          eligibleTargets: [],
+          skippedTargets: [],
+        }
+      }
+
+      const processIds = activeProcesses.map((process) => process.processId)
+      const processReferenceById = new Map(
+        activeProcesses.map((process) => [process.processId, process.processReference] as const),
+      )
+
+      const { containersByProcessId } = await deps.targetReadPort.listContainersByProcessIds({
+        processIds,
+      })
+
+      const eligibleTargets: DashboardSyncEligibleTarget[] = []
+      const skippedTargets: SyncDashboardSkippedTarget[] = []
+      let requestedContainers = 0
+
+      for (const process of activeProcesses) {
+        const containers = containersByProcessId.get(process.processId) ?? []
+        for (const container of containers) {
+          requestedContainers += 1
+
+          const containerNumber = normalizeContainerNumber(container.containerNumber)
+          const provider = toSupportedProvider(container.carrierCode)
+          const providerKey = toNormalizedProviderKey(container.carrierCode)
+          const processReference = processReferenceById.get(process.processId) ?? null
+
+          if (containerNumber.length === 0) {
+            skippedTargets.push({
+              processId: process.processId,
+              processReference,
+              containerNumber,
+              provider: providerKey,
+              reasonCode: 'MISSING_REQUIRED_DATA',
+              reasonMessage: MISSING_REQUIRED_DATA_MESSAGE,
+            })
+            continue
+          }
+
+          if (provider === null) {
+            skippedTargets.push({
+              processId: process.processId,
+              processReference,
+              containerNumber,
+              provider: providerKey,
+              reasonCode: 'UNSUPPORTED_PROVIDER',
+              reasonMessage: UNSUPPORTED_PROVIDER_MESSAGE,
+            })
+            continue
+          }
+
+          eligibleTargets.push({
+            processId: process.processId,
+            processReference,
+            containerNumber,
+            provider,
+          })
+        }
+      }
+
+      return {
+        requestedProcesses: activeProcesses.length,
+        requestedContainers,
+        eligibleTargets,
+        skippedTargets,
+      }
+    },
+  }
+}
+
+export type { SyncDashboardTargetsService }

--- a/src/capabilities/sync/application/services/sync-provider-resolution.utils.ts
+++ b/src/capabilities/sync/application/services/sync-provider-resolution.utils.ts
@@ -1,0 +1,38 @@
+import type { SupportedSyncProvider } from '~/capabilities/sync/application/ports/sync-queue.port'
+
+const PROVIDER_BY_CARRIER: Readonly<Record<string, SupportedSyncProvider>> = {
+  msc: 'msc',
+  maersk: 'maersk',
+  cmacgm: 'cmacgm',
+  pil: 'pil',
+  one: 'one',
+}
+
+export function normalizeCarrierCode(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replaceAll(/[^a-z0-9]/g, '')
+}
+
+export function normalizeContainerNumber(value: string): string {
+  return value.trim().toUpperCase()
+}
+
+export function toNormalizedProviderKey(carrierCode: string | null): string {
+  if (carrierCode === null) return 'unknown'
+
+  const normalizedCarrierCode = normalizeCarrierCode(carrierCode)
+  return normalizedCarrierCode.length > 0 ? normalizedCarrierCode : 'unknown'
+}
+
+export function toSupportedProvider(carrierCode: string | null): SupportedSyncProvider | null {
+  if (carrierCode === null) return null
+
+  const normalizedCarrierCode = normalizeCarrierCode(carrierCode)
+  if (normalizedCarrierCode.length === 0) {
+    return null
+  }
+
+  return PROVIDER_BY_CARRIER[normalizedCarrierCode] ?? null
+}

--- a/src/capabilities/sync/application/services/sync-target-resolver.service.ts
+++ b/src/capabilities/sync/application/services/sync-target-resolver.service.ts
@@ -4,6 +4,10 @@ import type {
   SyncTargetContainerRecord,
   SyncTargetReadPort,
 } from '~/capabilities/sync/application/ports/sync-target-read.port'
+import {
+  normalizeContainerNumber,
+  toSupportedProvider,
+} from '~/capabilities/sync/application/services/sync-provider-resolution.utils'
 import { HttpError } from '~/shared/errors/httpErrors'
 
 export type ResolvedSyncTarget = {
@@ -14,30 +18,6 @@ export type ResolvedSyncTarget = {
 
 type SyncTargetResolverService = {
   readonly resolveTargets: (scope: SyncScope) => Promise<readonly ResolvedSyncTarget[]>
-}
-
-const PROVIDER_BY_CARRIER: Readonly<Record<string, SupportedSyncProvider>> = {
-  msc: 'msc',
-  maersk: 'maersk',
-  cmacgm: 'cmacgm',
-  pil: 'pil',
-  one: 'one',
-}
-
-function normalizeCarrierCode(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replaceAll(/[^a-z0-9]/g, '')
-}
-
-function normalizeContainerNumber(value: string): string {
-  return value.trim().toUpperCase()
-}
-
-function toSupportedProvider(carrierCode: string | null): SupportedSyncProvider | null {
-  if (!carrierCode) return null
-  return PROVIDER_BY_CARRIER[normalizeCarrierCode(carrierCode)] ?? null
 }
 
 function toResolvedTarget(command: {

--- a/src/capabilities/sync/application/services/tests/sync-dashboard-enqueue.service.test.ts
+++ b/src/capabilities/sync/application/services/tests/sync-dashboard-enqueue.service.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSyncDashboardEnqueueService } from '~/capabilities/sync/application/services/sync-dashboard-enqueue.service'
+
+describe('sync-dashboard-enqueue.service', () => {
+  it('classifies new enqueues, duplicate open requests, batch duplicates, and enqueue failures', async () => {
+    const enqueueContainerSyncRequest = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'sync-1',
+        status: 'PENDING' as const,
+        isNew: true,
+      })
+      .mockResolvedValueOnce({
+        id: 'sync-2',
+        status: 'PENDING' as const,
+        isNew: false,
+      })
+      .mockRejectedValueOnce(new Error('rpc failed'))
+
+    const service = createSyncDashboardEnqueueService({
+      queuePort: {
+        enqueueContainerSyncRequest,
+        getSyncRequestStatuses: vi.fn(),
+      },
+    })
+
+    const result = await service.enqueue({
+      tenantId: 'tenant-1',
+      mode: 'manual',
+      targets: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-001',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+        },
+        {
+          processId: 'process-2',
+          processReference: 'REF-002',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+        },
+        {
+          processId: 'process-3',
+          processReference: 'REF-003',
+          containerNumber: 'MRKU7654321',
+          provider: 'maersk',
+        },
+        {
+          processId: 'process-4',
+          processReference: 'REF-004',
+          containerNumber: 'OOLU1234567',
+          provider: 'one',
+        },
+      ],
+    })
+
+    expect(enqueueContainerSyncRequest).toHaveBeenCalledTimes(3)
+    expect(result).toEqual({
+      enqueuedTargets: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-001',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+          syncRequestId: 'sync-1',
+        },
+      ],
+      skippedTargets: [
+        {
+          processId: 'process-2',
+          processReference: 'REF-002',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+          reasonCode: 'DUPLICATE_OPEN_REQUEST',
+          reasonMessage:
+            'Target already has an open sync request or was already included in this batch.',
+        },
+        {
+          processId: 'process-3',
+          processReference: 'REF-003',
+          containerNumber: 'MRKU7654321',
+          provider: 'maersk',
+          reasonCode: 'DUPLICATE_OPEN_REQUEST',
+          reasonMessage:
+            'Target already has an open sync request or was already included in this batch.',
+        },
+      ],
+      failedTargets: [
+        {
+          processId: 'process-4',
+          processReference: 'REF-004',
+          containerNumber: 'OOLU1234567',
+          provider: 'one',
+          reasonCode: 'ENQUEUE_FAILED',
+          reasonMessage: 'Failed to enqueue dashboard sync request.',
+        },
+      ],
+      newSyncRequestIds: ['sync-1'],
+    })
+  })
+})

--- a/src/capabilities/sync/application/services/tests/sync-dashboard-targets.service.test.ts
+++ b/src/capabilities/sync/application/services/tests/sync-dashboard-targets.service.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSyncDashboardTargetsService } from '~/capabilities/sync/application/services/sync-dashboard-targets.service'
+
+describe('sync-dashboard-targets.service', () => {
+  it('classifies eligible, unsupported, and missing-data dashboard targets without throwing', async () => {
+    const service = createSyncDashboardTargetsService({
+      targetReadPort: {
+        fetchProcessById: vi.fn(),
+        listActiveProcessesForDashboardSync: vi.fn(async () => [
+          { processId: 'process-1', processReference: 'REF-001' },
+          { processId: 'process-2', processReference: null },
+        ]),
+        listActiveProcessIds: vi.fn(),
+        listContainersByProcessId: vi.fn(),
+        listContainersByProcessIds: vi.fn(async () => ({
+          containersByProcessId: new Map([
+            [
+              'process-1',
+              [
+                {
+                  processId: 'process-1',
+                  containerNumber: '  mscu1234567  ',
+                  carrierCode: ' MSC ',
+                },
+                {
+                  processId: 'process-1',
+                  containerNumber: '   ',
+                  carrierCode: 'MSC',
+                },
+              ],
+            ],
+            [
+              'process-2',
+              [
+                {
+                  processId: 'process-2',
+                  containerNumber: 'HAPU1234567',
+                  carrierCode: 'hapag',
+                },
+                {
+                  processId: 'process-2',
+                  containerNumber: 'MSKU7654321',
+                  carrierCode: null,
+                },
+              ],
+            ],
+          ]),
+        })),
+        findContainersByNumber: vi.fn(),
+      },
+    })
+
+    const result = await service.resolveTargets()
+
+    expect(result).toEqual({
+      requestedProcesses: 2,
+      requestedContainers: 4,
+      eligibleTargets: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-001',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+        },
+      ],
+      skippedTargets: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-001',
+          containerNumber: '',
+          provider: 'msc',
+          reasonCode: 'MISSING_REQUIRED_DATA',
+          reasonMessage: 'Missing container number or provider required for dashboard manual sync.',
+        },
+        {
+          processId: 'process-2',
+          processReference: null,
+          containerNumber: 'HAPU1234567',
+          provider: 'hapag',
+          reasonCode: 'UNSUPPORTED_PROVIDER',
+          reasonMessage: 'Provider is not supported for dashboard manual sync.',
+        },
+        {
+          processId: 'process-2',
+          processReference: null,
+          containerNumber: 'MSKU7654321',
+          provider: 'unknown',
+          reasonCode: 'UNSUPPORTED_PROVIDER',
+          reasonMessage: 'Provider is not supported for dashboard manual sync.',
+        },
+      ],
+    })
+  })
+})

--- a/src/capabilities/sync/application/sync.usecases.ts
+++ b/src/capabilities/sync/application/sync.usecases.ts
@@ -1,6 +1,8 @@
 import type { SyncQueuePort } from '~/capabilities/sync/application/ports/sync-queue.port'
 import type { SyncStatusReadPort } from '~/capabilities/sync/application/ports/sync-status-read.port'
 import type { SyncTargetReadPort } from '~/capabilities/sync/application/ports/sync-target-read.port'
+import { createSyncDashboardEnqueueService } from '~/capabilities/sync/application/services/sync-dashboard-enqueue.service'
+import { createSyncDashboardTargetsService } from '~/capabilities/sync/application/services/sync-dashboard-targets.service'
 import { createSyncEnqueuePolicyService } from '~/capabilities/sync/application/services/sync-enqueue-policy.service'
 import { createSyncTargetResolverService } from '~/capabilities/sync/application/services/sync-target-resolver.service'
 import {
@@ -30,7 +32,7 @@ export type CreateSyncUseCasesDeps = {
   readonly statusReadPort: SyncStatusReadPort
   readonly refreshProcessDeps: RefreshProcessDeps
   readonly syncDashboardDeps?: Partial<
-    Omit<SyncDashboardDeps, 'targetResolverService' | 'enqueuePolicyService' | 'queuePort'>
+    Omit<SyncDashboardDeps, 'dashboardTargetsService' | 'dashboardEnqueueService' | 'queuePort'>
   >
   readonly syncProcessDeps?: Partial<
     Omit<SyncProcessDeps, 'targetResolverService' | 'enqueuePolicyService' | 'queuePort'>
@@ -45,13 +47,19 @@ export function createSyncUseCases(deps: CreateSyncUseCasesDeps) {
   const targetResolverService = createSyncTargetResolverService({
     targetReadPort: deps.targetReadPort,
   })
+  const dashboardTargetsService = createSyncDashboardTargetsService({
+    targetReadPort: deps.targetReadPort,
+  })
   const enqueuePolicyService = createSyncEnqueuePolicyService({
+    queuePort: deps.queuePort,
+  })
+  const dashboardEnqueueService = createSyncDashboardEnqueueService({
     queuePort: deps.queuePort,
   })
 
   const syncDashboard = createSyncDashboardUseCase({
-    targetResolverService,
-    enqueuePolicyService,
+    dashboardTargetsService,
+    dashboardEnqueueService,
     queuePort: deps.queuePort,
     ...deps.syncDashboardDeps,
   })

--- a/src/capabilities/sync/application/usecases/refresh-process.usecase.ts
+++ b/src/capabilities/sync/application/usecases/refresh-process.usecase.ts
@@ -1,4 +1,8 @@
 import type { SupportedSyncProvider } from '~/capabilities/sync/application/ports/sync-queue.port'
+import {
+  normalizeContainerNumber,
+  toSupportedProvider,
+} from '~/capabilities/sync/application/services/sync-provider-resolution.utils'
 import { HttpError } from '~/shared/errors/httpErrors'
 
 type RefreshMode = 'process' | 'container'
@@ -50,31 +54,6 @@ export type RefreshProcessDeps = {
     readonly status: 'PENDING' | 'LEASED'
     readonly isNew: boolean
   }>
-}
-
-const PROVIDER_BY_CARRIER: Readonly<Record<string, SupportedSyncProvider>> = {
-  msc: 'msc',
-  maersk: 'maersk',
-  cmacgm: 'cmacgm',
-  pil: 'pil',
-  one: 'one',
-}
-
-function normalizeCarrierCode(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replaceAll(/[^a-z0-9]/g, '')
-}
-
-function normalizeContainerNumber(value: string): string {
-  return value.trim().toUpperCase()
-}
-
-function toSupportedProvider(carrierCode: string | null): SupportedSyncProvider | null {
-  if (!carrierCode) return null
-  const normalizedCarrierCode = normalizeCarrierCode(carrierCode)
-  return PROVIDER_BY_CARRIER[normalizedCarrierCode] ?? null
 }
 
 export function createRefreshProcessUseCase(deps: RefreshProcessDeps) {

--- a/src/capabilities/sync/application/usecases/sync-dashboard-batch-result.ts
+++ b/src/capabilities/sync/application/usecases/sync-dashboard-batch-result.ts
@@ -1,0 +1,47 @@
+import type { SupportedSyncProvider } from '~/capabilities/sync/application/ports/sync-queue.port'
+
+export type SyncDashboardSkippedReasonCode =
+  | 'UNSUPPORTED_PROVIDER'
+  | 'DUPLICATE_OPEN_REQUEST'
+  | 'MISSING_REQUIRED_DATA'
+  | 'INELIGIBLE_TARGET'
+
+export type SyncDashboardFailedReasonCode =
+  | 'ENQUEUE_FAILED'
+  | 'INFRASTRUCTURE_ERROR'
+  | 'UNEXPECTED_ERROR'
+
+export type SyncDashboardBatchTargetBase = {
+  readonly processId: string
+  readonly processReference: string | null
+  readonly containerNumber: string
+  readonly provider: string
+}
+
+export type SyncDashboardEnqueuedTarget = SyncDashboardBatchTargetBase & {
+  readonly provider: SupportedSyncProvider
+  readonly syncRequestId: string
+}
+
+export type SyncDashboardSkippedTarget = SyncDashboardBatchTargetBase & {
+  readonly reasonCode: SyncDashboardSkippedReasonCode
+  readonly reasonMessage: string
+}
+
+export type SyncDashboardFailedTarget = SyncDashboardBatchTargetBase & {
+  readonly reasonCode: SyncDashboardFailedReasonCode
+  readonly reasonMessage: string
+}
+
+export type SyncDashboardBatchResult = {
+  readonly summary: {
+    readonly requestedProcesses: number
+    readonly requestedContainers: number
+    readonly enqueued: number
+    readonly skipped: number
+    readonly failed: number
+  }
+  readonly enqueuedTargets: readonly SyncDashboardEnqueuedTarget[]
+  readonly skippedTargets: readonly SyncDashboardSkippedTarget[]
+  readonly failedTargets: readonly SyncDashboardFailedTarget[]
+}

--- a/src/capabilities/sync/application/usecases/sync-dashboard.usecase.ts
+++ b/src/capabilities/sync/application/usecases/sync-dashboard.usecase.ts
@@ -135,26 +135,6 @@ export function createSyncDashboardUseCase(deps: SyncDashboardDeps) {
       reasonHistogram[target.reasonCode] = (reasonHistogram[target.reasonCode] ?? 0) + 1
     }
 
-    for (const target of result.skippedTargets) {
-      console.warn('[sync_dashboard_target_skipped]', {
-        processId: target.processId,
-        processReference: target.processReference,
-        containerNumber: target.containerNumber,
-        provider: target.provider,
-        reasonCode: target.reasonCode,
-      })
-    }
-
-    for (const target of result.failedTargets) {
-      console.error('[sync_dashboard_target_failed]', {
-        processId: target.processId,
-        processReference: target.processReference,
-        containerNumber: target.containerNumber,
-        provider: target.provider,
-        reasonCode: target.reasonCode,
-      })
-    }
-
     console.info('[sync_dashboard_batch]', {
       requestedProcesses: result.summary.requestedProcesses,
       requestedContainers: result.summary.requestedContainers,

--- a/src/capabilities/sync/application/usecases/sync-dashboard.usecase.ts
+++ b/src/capabilities/sync/application/usecases/sync-dashboard.usecase.ts
@@ -3,22 +3,24 @@ import type {
   SyncQueuePort,
   SyncRequestStatusItem,
 } from '~/capabilities/sync/application/ports/sync-queue.port'
-import type { SyncEnqueuePolicyService } from '~/capabilities/sync/application/services/sync-enqueue-policy.service'
-import type { SyncTargetResolverService } from '~/capabilities/sync/application/services/sync-target-resolver.service'
+import type { SyncDashboardEnqueueService } from '~/capabilities/sync/application/services/sync-dashboard-enqueue.service'
+import type { SyncDashboardTargetsService } from '~/capabilities/sync/application/services/sync-dashboard-targets.service'
+import type {
+  SyncDashboardBatchResult,
+  SyncDashboardFailedTarget,
+} from '~/capabilities/sync/application/usecases/sync-dashboard-batch-result'
 import { HttpError } from '~/shared/errors/httpErrors'
 import { systemClock } from '~/shared/time/clock'
 
 const DEFAULT_SYNC_TIMEOUT_MS = 180_000
 const DEFAULT_SYNC_POLL_INTERVAL_MS = 5_000
-
-type SyncDashboardResult = {
-  readonly syncedProcesses: number
-  readonly syncedContainers: number
-}
+const TERMINAL_ENQUEUE_FAILED_MESSAGE = 'Dashboard sync request failed after enqueue.'
+const TERMINAL_INFRASTRUCTURE_ERROR_MESSAGE =
+  'Dashboard sync request status could not be reconciled.'
 
 export type SyncDashboardDeps = {
-  readonly targetResolverService: SyncTargetResolverService
-  readonly enqueuePolicyService: SyncEnqueuePolicyService
+  readonly dashboardTargetsService: SyncDashboardTargetsService
+  readonly dashboardEnqueueService: SyncDashboardEnqueueService
   readonly queuePort: Pick<SyncQueuePort, 'getSyncRequestStatuses'>
   readonly nowMs?: () => number
   readonly sleep?: (delayMs: number) => Promise<void>
@@ -102,55 +104,145 @@ export function createSyncDashboardUseCase(deps: SyncDashboardDeps) {
   const timeoutMs = deps.timeoutMs ?? DEFAULT_SYNC_TIMEOUT_MS
   const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_SYNC_POLL_INTERVAL_MS
 
-  return async function execute(command: EnqueueSyncCommand): Promise<SyncDashboardResult> {
+  function toFailedTargetFromTerminalStatus(command: {
+    readonly statusItem: SyncRequestStatusItem
+    readonly enqueuedTarget: SyncDashboardBatchResult['enqueuedTargets'][number]
+  }): SyncDashboardFailedTarget {
+    if (command.statusItem.status === 'NOT_FOUND') {
+      return {
+        processId: command.enqueuedTarget.processId,
+        processReference: command.enqueuedTarget.processReference,
+        containerNumber: command.enqueuedTarget.containerNumber,
+        provider: command.enqueuedTarget.provider,
+        reasonCode: 'INFRASTRUCTURE_ERROR',
+        reasonMessage: TERMINAL_INFRASTRUCTURE_ERROR_MESSAGE,
+      }
+    }
+
+    return {
+      processId: command.enqueuedTarget.processId,
+      processReference: command.enqueuedTarget.processReference,
+      containerNumber: command.enqueuedTarget.containerNumber,
+      provider: command.enqueuedTarget.provider,
+      reasonCode: 'ENQUEUE_FAILED',
+      reasonMessage: TERMINAL_ENQUEUE_FAILED_MESSAGE,
+    }
+  }
+
+  function logBatchResult(result: SyncDashboardBatchResult): void {
+    const reasonHistogram = [...result.skippedTargets, ...result.failedTargets].reduce<
+      Record<string, number>
+    >((histogram, target) => {
+      const nextCount = (histogram[target.reasonCode] ?? 0) + 1
+      return {
+        ...histogram,
+        [target.reasonCode]: nextCount,
+      }
+    }, {})
+
+    for (const target of result.skippedTargets) {
+      console.warn('[sync_dashboard_target_skipped]', {
+        processId: target.processId,
+        processReference: target.processReference,
+        containerNumber: target.containerNumber,
+        provider: target.provider,
+        reasonCode: target.reasonCode,
+      })
+    }
+
+    for (const target of result.failedTargets) {
+      console.error('[sync_dashboard_target_failed]', {
+        processId: target.processId,
+        processReference: target.processReference,
+        containerNumber: target.containerNumber,
+        provider: target.provider,
+        reasonCode: target.reasonCode,
+      })
+    }
+
+    console.info('[sync_dashboard_batch]', {
+      requestedProcesses: result.summary.requestedProcesses,
+      requestedContainers: result.summary.requestedContainers,
+      enqueued: result.summary.enqueued,
+      skipped: result.summary.skipped,
+      failed: result.summary.failed,
+      reasonHistogram,
+    })
+  }
+
+  return async function execute(command: EnqueueSyncCommand): Promise<SyncDashboardBatchResult> {
     if (command.scope.kind !== 'dashboard') {
       throw new HttpError('invalid_sync_scope_for_dashboard', 400)
     }
 
-    const targets = await deps.targetResolverService.resolveTargets(command.scope)
-    if (targets.length === 0) {
-      return { syncedProcesses: 0, syncedContainers: 0 }
-    }
-
-    const enqueueResult = await deps.enqueuePolicyService.enqueue({
+    const resolvedTargets = await deps.dashboardTargetsService.resolveTargets()
+    const enqueueResult = await deps.dashboardEnqueueService.enqueue({
       tenantId: command.tenantId,
       mode: command.mode,
-      targets,
+      targets: resolvedTargets.eligibleTargets,
     })
 
-    if (enqueueResult.syncRequestIds.length === 0) {
-      return {
-        syncedProcesses: new Set(targets.map((target) => target.processId).filter(Boolean)).size,
-        syncedContainers: targets.length,
+    let enqueuedTargets: SyncDashboardBatchResult['enqueuedTargets'][number][] = [
+      ...enqueueResult.enqueuedTargets,
+    ]
+    const skippedTargets: SyncDashboardBatchResult['skippedTargets'][number][] = [
+      ...resolvedTargets.skippedTargets,
+      ...enqueueResult.skippedTargets,
+    ]
+    const failedTargets: SyncDashboardBatchResult['failedTargets'][number][] = [
+      ...enqueueResult.failedTargets,
+    ]
+
+    if (enqueueResult.newSyncRequestIds.length > 0) {
+      const requests = await waitForTerminalStatuses({
+        syncRequestIds: enqueueResult.newSyncRequestIds,
+        timeoutMs,
+        pollIntervalMs,
+        getSyncRequestStatuses: deps.queuePort.getSyncRequestStatuses,
+        nowMs,
+        sleep,
+      })
+
+      const failedBySyncRequestId = new Map(
+        requests
+          .filter((request) => request.status === 'FAILED' || request.status === 'NOT_FOUND')
+          .map((request) => [request.syncRequestId, request] as const),
+      )
+
+      if (failedBySyncRequestId.size > 0) {
+        const survivingTargets: SyncDashboardBatchResult['enqueuedTargets'][number][] = []
+        for (const target of enqueuedTargets) {
+          const failedRequest = failedBySyncRequestId.get(target.syncRequestId)
+          if (failedRequest === undefined) {
+            survivingTargets.push(target)
+            continue
+          }
+
+          failedTargets.push(
+            toFailedTargetFromTerminalStatus({
+              statusItem: failedRequest,
+              enqueuedTarget: target,
+            }),
+          )
+        }
+        enqueuedTargets = survivingTargets
       }
     }
 
-    const requests = await waitForTerminalStatuses({
-      syncRequestIds: enqueueResult.syncRequestIds,
-      timeoutMs,
-      pollIntervalMs,
-      getSyncRequestStatuses: deps.queuePort.getSyncRequestStatuses,
-      nowMs,
-      sleep,
-    })
-
-    const failures = requests.filter((request) => {
-      return request.status === 'FAILED' || request.status === 'NOT_FOUND'
-    })
-
-    const firstFailure = failures[0]
-    if (firstFailure !== undefined) {
-      const firstError =
-        firstFailure.lastError ??
-        `${firstFailure.status.toLowerCase()}_${firstFailure.syncRequestId}`
-      throw new HttpError(`sync_global_failed:${firstError}`, 502)
+    const result: SyncDashboardBatchResult = {
+      summary: {
+        requestedProcesses: resolvedTargets.requestedProcesses,
+        requestedContainers: resolvedTargets.requestedContainers,
+        enqueued: enqueuedTargets.length,
+        skipped: skippedTargets.length,
+        failed: failedTargets.length,
+      },
+      enqueuedTargets,
+      skippedTargets,
+      failedTargets,
     }
 
-    const syncedProcesses = new Set(targets.map((target) => target.processId).filter(Boolean)).size
-
-    return {
-      syncedProcesses,
-      syncedContainers: targets.length,
-    }
+    logBatchResult(result)
+    return result
   }
 }

--- a/src/capabilities/sync/application/usecases/sync-dashboard.usecase.ts
+++ b/src/capabilities/sync/application/usecases/sync-dashboard.usecase.ts
@@ -130,15 +130,10 @@ export function createSyncDashboardUseCase(deps: SyncDashboardDeps) {
   }
 
   function logBatchResult(result: SyncDashboardBatchResult): void {
-    const reasonHistogram = [...result.skippedTargets, ...result.failedTargets].reduce<
-      Record<string, number>
-    >((histogram, target) => {
-      const nextCount = (histogram[target.reasonCode] ?? 0) + 1
-      return {
-        ...histogram,
-        [target.reasonCode]: nextCount,
-      }
-    }, {})
+    const reasonHistogram: Record<string, number> = {}
+    for (const target of [...result.skippedTargets, ...result.failedTargets]) {
+      reasonHistogram[target.reasonCode] = (reasonHistogram[target.reasonCode] ?? 0) + 1
+    }
 
     for (const target of result.skippedTargets) {
       console.warn('[sync_dashboard_target_skipped]', {

--- a/src/capabilities/sync/application/usecases/tests/sync-dashboard.usecase.test.ts
+++ b/src/capabilities/sync/application/usecases/tests/sync-dashboard.usecase.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+import type { SyncMode } from '~/capabilities/sync/application/commands/enqueue-sync.command'
+import type { SyncDashboardEnqueueService } from '~/capabilities/sync/application/services/sync-dashboard-enqueue.service'
+import type { DashboardSyncEligibleTarget } from '~/capabilities/sync/application/services/sync-dashboard-targets.service'
 import {
   createSyncDashboardUseCase,
   type SyncDashboardDeps,
@@ -22,38 +25,64 @@ function createDeps(overrides: Partial<SyncDashboardDeps> = {}): {
     now += delayMs
   })
 
-  const resolveTargets = vi.fn(async () => [
-    {
-      processId: 'process-a',
-      containerNumber: 'MSCU1234567',
-      provider: 'msc' as const,
-    },
-    {
-      processId: 'process-b',
-      containerNumber: 'MRKU7654321',
-      provider: 'maersk' as const,
-    },
-  ])
-
-  const enqueue = vi.fn(async () => ({
-    requestedTargets: 2,
-    queuedTargets: 2,
-    syncRequestIds: ['sync-1', 'sync-2'],
-    requests: [
+  const resolveTargets = vi.fn(async () => ({
+    requestedProcesses: 2,
+    requestedContainers: 2,
+    eligibleTargets: [
       {
         processId: 'process-a',
+        processReference: 'REF-A',
         containerNumber: 'MSCU1234567',
-        syncRequestId: 'sync-1',
-        deduped: false,
+        provider: 'msc' as const,
       },
       {
         processId: 'process-b',
+        processReference: 'REF-B',
         containerNumber: 'MRKU7654321',
-        syncRequestId: 'sync-2',
-        deduped: false,
+        provider: 'maersk' as const,
       },
     ],
+    skippedTargets: [],
   }))
+
+  const enqueueImpl: SyncDashboardEnqueueService['enqueue'] = async (command: {
+    readonly tenantId: string
+    readonly mode: SyncMode
+    readonly targets: readonly DashboardSyncEligibleTarget[]
+  }) => {
+      if (command.targets.length === 0) {
+        return {
+          enqueuedTargets: [],
+          skippedTargets: [],
+          failedTargets: [],
+          newSyncRequestIds: [],
+        }
+      }
+
+      return {
+        enqueuedTargets: [
+          {
+            processId: 'process-a',
+            processReference: 'REF-A',
+            containerNumber: 'MSCU1234567',
+            provider: 'msc' as const,
+            syncRequestId: 'sync-1',
+          },
+          {
+            processId: 'process-b',
+            processReference: 'REF-B',
+            containerNumber: 'MRKU7654321',
+            provider: 'maersk' as const,
+            syncRequestId: 'sync-2',
+          },
+        ],
+        skippedTargets: [],
+        failedTargets: [],
+        newSyncRequestIds: ['sync-1', 'sync-2'],
+      }
+    }
+
+  const enqueue = vi.fn(enqueueImpl)
 
   const getSyncRequestStatuses = vi.fn(
     async (command: { readonly syncRequestIds: readonly string[] }) => ({
@@ -69,10 +98,10 @@ function createDeps(overrides: Partial<SyncDashboardDeps> = {}): {
   )
 
   const deps: SyncDashboardDeps = {
-    targetResolverService: {
+    dashboardTargetsService: {
       resolveTargets,
     },
-    enqueuePolicyService: {
+    dashboardEnqueueService: {
       enqueue,
     },
     queuePort: {
@@ -92,7 +121,7 @@ function createDeps(overrides: Partial<SyncDashboardDeps> = {}): {
 }
 
 describe('sync-dashboard.usecase', () => {
-  it('returns synced process and container counters when all sync requests finish as DONE', async () => {
+  it('returns structured summary and targets when all new sync requests finish as DONE', async () => {
     const { deps } = createDeps()
 
     const execute = createSyncDashboardUseCase(deps)
@@ -103,36 +132,71 @@ describe('sync-dashboard.usecase', () => {
     })
 
     expect(result).toEqual({
-      syncedProcesses: 2,
-      syncedContainers: 2,
+      summary: {
+        requestedProcesses: 2,
+        requestedContainers: 2,
+        enqueued: 2,
+        skipped: 0,
+        failed: 0,
+      },
+      enqueuedTargets: [
+        {
+          processId: 'process-a',
+          processReference: 'REF-A',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+          syncRequestId: 'sync-1',
+        },
+        {
+          processId: 'process-b',
+          processReference: 'REF-B',
+          containerNumber: 'MRKU7654321',
+          provider: 'maersk',
+          syncRequestId: 'sync-2',
+        },
+      ],
+      skippedTargets: [],
+      failedTargets: [],
     })
   })
 
-  it('propagates unsupported carrier/provider errors from target resolver', async () => {
+  it('returns skipped-only results for unsupported providers instead of throwing', async () => {
     const { deps, enqueue } = createDeps({
-      targetResolverService: {
-        resolveTargets: vi.fn(async () => {
-          throw new HttpError('unsupported_sync_provider_for_container:MSCU1234567:one', 422)
-        }),
+      dashboardTargetsService: {
+        resolveTargets: vi.fn(async () => ({
+          requestedProcesses: 1,
+          requestedContainers: 1,
+          eligibleTargets: [],
+          skippedTargets: [
+            {
+              processId: 'process-a',
+              processReference: 'REF-A',
+              containerNumber: 'MSCU1234567',
+              provider: 'hapag',
+              reasonCode: 'UNSUPPORTED_PROVIDER' as const,
+              reasonMessage: 'Provider is not supported for dashboard manual sync.',
+            },
+          ],
+        })),
       },
     })
 
     const execute = createSyncDashboardUseCase(deps)
+    const result = await execute({
+      tenantId: 'tenant-a',
+      scope: { kind: 'dashboard' },
+      mode: 'manual',
+    })
 
-    let thrown: unknown = null
-    try {
-      await execute({
-        tenantId: 'tenant-a',
-        scope: { kind: 'dashboard' },
-        mode: 'manual',
-      })
-    } catch (error) {
-      thrown = error
-    }
-
-    const httpError = toHttpErrorOrThrow(thrown)
-    expect(httpError.status).toBe(422)
-    expect(enqueue).toHaveBeenCalledTimes(0)
+    expect(result.summary).toEqual({
+      requestedProcesses: 1,
+      requestedContainers: 1,
+      enqueued: 0,
+      skipped: 1,
+      failed: 0,
+    })
+    expect(result.skippedTargets[0]?.reasonCode).toBe('UNSUPPORTED_PROVIDER')
+    expect(enqueue).toHaveBeenCalledTimes(1)
   })
 
   it('fails with 504 when sync requests do not reach terminal state before timeout', async () => {
@@ -175,7 +239,7 @@ describe('sync-dashboard.usecase', () => {
     expect(getSyncRequestStatusesMock).toHaveBeenCalledTimes(3)
   })
 
-  it('fails with 502 when at least one sync request reaches FAILED status', async () => {
+  it('reclassifies terminal queue failures as failed targets while keeping the batch response', async () => {
     const { deps } = createDeps({
       queuePort: {
         getSyncRequestStatuses: vi.fn(async () => ({
@@ -188,26 +252,53 @@ describe('sync-dashboard.usecase', () => {
               updatedAt: '2026-03-06T10:00:00.000Z',
               refValue: 'MSCU1234567',
             },
+            {
+              syncRequestId: 'sync-2',
+              status: 'DONE' as const,
+              lastError: null,
+              updatedAt: '2026-03-06T10:00:00.000Z',
+              refValue: 'MRKU7654321',
+            },
           ],
         })),
       },
     })
 
     const execute = createSyncDashboardUseCase(deps)
+    const result = await execute({
+      tenantId: 'tenant-a',
+      scope: { kind: 'dashboard' },
+      mode: 'manual',
+    })
 
-    let thrown: unknown = null
-    try {
-      await execute({
-        tenantId: 'tenant-a',
-        scope: { kind: 'dashboard' },
-        mode: 'manual',
-      })
-    } catch (error) {
-      thrown = error
-    }
-
-    const httpError = toHttpErrorOrThrow(thrown)
-    expect(httpError.status).toBe(502)
-    expect(httpError.message).toContain('provider_unavailable')
+    expect(result).toEqual({
+      summary: {
+        requestedProcesses: 2,
+        requestedContainers: 2,
+        enqueued: 1,
+        skipped: 0,
+        failed: 1,
+      },
+      enqueuedTargets: [
+        {
+          processId: 'process-b',
+          processReference: 'REF-B',
+          containerNumber: 'MRKU7654321',
+          provider: 'maersk',
+          syncRequestId: 'sync-2',
+        },
+      ],
+      skippedTargets: [],
+      failedTargets: [
+        {
+          processId: 'process-a',
+          processReference: 'REF-A',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+          reasonCode: 'ENQUEUE_FAILED',
+          reasonMessage: 'Dashboard sync request failed after enqueue.',
+        },
+      ],
+    })
   })
 })

--- a/src/capabilities/sync/application/usecases/tests/sync-dashboard.usecase.test.ts
+++ b/src/capabilities/sync/application/usecases/tests/sync-dashboard.usecase.test.ts
@@ -199,6 +199,72 @@ describe('sync-dashboard.usecase', () => {
     expect(enqueue).toHaveBeenCalledTimes(1)
   })
 
+  it('logs batch results as one aggregate entry without per-target log spam', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const { deps } = createDeps({
+      dashboardTargetsService: {
+        resolveTargets: vi.fn(async () => ({
+          requestedProcesses: 2,
+          requestedContainers: 2,
+          eligibleTargets: [],
+          skippedTargets: [
+            {
+              processId: 'process-a',
+              processReference: 'REF-A',
+              containerNumber: 'MSCU1234567',
+              provider: 'hapag',
+              reasonCode: 'UNSUPPORTED_PROVIDER' as const,
+              reasonMessage: 'Provider is not supported for dashboard manual sync.',
+            },
+            {
+              processId: 'process-b',
+              processReference: 'REF-B',
+              containerNumber: 'MRKU7654321',
+              provider: 'maersk',
+              reasonCode: 'MISSING_REQUIRED_DATA' as const,
+              reasonMessage: 'Container number is missing.',
+            },
+          ],
+        })),
+      },
+      dashboardEnqueueService: {
+        enqueue: vi.fn(async () => ({
+          enqueuedTargets: [],
+          skippedTargets: [],
+          failedTargets: [
+            {
+              processId: 'process-c',
+              processReference: 'REF-C',
+              containerNumber: 'CAXU1111111',
+              provider: 'msc',
+              reasonCode: 'ENQUEUE_FAILED' as const,
+              reasonMessage: 'Dashboard sync request failed after enqueue.',
+            },
+          ],
+          newSyncRequestIds: [],
+        })),
+      },
+    })
+
+    const execute = createSyncDashboardUseCase(deps)
+    await execute({
+      tenantId: 'tenant-a',
+      scope: { kind: 'dashboard' },
+      mode: 'manual',
+    })
+
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    infoSpy.mockRestore()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
   it('fails with 504 when sync requests do not reach terminal state before timeout', async () => {
     const getSyncRequestStatusesMock = vi.fn(async () => ({
       allTerminal: false,

--- a/src/capabilities/sync/application/usecases/tests/sync-dashboard.usecase.test.ts
+++ b/src/capabilities/sync/application/usecases/tests/sync-dashboard.usecase.test.ts
@@ -50,37 +50,37 @@ function createDeps(overrides: Partial<SyncDashboardDeps> = {}): {
     readonly mode: SyncMode
     readonly targets: readonly DashboardSyncEligibleTarget[]
   }) => {
-      if (command.targets.length === 0) {
-        return {
-          enqueuedTargets: [],
-          skippedTargets: [],
-          failedTargets: [],
-          newSyncRequestIds: [],
-        }
-      }
-
+    if (command.targets.length === 0) {
       return {
-        enqueuedTargets: [
-          {
-            processId: 'process-a',
-            processReference: 'REF-A',
-            containerNumber: 'MSCU1234567',
-            provider: 'msc' as const,
-            syncRequestId: 'sync-1',
-          },
-          {
-            processId: 'process-b',
-            processReference: 'REF-B',
-            containerNumber: 'MRKU7654321',
-            provider: 'maersk' as const,
-            syncRequestId: 'sync-2',
-          },
-        ],
+        enqueuedTargets: [],
         skippedTargets: [],
         failedTargets: [],
-        newSyncRequestIds: ['sync-1', 'sync-2'],
+        newSyncRequestIds: [],
       }
     }
+
+    return {
+      enqueuedTargets: [
+        {
+          processId: 'process-a',
+          processReference: 'REF-A',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc' as const,
+          syncRequestId: 'sync-1',
+        },
+        {
+          processId: 'process-b',
+          processReference: 'REF-B',
+          containerNumber: 'MRKU7654321',
+          provider: 'maersk' as const,
+          syncRequestId: 'sync-2',
+        },
+      ],
+      skippedTargets: [],
+      failedTargets: [],
+      newSyncRequestIds: ['sync-1', 'sync-2'],
+    }
+  }
 
   const enqueue = vi.fn(enqueueImpl)
 

--- a/src/capabilities/sync/interface/http/sync.controllers.ts
+++ b/src/capabilities/sync/interface/http/sync.controllers.ts
@@ -5,7 +5,8 @@ import {
 } from '~/capabilities/sync/interface/http/sync.schemas'
 import {
   toProcessRefreshResponse,
-  toSyncAllProcessesResponse,
+  toSyncAllProcessesBusinessErrorResponse,
+  toSyncAllProcessesSuccessResponse,
   toSyncContainerResponse,
   toSyncProcessResponse,
 } from '~/capabilities/sync/presenter/sync-response.presenter'
@@ -13,9 +14,12 @@ import { mapErrorToResponse } from '~/shared/api/errorToResponse'
 import { jsonResponse } from '~/shared/api/typedRoute'
 import {
   ProcessRefreshResponseSchema,
-  SyncAllProcessesResponseSchema,
+  SyncAllProcessesBusinessErrorResponseSchema,
+  SyncAllProcessesSuccessResponseSchema,
   SyncProcessResponseSchema,
 } from '~/shared/api-schemas/processes.schemas'
+
+const SYNC_DASHBOARD_FAILED_NO_ENQUEUE_ERROR = 'sync_dashboard_failed_no_targets_enqueued'
 
 type SyncControllersDeps = {
   readonly syncUseCases: Pick<
@@ -36,7 +40,22 @@ export function createSyncControllers(deps: SyncControllersDeps) {
         mode: 'manual',
       })
 
-      return jsonResponse(toSyncAllProcessesResponse(result), 200, SyncAllProcessesResponseSchema)
+      if (result.summary.enqueued === 0 && result.summary.failed > 0) {
+        return jsonResponse(
+          toSyncAllProcessesBusinessErrorResponse(
+            result,
+            SYNC_DASHBOARD_FAILED_NO_ENQUEUE_ERROR,
+          ),
+          422,
+          SyncAllProcessesBusinessErrorResponseSchema,
+        )
+      }
+
+      return jsonResponse(
+        toSyncAllProcessesSuccessResponse(result),
+        200,
+        SyncAllProcessesSuccessResponseSchema,
+      )
     } catch (err) {
       console.error('POST /api/dashboard/sync error:', err)
       return mapErrorToResponse(err)

--- a/src/capabilities/sync/interface/http/sync.controllers.ts
+++ b/src/capabilities/sync/interface/http/sync.controllers.ts
@@ -42,10 +42,7 @@ export function createSyncControllers(deps: SyncControllersDeps) {
 
       if (result.summary.enqueued === 0 && result.summary.failed > 0) {
         return jsonResponse(
-          toSyncAllProcessesBusinessErrorResponse(
-            result,
-            SYNC_DASHBOARD_FAILED_NO_ENQUEUE_ERROR,
-          ),
+          toSyncAllProcessesBusinessErrorResponse(result, SYNC_DASHBOARD_FAILED_NO_ENQUEUE_ERROR),
           422,
           SyncAllProcessesBusinessErrorResponseSchema,
         )

--- a/src/capabilities/sync/interface/http/tests/sync.controllers.test.ts
+++ b/src/capabilities/sync/interface/http/tests/sync.controllers.test.ts
@@ -4,14 +4,29 @@ import { createSyncControllers } from '~/capabilities/sync/interface/http/sync.c
 import { SyncContainerResponseSchema } from '~/capabilities/sync/interface/http/sync.schemas'
 import {
   ProcessRefreshResponseSchema,
-  SyncAllProcessesResponseSchema,
+  SyncAllProcessesBusinessErrorResponseSchema,
+  SyncAllProcessesSuccessResponseSchema,
   SyncProcessResponseSchema,
 } from '~/shared/api-schemas/processes.schemas'
 
 function createControllers() {
   const syncDashboard = vi.fn(async () => ({
-    syncedProcesses: 3,
-    syncedContainers: 8,
+    summary: {
+      requestedProcesses: 3,
+      requestedContainers: 8,
+      enqueued: 8,
+      skipped: 0,
+      failed: 0,
+    },
+    enqueuedTargets: Array.from({ length: 8 }, (_, index) => ({
+      processId: `process-${index + 1}`,
+      processReference: `REF-${index + 1}`,
+      containerNumber: `MSCU123456${index}`,
+      provider: 'msc' as const,
+      syncRequestId: `sync-${index + 1}`,
+    })),
+    skippedTargets: [],
+    failedTargets: [],
   }))
   const syncProcess = vi.fn(async (command: EnqueueSyncCommand) => {
     if (command.scope.kind !== 'process') {
@@ -75,19 +90,45 @@ function createControllers() {
   }
 }
 
+function buildDashboardSyncSuccessResult() {
+  return {
+    summary: {
+      requestedProcesses: 1,
+      requestedContainers: 1,
+      enqueued: 1,
+      skipped: 0,
+      failed: 0,
+    },
+    enqueuedTargets: [
+      {
+        processId: 'process-1',
+        processReference: 'REF-1',
+        containerNumber: 'MSCU1234567',
+        provider: 'msc' as const,
+        syncRequestId: 'sync-1',
+      },
+    ],
+    skippedTargets: [],
+    failedTargets: [],
+  }
+}
+
 describe('sync controllers', () => {
-  it('returns 200 with sync counters when dashboard sync completes', async () => {
+  it('returns 200 with structured batch results when dashboard sync completes', async () => {
     const { controllers, syncDashboard } = createControllers()
 
     const response = await controllers.syncAllProcesses()
-    const body = SyncAllProcessesResponseSchema.parse(await response.json())
+    const body = SyncAllProcessesSuccessResponseSchema.parse(await response.json())
 
     expect(response.status).toBe(200)
-    expect(body).toEqual({
-      ok: true,
-      syncedProcesses: 3,
-      syncedContainers: 8,
+    expect(body.summary).toEqual({
+      requestedProcesses: 3,
+      requestedContainers: 8,
+      enqueued: 8,
+      skipped: 0,
+      failed: 0,
     })
+    expect(body.enqueuedTargets).toHaveLength(8)
     expect(syncDashboard).toHaveBeenCalledTimes(1)
   })
 
@@ -100,8 +141,31 @@ describe('sync controllers', () => {
     const syncDashboard = vi.fn(async () => {
       await firstSyncGate
       return {
-        syncedProcesses: 1,
-        syncedContainers: 2,
+        summary: {
+          requestedProcesses: 1,
+          requestedContainers: 2,
+          enqueued: 2,
+          skipped: 0,
+          failed: 0,
+        },
+        enqueuedTargets: [
+          {
+            processId: 'process-1',
+            processReference: 'REF-1',
+            containerNumber: 'MSCU1234567',
+            provider: 'msc' as const,
+            syncRequestId: 'sync-1',
+          },
+          {
+            processId: 'process-1',
+            processReference: 'REF-1',
+            containerNumber: 'MRKU7654321',
+            provider: 'maersk' as const,
+            syncRequestId: 'sync-2',
+          },
+        ],
+        skippedTargets: [],
+        failedTargets: [],
       }
     })
 
@@ -135,6 +199,55 @@ describe('sync controllers', () => {
     expect(firstResponse.status).toBe(200)
     expect(secondResponse.status).toBe(200)
     expect(syncDashboard).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns 422 with structured batch results when dashboard sync finishes with failures and no enqueue', async () => {
+    const syncDashboard = vi.fn(async () => ({
+      summary: {
+        requestedProcesses: 1,
+        requestedContainers: 1,
+        enqueued: 0,
+        skipped: 0,
+        failed: 1,
+      },
+      enqueuedTargets: [],
+      skippedTargets: [],
+      failedTargets: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-1',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+          reasonCode: 'ENQUEUE_FAILED' as const,
+          reasonMessage: 'Failed to enqueue dashboard sync request.',
+        },
+      ],
+    }))
+
+    const controllers = createSyncControllers({
+      syncUseCases: {
+        syncDashboard,
+        syncProcess: vi.fn(async () => ({ processId: 'process-1', syncedContainers: 1 })),
+        syncContainer: vi.fn(async () => ({ containerNumber: 'MSCU1234567', syncedContainers: 1 })),
+        refreshProcess: vi.fn(async () => ({
+          processId: 'process-1',
+          mode: 'process' as const,
+          requestedContainers: 0,
+          queuedContainers: 0,
+          syncRequestIds: [],
+          requests: [],
+          failures: [],
+        })),
+      },
+      defaultTenantId: 'tenant-a',
+    })
+
+    const response = await controllers.syncDashboard()
+    const body = SyncAllProcessesBusinessErrorResponseSchema.parse(await response.json())
+
+    expect(response.status).toBe(422)
+    expect(body.error).toBe('sync_dashboard_failed_no_targets_enqueued')
+    expect(body.summary.failed).toBe(1)
   })
 
   it('returns 200 with process sync counters when process sync completes', async () => {
@@ -180,7 +293,7 @@ describe('sync controllers', () => {
 
     const controllers = createSyncControllers({
       syncUseCases: {
-        syncDashboard: vi.fn(async () => ({ syncedProcesses: 1, syncedContainers: 1 })),
+        syncDashboard: vi.fn(async () => buildDashboardSyncSuccessResult()),
         syncProcess,
         syncContainer: vi.fn(async () => ({ containerNumber: 'MSCU1234567', syncedContainers: 1 })),
         refreshProcess: vi.fn(async () => ({
@@ -255,7 +368,7 @@ describe('sync controllers', () => {
 
     const controllers = createSyncControllers({
       syncUseCases: {
-        syncDashboard: vi.fn(async () => ({ syncedProcesses: 1, syncedContainers: 1 })),
+        syncDashboard: vi.fn(async () => buildDashboardSyncSuccessResult()),
         syncProcess: vi.fn(async () => ({ processId: 'process-1', syncedContainers: 1 })),
         syncContainer,
         refreshProcess: vi.fn(async () => ({

--- a/src/capabilities/sync/presenter/sync-response.presenter.ts
+++ b/src/capabilities/sync/presenter/sync-response.presenter.ts
@@ -1,14 +1,57 @@
 import type { GetSyncStatusResult } from '~/capabilities/sync/application/usecases/get-sync-status.usecase'
 import type { RefreshProcessResult } from '~/capabilities/sync/application/usecases/refresh-process.usecase'
+import type { SyncDashboardBatchResult } from '~/capabilities/sync/application/usecases/sync-dashboard-batch-result'
 
-export function toSyncAllProcessesResponse(result: {
-  readonly syncedProcesses: number
-  readonly syncedContainers: number
-}) {
+function toSyncDashboardBatchPayload(result: SyncDashboardBatchResult) {
+  return {
+    summary: {
+      requestedProcesses: result.summary.requestedProcesses,
+      requestedContainers: result.summary.requestedContainers,
+      enqueued: result.summary.enqueued,
+      skipped: result.summary.skipped,
+      failed: result.summary.failed,
+    },
+    enqueuedTargets: result.enqueuedTargets.map((target) => ({
+      processId: target.processId,
+      processReference: target.processReference,
+      containerNumber: target.containerNumber,
+      provider: target.provider,
+      syncRequestId: target.syncRequestId,
+    })),
+    skippedTargets: result.skippedTargets.map((target) => ({
+      processId: target.processId,
+      processReference: target.processReference,
+      containerNumber: target.containerNumber,
+      provider: target.provider,
+      reasonCode: target.reasonCode,
+      reasonMessage: target.reasonMessage,
+    })),
+    failedTargets: result.failedTargets.map((target) => ({
+      processId: target.processId,
+      processReference: target.processReference,
+      containerNumber: target.containerNumber,
+      provider: target.provider,
+      reasonCode: target.reasonCode,
+      reasonMessage: target.reasonMessage,
+    })),
+  }
+}
+
+export function toSyncAllProcessesSuccessResponse(result: SyncDashboardBatchResult) {
   return {
     ok: true as const,
-    syncedProcesses: result.syncedProcesses,
-    syncedContainers: result.syncedContainers,
+    ...toSyncDashboardBatchPayload(result),
+  }
+}
+
+export function toSyncAllProcessesBusinessErrorResponse(
+  result: SyncDashboardBatchResult,
+  error: string,
+) {
+  return {
+    ok: false as const,
+    error,
+    ...toSyncDashboardBatchPayload(result),
   }
 }
 

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -107,6 +107,44 @@
       "syncing": "Sincronizando...",
       "syncFailed": "A última sincronização falhou"
     },
+    "syncBatch": {
+      "panel": {
+        "title": "Resultado do Sync All",
+        "subtitle": "O dashboard foi reconciliado com o snapshot mais recente do servidor.",
+        "headlineSuccess": "Todos os targets elegíveis foram enfileirados.",
+        "headlinePartial": "O lote foi processado com resultado parcial.",
+        "headlineNoEnqueue": "Nenhum target foi enfileirado neste lote.",
+        "dismiss": "Dispensar resultado do Sync All",
+        "showAll": "Mostrar +{{count}}",
+        "showLess": "Mostrar menos",
+        "sections": {
+          "failed": "Falhas localizadas",
+          "skipped": "Ignorados explicitamente"
+        },
+        "summary": {
+          "requestedProcesses": "{{count}} processo(s) solicitados",
+          "requestedContainers": "{{count}} container(s) avaliados",
+          "enqueued": "{{count}} enfileirado(s)",
+          "skipped": "{{count}} ignorado(s)",
+          "failed": "{{count}} falha(s)"
+        }
+      },
+      "reasonCodes": {
+        "unsupportedProvider": "Provider não suportado",
+        "duplicateOpenRequest": "Sync já aberto ou duplicado no lote",
+        "missingRequiredData": "Dados obrigatórios ausentes",
+        "ineligibleTarget": "Target inelegível",
+        "enqueueFailed": "Falha ao enfileirar sync",
+        "infrastructureError": "Falha de infraestrutura ao reconciliar sync",
+        "unexpectedError": "Erro inesperado"
+      },
+      "rowIssue": {
+        "failedOnly": "{{failed}} falha(s) no último Sync All",
+        "skippedOnly": "{{skipped}} item(ns) ignorado(s) no último Sync All",
+        "mixed": "{{failed}} falha(s) e {{skipped}} item(ns) ignorado(s) no último Sync All",
+        "additionalItems": "+{{count}} item(ns)"
+      }
+    },
     "alertIndicators": {
       "title": "Alertas Operacionais",
       "total": "Total de Alertas Ativos",

--- a/src/modules/process/ui/api/processSync.api.ts
+++ b/src/modules/process/ui/api/processSync.api.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import type { z } from 'zod'
 import { TypedFetchError, typedFetch } from '~/shared/api/typedFetch'
 import {
   ProcessesSyncStatusResponseSchema,

--- a/src/modules/process/ui/api/processSync.api.ts
+++ b/src/modules/process/ui/api/processSync.api.ts
@@ -1,22 +1,51 @@
-import { typedFetch } from '~/shared/api/typedFetch'
+import { z } from 'zod'
+import { TypedFetchError, typedFetch } from '~/shared/api/typedFetch'
 import {
   ProcessesSyncStatusResponseSchema,
-  SyncAllProcessesResponseSchema,
+  SyncAllProcessesBusinessErrorResponseSchema,
+  SyncAllProcessesSuccessResponseSchema,
   SyncProcessResponseSchema,
 } from '~/shared/api-schemas/processes.schemas'
 
-export async function syncAllProcessesRequest(): Promise<{
-  readonly ok: true
-  readonly syncedProcesses: number
-  readonly syncedContainers: number
-}> {
-  return typedFetch(
-    '/api/processes/sync',
-    {
-      method: 'POST',
-    },
-    SyncAllProcessesResponseSchema,
-  )
+export type SyncAllProcessesSuccessResponse = z.infer<typeof SyncAllProcessesSuccessResponseSchema>
+export type SyncAllProcessesBusinessErrorResponse = z.infer<
+  typeof SyncAllProcessesBusinessErrorResponseSchema
+>
+
+export type SyncAllProcessesRequestResult =
+  | {
+      readonly httpStatus: 200
+      readonly payload: SyncAllProcessesSuccessResponse
+    }
+  | {
+      readonly httpStatus: 422
+      readonly payload: SyncAllProcessesBusinessErrorResponse
+    }
+
+export async function syncAllProcessesRequest(): Promise<SyncAllProcessesRequestResult> {
+  try {
+    const payload = await typedFetch(
+      '/api/processes/sync',
+      {
+        method: 'POST',
+      },
+      SyncAllProcessesSuccessResponseSchema,
+    )
+
+    return {
+      httpStatus: 200,
+      payload,
+    }
+  } catch (error) {
+    if (error instanceof TypedFetchError && error.status === 422) {
+      return {
+        httpStatus: 422,
+        payload: SyncAllProcessesBusinessErrorResponseSchema.parse(error.body),
+      }
+    }
+
+    throw error
+  }
 }
 
 export async function syncProcessRequest(processId: string): Promise<{

--- a/src/modules/process/ui/api/tests/processSync.api.test.ts
+++ b/src/modules/process/ui/api/tests/processSync.api.test.ts
@@ -12,12 +12,63 @@ describe('syncAllProcessesRequest', () => {
   it('calls the global process sync endpoint and returns parsed counters', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
       async () =>
-        new Response(JSON.stringify({ ok: true, syncedProcesses: 2, syncedContainers: 5 }), {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json',
+        new Response(
+          JSON.stringify({
+            ok: true,
+            summary: {
+              requestedProcesses: 2,
+              requestedContainers: 5,
+              enqueued: 5,
+              skipped: 0,
+              failed: 0,
+            },
+            enqueuedTargets: [
+              {
+                processId: 'process-1',
+                processReference: 'REF-1',
+                containerNumber: 'MSCU1234567',
+                provider: 'msc',
+                syncRequestId: 'sync-1',
+              },
+              {
+                processId: 'process-2',
+                processReference: 'REF-2',
+                containerNumber: 'MRKU7654321',
+                provider: 'maersk',
+                syncRequestId: 'sync-2',
+              },
+              {
+                processId: 'process-3',
+                processReference: 'REF-3',
+                containerNumber: 'OOLU1234567',
+                provider: 'one',
+                syncRequestId: 'sync-3',
+              },
+              {
+                processId: 'process-4',
+                processReference: 'REF-4',
+                containerNumber: 'MEDU1234567',
+                provider: 'msc',
+                syncRequestId: 'sync-4',
+              },
+              {
+                processId: 'process-5',
+                processReference: 'REF-5',
+                containerNumber: 'TGHU1234567',
+                provider: 'pil',
+                syncRequestId: 'sync-5',
+              },
+            ],
+            skippedTargets: [],
+            failedTargets: [],
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
           },
-        }),
+        ),
     )
 
     const result = await syncAllProcessesRequest()
@@ -25,10 +76,73 @@ describe('syncAllProcessesRequest', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/processes/sync', {
       method: 'POST',
     })
+    expect(result.httpStatus).toBe(200)
+    expect(result.payload.summary.enqueued).toBe(5)
+  })
+
+  it('returns structured 422 business errors without throwing', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error: 'sync_dashboard_failed_no_targets_enqueued',
+            summary: {
+              requestedProcesses: 1,
+              requestedContainers: 1,
+              enqueued: 0,
+              skipped: 0,
+              failed: 1,
+            },
+            enqueuedTargets: [],
+            skippedTargets: [],
+            failedTargets: [
+              {
+                processId: 'process-1',
+                processReference: 'REF-1',
+                containerNumber: 'MSCU1234567',
+                provider: 'msc',
+                reasonCode: 'ENQUEUE_FAILED',
+                reasonMessage: 'Failed to enqueue dashboard sync request.',
+              },
+            ],
+          }),
+          {
+            status: 422,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+    )
+
+    const result = await syncAllProcessesRequest()
+
     expect(result).toEqual({
-      ok: true,
-      syncedProcesses: 2,
-      syncedContainers: 5,
+      httpStatus: 422,
+      payload: {
+        ok: false,
+        error: 'sync_dashboard_failed_no_targets_enqueued',
+        summary: {
+          requestedProcesses: 1,
+          requestedContainers: 1,
+          enqueued: 0,
+          skipped: 0,
+          failed: 1,
+        },
+        enqueuedTargets: [],
+        skippedTargets: [],
+        failedTargets: [
+          {
+            processId: 'process-1',
+            processReference: 'REF-1',
+            containerNumber: 'MSCU1234567',
+            provider: 'msc',
+            reasonCode: 'ENQUEUE_FAILED',
+            reasonMessage: 'Failed to enqueue dashboard sync request.',
+          },
+        ],
+      },
     })
   })
 })

--- a/src/modules/process/ui/components/DashboardProcessTable.tsx
+++ b/src/modules/process/ui/components/DashboardProcessTable.tsx
@@ -46,6 +46,7 @@ import type {
   DashboardSortField,
   DashboardSortSelection,
 } from '~/modules/process/ui/viewmodels/dashboard-sort.vm'
+import type { DashboardProcessRowVM } from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
 import type { ProcessSummaryVM } from '~/modules/process/ui/viewmodels/process-summary.vm'
 import { useTranslation } from '~/shared/localization/i18n'
 import { EmptyState } from '~/shared/ui/EmptyState'
@@ -60,7 +61,7 @@ import { toCarrierDisplayLabel } from '~/shared/utils/carrierDisplay'
 type DashboardProcessSeverity = 'danger' | 'warning' | 'info' | 'success' | 'none'
 
 type Props = {
-  readonly processes: readonly ProcessSummaryVM[]
+  readonly processes: readonly DashboardProcessRowVM[]
   readonly highlightedProcessId: string | null
   readonly initialLoading: boolean
   readonly refreshing: boolean
@@ -76,7 +77,7 @@ type Props = {
 }
 
 type RowProps = {
-  readonly process: ProcessSummaryVM
+  readonly process: DashboardProcessRowVM
   readonly isHighlighted: boolean
   readonly columnOrder: readonly DashboardColumnId[]
   readonly gridStyle: string
@@ -86,7 +87,7 @@ type RowProps = {
 }
 
 type TableRowsProps = {
-  readonly processes: readonly ProcessSummaryVM[]
+  readonly processes: readonly DashboardProcessRowVM[]
   readonly highlightedProcessId: string | null
   readonly sortSelection: DashboardSortSelection
   readonly onSortToggle: (field: DashboardSortField) => void
@@ -299,7 +300,7 @@ function formatDashboardAlertAge(params: {
 // ---------------------------------------------------------------------------
 
 type CellContext = {
-  readonly process: ProcessSummaryVM
+  readonly process: DashboardProcessRowVM
   readonly processHref: string
   readonly handleProcessLinkClick: (event: MouseEvent) => void
   readonly t: (key: string, opts?: Record<string, unknown>) => string
@@ -459,6 +460,7 @@ function SyncCell(ctx: CellContext): JSX.Element {
   return (
     <SyncCellComponent
       state={cellState()}
+      issue={ctx.process.syncIssue}
       onSync={() => {
         void ctx.onProcessSync(ctx.process.id)
       }}
@@ -856,7 +858,7 @@ function DashboardProcessRows(props: TableRowsProps): JSX.Element {
   const gridStyle = createMemo(() => buildGridTemplate(props.columnOrder))
 
   /** Default priority ordering: severity desc → alert count desc → preserve API order. */
-  const prioritySorted = (): readonly ProcessSummaryVM[] => {
+  const prioritySorted = (): readonly DashboardProcessRowVM[] => {
     if (props.sortSelection !== null) return props.processes
     return [...props.processes].sort((a, b) => {
       const sevDiff = SEVERITY_ORDER[toDominantSeverity(a)] - SEVERITY_ORDER[toDominantSeverity(b)]

--- a/src/modules/process/ui/components/DashboardSyncBatchResultPanel.tsx
+++ b/src/modules/process/ui/components/DashboardSyncBatchResultPanel.tsx
@@ -47,18 +47,22 @@ function toSummaryChipClasses(kind: 'neutral' | 'success' | 'warning' | 'danger'
   return 'border-border bg-surface text-text-muted'
 }
 
-function ResultToneIcon(props: {
-  readonly tone: DashboardSyncBatchResultVM['tone']
-}): JSX.Element {
-  if (props.tone === 'danger') {
-    return <OctagonAlert class="h-5 w-5 text-tone-danger-fg" aria-hidden="true" />
-  }
-
-  if (props.tone === 'warning') {
-    return <CircleAlert class="h-5 w-5 text-tone-warning-fg" aria-hidden="true" />
-  }
-
-  return <CheckCircle2 class="h-5 w-5 text-tone-success-fg" aria-hidden="true" />
+function ResultToneIcon(props: { readonly tone: DashboardSyncBatchResultVM['tone'] }): JSX.Element {
+  return (
+    <Show
+      when={props.tone === 'danger'}
+      fallback={
+        <Show
+          when={props.tone === 'warning'}
+          fallback={<CheckCircle2 class="h-5 w-5 text-tone-success-fg" aria-hidden="true" />}
+        >
+          <CircleAlert class="h-5 w-5 text-tone-warning-fg" aria-hidden="true" />
+        </Show>
+      }
+    >
+      <OctagonAlert class="h-5 w-5 text-tone-danger-fg" aria-hidden="true" />
+    </Show>
+  )
 }
 
 function DashboardSyncBatchSection(props: DashboardSyncBatchSectionProps): JSX.Element {
@@ -125,7 +129,9 @@ export function DashboardSyncBatchResultPanel(
   })
 
   return (
-    <section class={`mb-5 rounded-2xl border p-4 shadow-sm ${toPanelToneClasses(props.result.tone)}`}>
+    <section
+      class={`mb-5 rounded-2xl border p-4 shadow-sm ${toPanelToneClasses(props.result.tone)}`}
+    >
       <div class="flex items-start justify-between gap-4">
         <div class="flex min-w-0 items-start gap-3">
           <ResultToneIcon tone={props.result.tone} />
@@ -142,7 +148,7 @@ export function DashboardSyncBatchResultPanel(
 
         <button
           type="button"
-          onClick={props.onDismiss}
+          onClick={() => props.onDismiss()}
           class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-surface text-text-muted transition-colors hover:border-border-strong hover:text-foreground"
           aria-label={t(keys.dashboard.syncBatch.panel.dismiss)}
           title={t(keys.dashboard.syncBatch.panel.dismiss)}
@@ -152,27 +158,37 @@ export function DashboardSyncBatchResultPanel(
       </div>
 
       <div class="mt-4 flex flex-wrap gap-2">
-        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('neutral')}`}>
+        <span
+          class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('neutral')}`}
+        >
           {t(keys.dashboard.syncBatch.panel.summary.requestedProcesses, {
             count: props.result.summary.requestedProcesses,
           })}
         </span>
-        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('neutral')}`}>
+        <span
+          class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('neutral')}`}
+        >
           {t(keys.dashboard.syncBatch.panel.summary.requestedContainers, {
             count: props.result.summary.requestedContainers,
           })}
         </span>
-        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('success')}`}>
+        <span
+          class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('success')}`}
+        >
           {t(keys.dashboard.syncBatch.panel.summary.enqueued, {
             count: props.result.summary.enqueued,
           })}
         </span>
-        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('warning')}`}>
+        <span
+          class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('warning')}`}
+        >
           {t(keys.dashboard.syncBatch.panel.summary.skipped, {
             count: props.result.summary.skipped,
           })}
         </span>
-        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('danger')}`}>
+        <span
+          class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('danger')}`}
+        >
           {t(keys.dashboard.syncBatch.panel.summary.failed, {
             count: props.result.summary.failed,
           })}

--- a/src/modules/process/ui/components/DashboardSyncBatchResultPanel.tsx
+++ b/src/modules/process/ui/components/DashboardSyncBatchResultPanel.tsx
@@ -1,0 +1,198 @@
+import { CheckCircle2, CircleAlert, OctagonAlert, X } from 'lucide-solid'
+import type { JSX } from 'solid-js'
+import { createMemo, createSignal, For, Show } from 'solid-js'
+import type {
+  DashboardSyncBatchProblemTargetVM,
+  DashboardSyncBatchResultVM,
+} from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
+import { useTranslation } from '~/shared/localization/i18n'
+
+const VISIBLE_ITEMS_LIMIT = 5
+
+type DashboardSyncBatchResultPanelProps = {
+  readonly result: DashboardSyncBatchResultVM
+  readonly onDismiss: () => void
+}
+
+type DashboardSyncBatchSectionProps = {
+  readonly title: string
+  readonly items: readonly DashboardSyncBatchProblemTargetVM[]
+}
+
+function toPanelToneClasses(tone: DashboardSyncBatchResultVM['tone']): string {
+  if (tone === 'danger') {
+    return 'border-tone-danger-border bg-tone-danger-bg/45'
+  }
+
+  if (tone === 'warning') {
+    return 'border-tone-warning-border bg-tone-warning-bg/45'
+  }
+
+  return 'border-tone-success-border bg-tone-success-bg/40'
+}
+
+function toSummaryChipClasses(kind: 'neutral' | 'success' | 'warning' | 'danger'): string {
+  if (kind === 'success') {
+    return 'border-tone-success-border bg-tone-success-bg text-tone-success-fg'
+  }
+
+  if (kind === 'warning') {
+    return 'border-tone-warning-border bg-tone-warning-bg text-tone-warning-fg'
+  }
+
+  if (kind === 'danger') {
+    return 'border-tone-danger-border bg-tone-danger-bg text-tone-danger-fg'
+  }
+
+  return 'border-border bg-surface text-text-muted'
+}
+
+function ResultToneIcon(props: {
+  readonly tone: DashboardSyncBatchResultVM['tone']
+}): JSX.Element {
+  if (props.tone === 'danger') {
+    return <OctagonAlert class="h-5 w-5 text-tone-danger-fg" aria-hidden="true" />
+  }
+
+  if (props.tone === 'warning') {
+    return <CircleAlert class="h-5 w-5 text-tone-warning-fg" aria-hidden="true" />
+  }
+
+  return <CheckCircle2 class="h-5 w-5 text-tone-success-fg" aria-hidden="true" />
+}
+
+function DashboardSyncBatchSection(props: DashboardSyncBatchSectionProps): JSX.Element {
+  const { t, keys } = useTranslation()
+  const [expanded, setExpanded] = createSignal(false)
+  const visibleItems = createMemo(() =>
+    expanded() ? props.items : props.items.slice(0, VISIBLE_ITEMS_LIMIT),
+  )
+  const remainingCount = createMemo(() => props.items.length - visibleItems().length)
+
+  return (
+    <section class="rounded-xl border border-border bg-surface/90 p-3">
+      <div class="flex items-center justify-between gap-3">
+        <h3 class="text-sm-ui font-semibold text-foreground">{props.title}</h3>
+        <Show when={props.items.length > VISIBLE_ITEMS_LIMIT}>
+          <button
+            type="button"
+            class="text-xs-ui font-medium text-primary hover:text-primary-hover"
+            onClick={() => setExpanded((current) => !current)}
+          >
+            {expanded()
+              ? t(keys.dashboard.syncBatch.panel.showLess)
+              : t(keys.dashboard.syncBatch.panel.showAll, {
+                  count: remainingCount(),
+                })}
+          </button>
+        </Show>
+      </div>
+
+      <div class="mt-3 space-y-2">
+        <For each={visibleItems()}>
+          {(item) => (
+            <article class="rounded-lg border border-border bg-background/80 px-3 py-2">
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs-ui text-text-muted">
+                <span class="font-semibold text-foreground">{item.processLabel}</span>
+                <span>{item.containerNumber}</span>
+                <span>{item.providerLabel}</span>
+              </div>
+              <p class="mt-1 text-sm-ui font-medium text-foreground">{item.reasonLabel}</p>
+              <p class="mt-1 text-xs-ui leading-relaxed text-text-muted">{item.reasonMessage}</p>
+            </article>
+          )}
+        </For>
+      </div>
+    </section>
+  )
+}
+
+export function DashboardSyncBatchResultPanel(
+  props: DashboardSyncBatchResultPanelProps,
+): JSX.Element {
+  const { t, keys } = useTranslation()
+
+  const headline = createMemo(() => {
+    if (props.result.isBusinessError) {
+      return t(keys.dashboard.syncBatch.panel.headlineNoEnqueue)
+    }
+
+    if (props.result.tone === 'warning' || props.result.tone === 'danger') {
+      return t(keys.dashboard.syncBatch.panel.headlinePartial)
+    }
+
+    return t(keys.dashboard.syncBatch.panel.headlineSuccess)
+  })
+
+  return (
+    <section class={`mb-5 rounded-2xl border p-4 shadow-sm ${toPanelToneClasses(props.result.tone)}`}>
+      <div class="flex items-start justify-between gap-4">
+        <div class="flex min-w-0 items-start gap-3">
+          <ResultToneIcon tone={props.result.tone} />
+          <div class="min-w-0">
+            <h2 class="text-base font-semibold text-foreground">
+              {t(keys.dashboard.syncBatch.panel.title)}
+            </h2>
+            <p class="text-sm-ui font-medium text-foreground">{headline()}</p>
+            <p class="mt-1 text-xs-ui leading-relaxed text-text-muted">
+              {t(keys.dashboard.syncBatch.panel.subtitle)}
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={props.onDismiss}
+          class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-surface text-text-muted transition-colors hover:border-border-strong hover:text-foreground"
+          aria-label={t(keys.dashboard.syncBatch.panel.dismiss)}
+          title={t(keys.dashboard.syncBatch.panel.dismiss)}
+        >
+          <X class="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div class="mt-4 flex flex-wrap gap-2">
+        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('neutral')}`}>
+          {t(keys.dashboard.syncBatch.panel.summary.requestedProcesses, {
+            count: props.result.summary.requestedProcesses,
+          })}
+        </span>
+        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('neutral')}`}>
+          {t(keys.dashboard.syncBatch.panel.summary.requestedContainers, {
+            count: props.result.summary.requestedContainers,
+          })}
+        </span>
+        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('success')}`}>
+          {t(keys.dashboard.syncBatch.panel.summary.enqueued, {
+            count: props.result.summary.enqueued,
+          })}
+        </span>
+        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('warning')}`}>
+          {t(keys.dashboard.syncBatch.panel.summary.skipped, {
+            count: props.result.summary.skipped,
+          })}
+        </span>
+        <span class={`rounded-full border px-3 py-1 text-xs-ui font-semibold ${toSummaryChipClasses('danger')}`}>
+          {t(keys.dashboard.syncBatch.panel.summary.failed, {
+            count: props.result.summary.failed,
+          })}
+        </span>
+      </div>
+
+      <div class="mt-4 space-y-3">
+        <Show when={props.result.failedTargets.length > 0}>
+          <DashboardSyncBatchSection
+            title={t(keys.dashboard.syncBatch.panel.sections.failed)}
+            items={props.result.failedTargets}
+          />
+        </Show>
+        <Show when={props.result.skippedTargets.length > 0}>
+          <DashboardSyncBatchSection
+            title={t(keys.dashboard.syncBatch.panel.sections.skipped)}
+            items={props.result.skippedTargets}
+          />
+        </Show>
+      </div>
+    </section>
+  )
+}

--- a/src/modules/process/ui/components/SyncCell.tsx
+++ b/src/modules/process/ui/components/SyncCell.tsx
@@ -1,6 +1,7 @@
-import { RefreshCw } from 'lucide-solid'
+import { CircleAlert, RefreshCw, TriangleAlert } from 'lucide-solid'
 import type { JSX } from 'solid-js'
-import { Match, Switch } from 'solid-js'
+import { Match, Show, Switch } from 'solid-js'
+import type { DashboardProcessSyncIssueVM } from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
 import { useTranslation } from '~/shared/localization/i18n'
 
 // ---------------------------------------------------------------------------
@@ -11,6 +12,7 @@ export type SyncCellState = 'idle' | 'syncing' | 'success_recent' | 'failed' | '
 
 type SyncCellProps = {
   readonly state: SyncCellState
+  readonly issue?: DashboardProcessSyncIssueVM | null
   readonly onSync?: () => void
 }
 
@@ -108,6 +110,29 @@ function SyncCellIcon(props: { readonly state: SyncCellState }): JSX.Element {
   )
 }
 
+function SyncIssueBadge(props: {
+  readonly issue: DashboardProcessSyncIssueVM
+}): JSX.Element {
+  const badgeClass =
+    props.issue.severity === 'danger'
+      ? 'border-tone-danger-border bg-tone-danger-bg text-tone-danger-fg'
+      : 'border-tone-warning-border bg-tone-warning-bg text-tone-warning-fg'
+
+  return (
+    <span
+      class={`pointer-events-none absolute -right-1 -top-1 inline-flex h-4 w-4 items-center justify-center rounded-full border ${badgeClass}`}
+      aria-hidden="true"
+    >
+      <Show
+        when={props.issue.severity === 'danger'}
+        fallback={<CircleAlert class="h-2.5 w-2.5" strokeWidth={2} />}
+      >
+        <TriangleAlert class="h-2.5 w-2.5" strokeWidth={2} />
+      </Show>
+    </span>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Style helpers
 // ---------------------------------------------------------------------------
@@ -139,6 +164,20 @@ function toAriaLabel(
   return t(keys.dashboard.table.sync.idle)
 }
 
+function toCompositeLabel(command: {
+  readonly state: SyncCellState
+  readonly issue: DashboardProcessSyncIssueVM | null
+  readonly t: ReturnType<typeof useTranslation>['t']
+  readonly keys: ReturnType<typeof useTranslation>['keys']
+}): string {
+  const baseLabel = toAriaLabel(command.state, command.t, command.keys)
+  if (command.issue === null) {
+    return baseLabel
+  }
+
+  return `${baseLabel}\n${command.issue.tooltip}`
+}
+
 function isInteractive(state: SyncCellState): boolean {
   return state === 'idle'
 }
@@ -159,17 +198,32 @@ export function SyncCell(props: SyncCellProps): JSX.Element {
 
   return (
     <div class="flex min-w-0 items-center justify-center px-[var(--dashboard-table-cell-px)] py-[var(--dashboard-table-cell-py)]">
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={!isInteractive(props.state)}
-        aria-busy={props.state === 'syncing'}
-        aria-label={toAriaLabel(props.state, t, keys)}
-        title={toAriaLabel(props.state, t, keys)}
-        class={toButtonClasses(props.state)}
-      >
-        <SyncCellIcon state={props.state} />
-      </button>
+      <div class="relative">
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={!isInteractive(props.state)}
+          aria-busy={props.state === 'syncing'}
+          aria-label={toCompositeLabel({
+            state: props.state,
+            issue: props.issue ?? null,
+            t,
+            keys,
+          })}
+          title={toCompositeLabel({
+            state: props.state,
+            issue: props.issue ?? null,
+            t,
+            keys,
+          })}
+          class={toButtonClasses(props.state)}
+        >
+          <SyncCellIcon state={props.state} />
+        </button>
+        <Show when={props.issue}>
+          {(issue) => <SyncIssueBadge issue={issue()} />}
+        </Show>
+      </div>
     </div>
   )
 }

--- a/src/modules/process/ui/components/SyncCell.tsx
+++ b/src/modules/process/ui/components/SyncCell.tsx
@@ -110,26 +110,26 @@ function SyncCellIcon(props: { readonly state: SyncCellState }): JSX.Element {
   )
 }
 
-function SyncIssueBadge(props: {
-  readonly issue: DashboardProcessSyncIssueVM
-}): JSX.Element {
-  const badgeClass =
-    props.issue.severity === 'danger'
-      ? 'border-tone-danger-border bg-tone-danger-bg text-tone-danger-fg'
-      : 'border-tone-warning-border bg-tone-warning-bg text-tone-warning-fg'
-
+function SyncIssueBadge(props: { readonly issue: DashboardProcessSyncIssueVM }): JSX.Element {
   return (
-    <span
-      class={`pointer-events-none absolute -right-1 -top-1 inline-flex h-4 w-4 items-center justify-center rounded-full border ${badgeClass}`}
-      aria-hidden="true"
+    <Show
+      when={props.issue.severity === 'danger'}
+      fallback={
+        <span
+          class="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 w-4 items-center justify-center rounded-full border border-tone-warning-border bg-tone-warning-bg text-tone-warning-fg"
+          aria-hidden="true"
+        >
+          <CircleAlert class="h-2.5 w-2.5" strokeWidth={2} />
+        </span>
+      }
     >
-      <Show
-        when={props.issue.severity === 'danger'}
-        fallback={<CircleAlert class="h-2.5 w-2.5" strokeWidth={2} />}
+      <span
+        class="pointer-events-none absolute -right-1 -top-1 inline-flex h-4 w-4 items-center justify-center rounded-full border border-tone-danger-border bg-tone-danger-bg text-tone-danger-fg"
+        aria-hidden="true"
       >
         <TriangleAlert class="h-2.5 w-2.5" strokeWidth={2} />
-      </Show>
-    </span>
+      </span>
+    </Show>
   )
 }
 
@@ -220,9 +220,7 @@ export function SyncCell(props: SyncCellProps): JSX.Element {
         >
           <SyncCellIcon state={props.state} />
         </button>
-        <Show when={props.issue}>
-          {(issue) => <SyncIssueBadge issue={issue()} />}
-        </Show>
+        <Show when={props.issue}>{(issue) => <SyncIssueBadge issue={issue()} />}</Show>
       </div>
     </div>
   )

--- a/src/modules/process/ui/components/tests/DashboardSyncBatchResultPanel.test.tsx
+++ b/src/modules/process/ui/components/tests/DashboardSyncBatchResultPanel.test.tsx
@@ -1,0 +1,261 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { DashboardSyncBatchResultPanel } from '~/modules/process/ui/components/DashboardSyncBatchResultPanel'
+import type {
+  DashboardSyncBatchProblemTargetVM,
+  DashboardSyncBatchResultVM,
+} from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
+
+const translationKeys = vi.hoisted(() => ({
+  dashboard: {
+    syncBatch: {
+      panel: {
+        title: 'Sync batch result',
+        subtitle: 'Server-first reconciliation summary',
+        headlineSuccess: 'All eligible targets were enqueued',
+        headlinePartial: 'Partial sync result',
+        headlineNoEnqueue: 'No targets were enqueued',
+        dismiss: 'Dismiss',
+        showAll: 'Show all ({count})',
+        showLess: 'Show less',
+        sections: {
+          failed: 'Failed targets',
+          skipped: 'Skipped targets',
+        },
+        summary: {
+          requestedProcesses: 'Requested processes: {count}',
+          requestedContainers: 'Requested containers: {count}',
+          enqueued: 'Enqueued: {count}',
+          skipped: 'Skipped: {count}',
+          failed: 'Failed: {count}',
+        },
+      },
+    },
+  },
+}))
+
+vi.mock('~/shared/localization/i18n', () => ({
+  useTranslation: () => ({
+    keys: translationKeys,
+    t: (value: string, params?: Readonly<Record<string, unknown>>) => {
+      if (params === undefined) {
+        return value
+      }
+
+      let translated = value
+      for (const [key, paramValue] of Object.entries(params)) {
+        translated = translated.replace(`{${key}}`, String(paramValue))
+      }
+      return translated
+    },
+  }),
+}))
+
+function buildProblemTarget(command: {
+  readonly processId: string
+  readonly processLabel: string
+  readonly containerNumber: string
+  readonly providerLabel: string
+  readonly reasonLabel: string
+  readonly reasonMessage: string
+}): DashboardSyncBatchProblemTargetVM {
+  return {
+    processId: command.processId,
+    processReference: command.processLabel,
+    processLabel: command.processLabel,
+    containerNumber: command.containerNumber,
+    provider: command.providerLabel.toLowerCase(),
+    providerLabel: command.providerLabel,
+    reasonCode: 'UNSUPPORTED_PROVIDER',
+    reasonLabel: command.reasonLabel,
+    reasonMessage: command.reasonMessage,
+  }
+}
+
+function buildResult(command?: {
+  readonly tone?: DashboardSyncBatchResultVM['tone']
+  readonly isBusinessError?: boolean
+  readonly httpStatus?: DashboardSyncBatchResultVM['httpStatus']
+}): DashboardSyncBatchResultVM {
+  const failedTargets = [
+    buildProblemTarget({
+      processId: 'process-1',
+      processLabel: 'REF-1',
+      containerNumber: 'FAILED-000001',
+      providerLabel: 'Maersk',
+      reasonLabel: 'Failed reason 1',
+      reasonMessage: 'Failed message 1',
+    }),
+    buildProblemTarget({
+      processId: 'process-2',
+      processLabel: 'REF-2',
+      containerNumber: 'FAILED-000002',
+      providerLabel: 'Maersk',
+      reasonLabel: 'Failed reason 2',
+      reasonMessage: 'Failed message 2',
+    }),
+    buildProblemTarget({
+      processId: 'process-3',
+      processLabel: 'REF-3',
+      containerNumber: 'FAILED-000003',
+      providerLabel: 'MSC',
+      reasonLabel: 'Failed reason 3',
+      reasonMessage: 'Failed message 3',
+    }),
+    buildProblemTarget({
+      processId: 'process-4',
+      processLabel: 'REF-4',
+      containerNumber: 'FAILED-000004',
+      providerLabel: 'MSC',
+      reasonLabel: 'Failed reason 4',
+      reasonMessage: 'Failed message 4',
+    }),
+    buildProblemTarget({
+      processId: 'process-5',
+      processLabel: 'REF-5',
+      containerNumber: 'FAILED-000005',
+      providerLabel: 'Hapag',
+      reasonLabel: 'Failed reason 5',
+      reasonMessage: 'Failed message 5',
+    }),
+    buildProblemTarget({
+      processId: 'process-6',
+      processLabel: 'REF-6',
+      containerNumber: 'FAILED-000006',
+      providerLabel: 'Hapag',
+      reasonLabel: 'Failed reason 6',
+      reasonMessage: 'Failed message 6',
+    }),
+  ]
+
+  const skippedTargets = [
+    buildProblemTarget({
+      processId: 'process-7',
+      processLabel: 'REF-7',
+      containerNumber: 'SKIPPED-000001',
+      providerLabel: 'Hapag',
+      reasonLabel: 'Skipped reason 1',
+      reasonMessage: 'Skipped message 1',
+    }),
+    buildProblemTarget({
+      processId: 'process-8',
+      processLabel: 'REF-8',
+      containerNumber: 'SKIPPED-000002',
+      providerLabel: 'Hapag',
+      reasonLabel: 'Skipped reason 2',
+      reasonMessage: 'Skipped message 2',
+    }),
+    buildProblemTarget({
+      processId: 'process-9',
+      processLabel: 'REF-9',
+      containerNumber: 'SKIPPED-000003',
+      providerLabel: 'MSC',
+      reasonLabel: 'Skipped reason 3',
+      reasonMessage: 'Skipped message 3',
+    }),
+    buildProblemTarget({
+      processId: 'process-10',
+      processLabel: 'REF-10',
+      containerNumber: 'SKIPPED-000004',
+      providerLabel: 'MSC',
+      reasonLabel: 'Skipped reason 4',
+      reasonMessage: 'Skipped message 4',
+    }),
+    buildProblemTarget({
+      processId: 'process-11',
+      processLabel: 'REF-11',
+      containerNumber: 'SKIPPED-000005',
+      providerLabel: 'ONE',
+      reasonLabel: 'Skipped reason 5',
+      reasonMessage: 'Skipped message 5',
+    }),
+    buildProblemTarget({
+      processId: 'process-12',
+      processLabel: 'REF-12',
+      containerNumber: 'SKIPPED-000006',
+      providerLabel: 'ONE',
+      reasonLabel: 'Skipped reason 6',
+      reasonMessage: 'Skipped message 6',
+    }),
+  ]
+
+  return {
+    httpStatus: command?.httpStatus ?? 200,
+    tone: command?.tone ?? 'danger',
+    isBusinessError: command?.isBusinessError ?? false,
+    summary: {
+      requestedProcesses: 12,
+      requestedContainers: 14,
+      enqueued: 2,
+      skipped: skippedTargets.length,
+      failed: failedTargets.length,
+    },
+    enqueuedTargets: [
+      {
+        processId: 'process-13',
+        processReference: 'REF-13',
+        processLabel: 'REF-13',
+        containerNumber: 'ENQUEUED-000001',
+        provider: 'maersk',
+        providerLabel: 'Maersk',
+        syncRequestId: 'sync-request-1',
+      },
+      {
+        processId: 'process-14',
+        processReference: 'REF-14',
+        processLabel: 'REF-14',
+        containerNumber: 'ENQUEUED-000002',
+        provider: 'msc',
+        providerLabel: 'MSC',
+        syncRequestId: 'sync-request-2',
+      },
+    ],
+    skippedTargets,
+    failedTargets,
+    issueByProcessId: {},
+    failedProcessIds: failedTargets.map((target) => target.processId),
+    enqueuedProcessIds: ['process-13', 'process-14'],
+  }
+}
+
+describe('DashboardSyncBatchResultPanel', () => {
+  it('renders summary chips, failed section first, and only the first five items per section by default', () => {
+    const html = renderToString(() =>
+      createComponent(DashboardSyncBatchResultPanel, {
+        result: buildResult(),
+        onDismiss: vi.fn(),
+      }),
+    )
+
+    expect(html).toContain('Sync batch result')
+    expect(html).toContain('Partial sync result')
+    expect(html).toContain('Requested processes: 12')
+    expect(html).toContain('Requested containers: 14')
+    expect(html).toContain('Enqueued: 2')
+    expect(html).toContain('Skipped: 6')
+    expect(html).toContain('Failed: 6')
+    expect(html.indexOf('Failed targets')).toBeLessThan(html.indexOf('Skipped targets'))
+    expect(html).toContain('FAILED-000005')
+    expect(html).not.toContain('FAILED-000006')
+    expect(html).toContain('SKIPPED-000005')
+    expect(html).not.toContain('SKIPPED-000006')
+    expect(html.split('Show all (1)').length - 1).toBe(2)
+  })
+
+  it('renders the business-error headline when no target was enqueued', () => {
+    const html = renderToString(() =>
+      createComponent(DashboardSyncBatchResultPanel, {
+        result: buildResult({
+          httpStatus: 422,
+          isBusinessError: true,
+          tone: 'danger',
+        }),
+        onDismiss: vi.fn(),
+      }),
+    )
+
+    expect(html).toContain('No targets were enqueued')
+    expect(html).toContain('Dismiss')
+  })
+})

--- a/src/modules/process/ui/components/tests/SyncCell.test.tsx
+++ b/src/modules/process/ui/components/tests/SyncCell.test.tsx
@@ -1,0 +1,72 @@
+import { createComponent } from 'solid-js'
+import { renderToString } from 'solid-js/web'
+import { describe, expect, it, vi } from 'vitest'
+import { SyncCell } from '~/modules/process/ui/components/SyncCell'
+import type { DashboardProcessSyncIssueVM } from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
+
+const translationKeys = vi.hoisted(() => ({
+  dashboard: {
+    table: {
+      sync: {
+        idle: 'Sync idle',
+        syncing: 'Sync running',
+        successRecent: 'Sync succeeded',
+        failed: 'Sync failed',
+        disabled: 'Sync unavailable',
+      },
+    },
+  },
+}))
+
+vi.mock('~/shared/localization/i18n', () => ({
+  useTranslation: () => ({
+    keys: translationKeys,
+    t: (value: string) => value,
+  }),
+}))
+
+function buildIssue(severity: DashboardProcessSyncIssueVM['severity']): DashboardProcessSyncIssueVM {
+  return {
+    severity,
+    tooltip:
+      severity === 'danger'
+        ? '1 failed\nMSCU1234567 · Maersk · Enqueue failed'
+        : '1 skipped\nMSCU1234567 · Hapag · Unsupported provider',
+    failedCount: severity === 'danger' ? 1 : 0,
+    skippedCount: severity === 'warning' ? 1 : 0,
+  }
+}
+
+describe('SyncCell', () => {
+  it('merges the persistent row issue tooltip with the idle sync label', () => {
+    const html = renderToString(() =>
+      createComponent(SyncCell, {
+        state: 'idle',
+        issue: buildIssue('warning'),
+        onSync: vi.fn(),
+      }),
+    )
+
+    expect(html).toContain('Sync idle')
+    expect(html).toContain('1 skipped')
+    expect(html).toContain('Unsupported provider')
+    expect(html).toContain('absolute -right-1 -top-1')
+    expect(html).not.toContain('disabled')
+  })
+
+  it('keeps failed state non-interactive while still exposing the row issue marker', () => {
+    const html = renderToString(() =>
+      createComponent(SyncCell, {
+        state: 'failed',
+        issue: buildIssue('danger'),
+      }),
+    )
+
+    expect(html).toContain('Sync failed')
+    expect(html).toContain('1 failed')
+    expect(html).toContain('Enqueue failed')
+    expect(html).toContain('disabled')
+    expect(html).toContain('cursor-default')
+    expect(html).toContain('border-tone-danger-border')
+  })
+})

--- a/src/modules/process/ui/components/tests/SyncCell.test.tsx
+++ b/src/modules/process/ui/components/tests/SyncCell.test.tsx
@@ -25,7 +25,9 @@ vi.mock('~/shared/localization/i18n', () => ({
   }),
 }))
 
-function buildIssue(severity: DashboardProcessSyncIssueVM['severity']): DashboardProcessSyncIssueVM {
+function buildIssue(
+  severity: DashboardProcessSyncIssueVM['severity'],
+): DashboardProcessSyncIssueVM {
   return {
     severity,
     tooltip:

--- a/src/modules/process/ui/mappers/dashboard-sync-batch-result.ui-mapper.ts
+++ b/src/modules/process/ui/mappers/dashboard-sync-batch-result.ui-mapper.ts
@@ -1,0 +1,218 @@
+import type { TranslationKeys } from '~/shared/localization/translationTypes'
+import { toCarrierDisplayLabel } from '~/shared/utils/carrierDisplay'
+import type { SyncAllProcessesRequestResult } from '~/modules/process/ui/api/processSync.api'
+import type {
+  DashboardProcessSyncIssueVM,
+  DashboardSyncBatchEnqueuedTargetVM,
+  DashboardSyncBatchProblemTargetVM,
+  DashboardSyncBatchReasonCode,
+  DashboardSyncBatchResultVM,
+} from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
+
+const MAX_ROW_TOOLTIP_ITEMS = 3
+
+function toProcessLabel(processReference: string | null, processId: string): string {
+  const trimmedReference = processReference?.trim() ?? ''
+  if (trimmedReference.length > 0) {
+    return trimmedReference
+  }
+
+  return `<${processId.slice(0, 8)}>`
+}
+
+function toProviderLabel(provider: string): string {
+  return toCarrierDisplayLabel(provider) ?? provider
+}
+
+function toReasonLabel(command: {
+  readonly reasonCode: DashboardSyncBatchReasonCode
+  readonly t: (key: string, params?: Readonly<Record<string, unknown>>) => string
+  readonly keys: TranslationKeys
+}): string {
+  switch (command.reasonCode) {
+    case 'UNSUPPORTED_PROVIDER':
+      return command.t(command.keys.dashboard.syncBatch.reasonCodes.unsupportedProvider)
+    case 'DUPLICATE_OPEN_REQUEST':
+      return command.t(command.keys.dashboard.syncBatch.reasonCodes.duplicateOpenRequest)
+    case 'MISSING_REQUIRED_DATA':
+      return command.t(command.keys.dashboard.syncBatch.reasonCodes.missingRequiredData)
+    case 'INELIGIBLE_TARGET':
+      return command.t(command.keys.dashboard.syncBatch.reasonCodes.ineligibleTarget)
+    case 'ENQUEUE_FAILED':
+      return command.t(command.keys.dashboard.syncBatch.reasonCodes.enqueueFailed)
+    case 'INFRASTRUCTURE_ERROR':
+      return command.t(command.keys.dashboard.syncBatch.reasonCodes.infrastructureError)
+    case 'UNEXPECTED_ERROR':
+      return command.t(command.keys.dashboard.syncBatch.reasonCodes.unexpectedError)
+  }
+}
+
+function toEnqueuedTargetVm(
+  source: SyncAllProcessesRequestResult['payload']['enqueuedTargets'][number],
+): DashboardSyncBatchEnqueuedTargetVM {
+  return {
+    processId: source.processId,
+    processReference: source.processReference,
+    processLabel: toProcessLabel(source.processReference, source.processId),
+    containerNumber: source.containerNumber,
+    provider: source.provider,
+    providerLabel: toProviderLabel(source.provider),
+    syncRequestId: source.syncRequestId,
+  }
+}
+
+function toProblemTargetVm(command: {
+  readonly source:
+    | SyncAllProcessesRequestResult['payload']['skippedTargets'][number]
+    | SyncAllProcessesRequestResult['payload']['failedTargets'][number]
+  readonly t: (key: string, params?: Readonly<Record<string, unknown>>) => string
+  readonly keys: TranslationKeys
+}): DashboardSyncBatchProblemTargetVM {
+  const reasonLabel = toReasonLabel({
+    reasonCode: command.source.reasonCode,
+    t: command.t,
+    keys: command.keys,
+  })
+
+  return {
+    processId: command.source.processId,
+    processReference: command.source.processReference,
+    processLabel: toProcessLabel(command.source.processReference, command.source.processId),
+    containerNumber: command.source.containerNumber,
+    provider: command.source.provider,
+    providerLabel: toProviderLabel(command.source.provider),
+    reasonCode: command.source.reasonCode,
+    reasonLabel,
+    reasonMessage: command.source.reasonMessage,
+  }
+}
+
+function toProblemLine(target: DashboardSyncBatchProblemTargetVM): string {
+  return `${target.containerNumber} · ${target.providerLabel} · ${target.reasonLabel}`
+}
+
+function toRowIssueTooltip(command: {
+  readonly failedTargets: readonly DashboardSyncBatchProblemTargetVM[]
+  readonly skippedTargets: readonly DashboardSyncBatchProblemTargetVM[]
+  readonly t: (key: string, params?: Readonly<Record<string, unknown>>) => string
+  readonly keys: TranslationKeys
+}): string {
+  const failedCount = command.failedTargets.length
+  const skippedCount = command.skippedTargets.length
+
+  const summaryLine =
+    failedCount > 0 && skippedCount > 0
+      ? command.t(command.keys.dashboard.syncBatch.rowIssue.mixed, {
+          failed: failedCount,
+          skipped: skippedCount,
+        })
+      : failedCount > 0
+        ? command.t(command.keys.dashboard.syncBatch.rowIssue.failedOnly, {
+            failed: failedCount,
+          })
+        : command.t(command.keys.dashboard.syncBatch.rowIssue.skippedOnly, {
+            skipped: skippedCount,
+          })
+
+  const items = [...command.failedTargets, ...command.skippedTargets]
+  const visibleLines = items.slice(0, MAX_ROW_TOOLTIP_ITEMS).map(toProblemLine)
+  const remainingCount = items.length - visibleLines.length
+
+  return [
+    summaryLine,
+    ...visibleLines,
+    ...(remainingCount > 0
+      ? [
+          command.t(command.keys.dashboard.syncBatch.rowIssue.additionalItems, {
+            count: remainingCount,
+          }),
+        ]
+      : []),
+  ].join('\n')
+}
+
+function toIssueByProcessId(command: {
+  readonly failedTargets: readonly DashboardSyncBatchProblemTargetVM[]
+  readonly skippedTargets: readonly DashboardSyncBatchProblemTargetVM[]
+  readonly t: (key: string, params?: Readonly<Record<string, unknown>>) => string
+  readonly keys: TranslationKeys
+}): Readonly<Record<string, DashboardProcessSyncIssueVM>> {
+  const processIds = new Set([
+    ...command.failedTargets.map((target) => target.processId),
+    ...command.skippedTargets.map((target) => target.processId),
+  ])
+
+  const issues: Record<string, DashboardProcessSyncIssueVM> = {}
+
+  for (const processId of processIds) {
+    const failedTargets = command.failedTargets.filter((target) => target.processId === processId)
+    const skippedTargets = command.skippedTargets.filter(
+      (target) => target.processId === processId,
+    )
+
+    issues[processId] = {
+      severity: failedTargets.length > 0 ? 'danger' : 'warning',
+      tooltip: toRowIssueTooltip({
+        failedTargets,
+        skippedTargets,
+        t: command.t,
+        keys: command.keys,
+      }),
+      failedCount: failedTargets.length,
+      skippedCount: skippedTargets.length,
+    }
+  }
+
+  return issues
+}
+
+function uniqueProcessIds(targets: readonly { readonly processId: string }[]): readonly string[] {
+  return Array.from(new Set(targets.map((target) => target.processId)))
+}
+
+export function toDashboardSyncBatchResultVm(command: {
+  readonly source: SyncAllProcessesRequestResult
+  readonly t: (key: string, params?: Readonly<Record<string, unknown>>) => string
+  readonly keys: TranslationKeys
+}): DashboardSyncBatchResultVM {
+  const failedTargets = command.source.payload.failedTargets.map((target) =>
+    toProblemTargetVm({
+      source: target,
+      t: command.t,
+      keys: command.keys,
+    }),
+  )
+  const skippedTargets = command.source.payload.skippedTargets.map((target) =>
+    toProblemTargetVm({
+      source: target,
+      t: command.t,
+      keys: command.keys,
+    }),
+  )
+  const issueByProcessId = toIssueByProcessId({
+    failedTargets,
+    skippedTargets,
+    t: command.t,
+    keys: command.keys,
+  })
+
+  return {
+    httpStatus: command.source.httpStatus,
+    tone:
+      failedTargets.length > 0 ? 'danger' : skippedTargets.length > 0 ? 'warning' : 'success',
+    isBusinessError: command.source.httpStatus === 422,
+    summary: {
+      requestedProcesses: command.source.payload.summary.requestedProcesses,
+      requestedContainers: command.source.payload.summary.requestedContainers,
+      enqueued: command.source.payload.summary.enqueued,
+      skipped: command.source.payload.summary.skipped,
+      failed: command.source.payload.summary.failed,
+    },
+    enqueuedTargets: command.source.payload.enqueuedTargets.map(toEnqueuedTargetVm),
+    skippedTargets,
+    failedTargets,
+    issueByProcessId,
+    failedProcessIds: uniqueProcessIds(failedTargets),
+    enqueuedProcessIds: uniqueProcessIds(command.source.payload.enqueuedTargets),
+  }
+}

--- a/src/modules/process/ui/mappers/dashboard-sync-batch-result.ui-mapper.ts
+++ b/src/modules/process/ui/mappers/dashboard-sync-batch-result.ui-mapper.ts
@@ -1,5 +1,3 @@
-import type { TranslationKeys } from '~/shared/localization/translationTypes'
-import { toCarrierDisplayLabel } from '~/shared/utils/carrierDisplay'
 import type { SyncAllProcessesRequestResult } from '~/modules/process/ui/api/processSync.api'
 import type {
   DashboardProcessSyncIssueVM,
@@ -8,6 +6,8 @@ import type {
   DashboardSyncBatchReasonCode,
   DashboardSyncBatchResultVM,
 } from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
+import type { TranslationKeys } from '~/shared/localization/translationTypes'
+import { toCarrierDisplayLabel } from '~/shared/utils/carrierDisplay'
 
 const MAX_ROW_TOOLTIP_ITEMS = 3
 
@@ -100,19 +100,21 @@ function toRowIssueTooltip(command: {
   const failedCount = command.failedTargets.length
   const skippedCount = command.skippedTargets.length
 
-  const summaryLine =
-    failedCount > 0 && skippedCount > 0
-      ? command.t(command.keys.dashboard.syncBatch.rowIssue.mixed, {
-          failed: failedCount,
-          skipped: skippedCount,
-        })
-      : failedCount > 0
-        ? command.t(command.keys.dashboard.syncBatch.rowIssue.failedOnly, {
-            failed: failedCount,
-          })
-        : command.t(command.keys.dashboard.syncBatch.rowIssue.skippedOnly, {
-            skipped: skippedCount,
-          })
+  let summaryLine: string
+  if (failedCount > 0 && skippedCount > 0) {
+    summaryLine = command.t(command.keys.dashboard.syncBatch.rowIssue.mixed, {
+      failed: failedCount,
+      skipped: skippedCount,
+    })
+  } else if (failedCount > 0) {
+    summaryLine = command.t(command.keys.dashboard.syncBatch.rowIssue.failedOnly, {
+      failed: failedCount,
+    })
+  } else {
+    summaryLine = command.t(command.keys.dashboard.syncBatch.rowIssue.skippedOnly, {
+      skipped: skippedCount,
+    })
+  }
 
   const items = [...command.failedTargets, ...command.skippedTargets]
   const visibleLines = items.slice(0, MAX_ROW_TOOLTIP_ITEMS).map(toProblemLine)
@@ -146,9 +148,7 @@ function toIssueByProcessId(command: {
 
   for (const processId of processIds) {
     const failedTargets = command.failedTargets.filter((target) => target.processId === processId)
-    const skippedTargets = command.skippedTargets.filter(
-      (target) => target.processId === processId,
-    )
+    const skippedTargets = command.skippedTargets.filter((target) => target.processId === processId)
 
     issues[processId] = {
       severity: failedTargets.length > 0 ? 'danger' : 'warning',
@@ -196,10 +196,18 @@ export function toDashboardSyncBatchResultVm(command: {
     keys: command.keys,
   })
 
+  let tone: DashboardSyncBatchResultVM['tone']
+  if (failedTargets.length > 0) {
+    tone = 'danger'
+  } else if (skippedTargets.length > 0) {
+    tone = 'warning'
+  } else {
+    tone = 'success'
+  }
+
   return {
     httpStatus: command.source.httpStatus,
-    tone:
-      failedTargets.length > 0 ? 'danger' : skippedTargets.length > 0 ? 'warning' : 'success',
+    tone,
     isBusinessError: command.source.httpStatus === 422,
     summary: {
       requestedProcesses: command.source.payload.summary.requestedProcesses,

--- a/src/modules/process/ui/screens/DashboardScreen.tsx
+++ b/src/modules/process/ui/screens/DashboardScreen.tsx
@@ -21,6 +21,7 @@ import { DashboardActivityChartCard } from '~/modules/process/ui/components/Dash
 import { DashboardKpiRow } from '~/modules/process/ui/components/DashboardKpiRow'
 import { DashboardProcessTable } from '~/modules/process/ui/components/DashboardProcessTable'
 import { DashboardRefreshButton } from '~/modules/process/ui/components/DashboardRefreshButton'
+import { DashboardSyncBatchResultPanel } from '~/modules/process/ui/components/DashboardSyncBatchResultPanel'
 import { ExportImportActions } from '~/modules/process/ui/components/export-import/ExportImportActions'
 import { UnifiedDashboardFilters } from '~/modules/process/ui/components/UnifiedDashboardFilters'
 import { fetchDashboardKpis } from '~/modules/process/ui/fetchDashboardKpis'
@@ -220,15 +221,20 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
   const sortedProcesses = createMemo(() =>
     sortDashboardProcesses(filteredProcesses(), sortSelection()),
   )
-  const { processesWithSyncFeedback, handleDashboardRefresh, handleProcessSync } =
-    useDashboardSyncController({
-      allProcesses: () => processesState.data() ?? [],
-      sortedProcesses,
-      refetchProcesses,
-      refetchGlobalAlerts,
-      refetchDashboardKpis,
-      refetchDashboardProcessesCreatedByMonth,
-    })
+  const {
+    processesWithSyncFeedback,
+    dashboardSyncBatchResult,
+    dismissDashboardSyncBatchResult,
+    handleDashboardRefresh,
+    handleProcessSync,
+  } = useDashboardSyncController({
+    allProcesses: () => processesState.data() ?? [],
+    sortedProcesses,
+    refetchProcesses,
+    refetchGlobalAlerts,
+    refetchDashboardKpis,
+    refetchDashboardProcessesCreatedByMonth,
+  })
   const highlightedProcessId = createMemo(() =>
     resolveHighlightedDashboardProcessId({
       processes: processesWithSyncFeedback(),
@@ -374,6 +380,14 @@ export function Dashboard(props: { readonly searchSlot?: JSX.Element }): JSX.Ele
             onSeveritySelect={handleSeverityFilterSelect}
             onClearAllFilters={handleClearAllFilters}
           />
+          <Show when={dashboardSyncBatchResult()}>
+            {(result) => (
+              <DashboardSyncBatchResultPanel
+                result={result()}
+                onDismiss={dismissDashboardSyncBatchResult}
+              />
+            )}
+          </Show>
           <DashboardProcessTable
             processes={processesWithSyncFeedback()}
             highlightedProcessId={highlightedProcessId()}

--- a/src/modules/process/ui/screens/dashboard/hooks/dashboard-sync-feedback-expiry.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/dashboard-sync-feedback-expiry.ts
@@ -1,0 +1,209 @@
+type LocalSyncFeedbackDocument = Pick<
+  Document,
+  'addEventListener' | 'removeEventListener' | 'visibilityState'
+>
+
+export type LocalSyncFeedbackEnvironment = {
+  readonly document?: LocalSyncFeedbackDocument | undefined
+}
+
+export type LocalSyncFeedbackExpiryHandle = {
+  readonly dispose: () => void
+}
+
+function resolveLocalSyncFeedbackDocument(
+  environment?: LocalSyncFeedbackEnvironment,
+): LocalSyncFeedbackDocument | undefined {
+  if (environment?.document) {
+    return environment.document
+  }
+
+  if (typeof document === 'undefined') {
+    return undefined
+  }
+
+  return document
+}
+
+function isLocalSyncFeedbackDocumentVisible(
+  currentDocument: LocalSyncFeedbackDocument | undefined,
+): boolean {
+  if (!currentDocument) {
+    return true
+  }
+
+  return currentDocument.visibilityState === 'visible'
+}
+
+export function createLocalSyncFeedbackExpiryHandle(command: {
+  readonly ttlMs: number
+  readonly onExpire: () => void
+}): LocalSyncFeedbackExpiryHandle {
+  const timeoutId = setTimeout(() => {
+    command.onExpire()
+  }, command.ttlMs)
+
+  return {
+    dispose: () => {
+      clearTimeout(timeoutId)
+    },
+  }
+}
+
+export function createVisibleLocalSyncFeedbackExpiryHandle(command: {
+  readonly ttlMs: number
+  readonly onExpire: () => void
+  readonly environment?: LocalSyncFeedbackEnvironment
+}): LocalSyncFeedbackExpiryHandle {
+  const currentDocument = resolveLocalSyncFeedbackDocument(command.environment)
+  if (!currentDocument) {
+    return createLocalSyncFeedbackExpiryHandle({
+      ttlMs: command.ttlMs,
+      onExpire: command.onExpire,
+    })
+  }
+
+  let remainingMs = command.ttlMs
+  let countdownStartedAtMs: number | null = null
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const clearCountdown = (): void => {
+    if (timeoutId === null) {
+      return
+    }
+
+    clearTimeout(timeoutId)
+    timeoutId = null
+  }
+
+  const stopVisibleCountdown = (): void => {
+    if (countdownStartedAtMs === null) {
+      clearCountdown()
+      return
+    }
+
+    const elapsedMs = Date.now() - countdownStartedAtMs
+    remainingMs = Math.max(0, remainingMs - elapsedMs)
+    countdownStartedAtMs = null
+    clearCountdown()
+  }
+
+  const cleanup = (): void => {
+    currentDocument.removeEventListener('visibilitychange', handleVisibilityChange)
+    clearCountdown()
+    countdownStartedAtMs = null
+  }
+
+  const expire = (): void => {
+    if (disposed) {
+      return
+    }
+
+    disposed = true
+    cleanup()
+    command.onExpire()
+  }
+
+  const startVisibleCountdown = (): void => {
+    if (disposed || countdownStartedAtMs !== null) {
+      return
+    }
+
+    if (!isLocalSyncFeedbackDocumentVisible(currentDocument)) {
+      return
+    }
+
+    if (remainingMs <= 0) {
+      expire()
+      return
+    }
+
+    countdownStartedAtMs = Date.now()
+    timeoutId = setTimeout(() => {
+      remainingMs = 0
+      countdownStartedAtMs = null
+      expire()
+    }, remainingMs)
+  }
+
+  function handleVisibilityChange(): void {
+    if (disposed) {
+      return
+    }
+
+    if (isLocalSyncFeedbackDocumentVisible(currentDocument)) {
+      startVisibleCountdown()
+      return
+    }
+
+    stopVisibleCountdown()
+  }
+
+  currentDocument.addEventListener('visibilitychange', handleVisibilityChange)
+  startVisibleCountdown()
+
+  return {
+    dispose: () => {
+      if (disposed) {
+        return
+      }
+
+      disposed = true
+      cleanup()
+    },
+  }
+}
+
+export function schedulePerProcessVisibleLocalSyncExpiry(command: {
+  readonly processIds: readonly string[]
+  readonly ttlMs: number
+  readonly onExpire: (processId: string) => void
+  readonly environment?: LocalSyncFeedbackEnvironment
+}): ReadonlyMap<string, LocalSyncFeedbackExpiryHandle> {
+  const expiryByProcessId = new Map<string, LocalSyncFeedbackExpiryHandle>()
+
+  for (const processId of command.processIds) {
+    const expiryCommand =
+      command.environment === undefined
+        ? {
+            ttlMs: command.ttlMs,
+            onExpire: () => {
+              command.onExpire(processId)
+            },
+          }
+        : {
+            ttlMs: command.ttlMs,
+            onExpire: () => {
+              command.onExpire(processId)
+            },
+            environment: command.environment,
+          }
+
+    expiryByProcessId.set(processId, createVisibleLocalSyncFeedbackExpiryHandle(expiryCommand))
+  }
+
+  return expiryByProcessId
+}
+
+export function schedulePerProcessLocalSyncExpiry(command: {
+  readonly processIds: readonly string[]
+  readonly ttlMs: number
+  readonly onExpire: (processId: string) => void
+}): ReadonlyMap<string, LocalSyncFeedbackExpiryHandle> {
+  const expiryByProcessId = new Map<string, LocalSyncFeedbackExpiryHandle>()
+
+  for (const processId of command.processIds) {
+    expiryByProcessId.set(
+      processId,
+      createLocalSyncFeedbackExpiryHandle({
+        ttlMs: command.ttlMs,
+        onExpire: () => {
+          command.onExpire(processId)
+        },
+      }),
+    )
+  }
+
+  return expiryByProcessId
+}

--- a/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.behavior.test.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.behavior.test.ts
@@ -290,14 +290,11 @@ describe('useDashboardSyncController behavior', () => {
       },
     })
     expect(
-      harness
-        .controller
-        .processesWithSyncFeedback()
-        .map((process) => ({
-          id: process.id,
-          syncStatus: process.syncStatus,
-          issue: process.syncIssue?.severity ?? null,
-        })),
+      harness.controller.processesWithSyncFeedback().map((process) => ({
+        id: process.id,
+        syncStatus: process.syncStatus,
+        issue: process.syncIssue?.severity ?? null,
+      })),
     ).toEqual([
       {
         id: 'process-1',
@@ -319,14 +316,11 @@ describe('useDashboardSyncController behavior', () => {
     await vi.advanceTimersByTimeAsync(2_600)
 
     expect(
-      harness
-        .controller
-        .processesWithSyncFeedback()
-        .map((process) => ({
-          id: process.id,
-          syncStatus: process.syncStatus,
-          issue: process.syncIssue?.severity ?? null,
-        })),
+      harness.controller.processesWithSyncFeedback().map((process) => ({
+        id: process.id,
+        syncStatus: process.syncStatus,
+        issue: process.syncIssue?.severity ?? null,
+      })),
     ).toEqual([
       {
         id: 'process-1',
@@ -348,14 +342,11 @@ describe('useDashboardSyncController behavior', () => {
     await vi.advanceTimersByTimeAsync(27_500)
 
     expect(
-      harness
-        .controller
-        .processesWithSyncFeedback()
-        .map((process) => ({
-          id: process.id,
-          syncStatus: process.syncStatus,
-          issue: process.syncIssue?.severity ?? null,
-        })),
+      harness.controller.processesWithSyncFeedback().map((process) => ({
+        id: process.id,
+        syncStatus: process.syncStatus,
+        issue: process.syncIssue?.severity ?? null,
+      })),
     ).toEqual([
       {
         id: 'process-1',
@@ -377,12 +368,8 @@ describe('useDashboardSyncController behavior', () => {
     harness.controller.dismissDashboardSyncBatchResult()
 
     expect(harness.controller.dashboardSyncBatchResult()).toBeNull()
-    expect(
-      harness.controller.processesWithSyncFeedback()[1]?.syncIssue?.severity,
-    ).toBe('warning')
-    expect(
-      harness.controller.processesWithSyncFeedback()[2]?.syncIssue?.severity,
-    ).toBe('danger')
+    expect(harness.controller.processesWithSyncFeedback()[1]?.syncIssue?.severity).toBe('warning')
+    expect(harness.controller.processesWithSyncFeedback()[2]?.syncIssue?.severity).toBe('danger')
     harness.dispose()
   })
 
@@ -408,14 +395,11 @@ describe('useDashboardSyncController behavior', () => {
       },
     })
     expect(
-      harness
-        .controller
-        .processesWithSyncFeedback()
-        .map((process) => ({
-          id: process.id,
-          syncStatus: process.syncStatus,
-          issue: process.syncIssue?.severity ?? null,
-        })),
+      harness.controller.processesWithSyncFeedback().map((process) => ({
+        id: process.id,
+        syncStatus: process.syncStatus,
+        issue: process.syncIssue?.severity ?? null,
+      })),
     ).toEqual([
       {
         id: 'process-1',

--- a/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.behavior.test.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.behavior.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  SyncAllProcessesBusinessErrorResponse,
+  SyncAllProcessesRequestResult,
+  SyncAllProcessesSuccessResponse,
+} from '~/modules/process/ui/api/processSync.api'
 import type { ProcessSummaryVM } from '~/modules/process/ui/viewmodels/process-summary.vm'
 
 const fetchProcessesSyncStatusMock = vi.hoisted(() => vi.fn())
@@ -116,6 +121,104 @@ function createControllerHarness(processes: readonly ProcessSummaryVM[]) {
   })
 }
 
+function buildSyncAllSuccessPayload(): SyncAllProcessesSuccessResponse {
+  return {
+    ok: true,
+    summary: {
+      requestedProcesses: 3,
+      requestedContainers: 4,
+      enqueued: 2,
+      skipped: 1,
+      failed: 1,
+    },
+    enqueuedTargets: [
+      {
+        processId: 'process-1',
+        processReference: 'REF-process-1',
+        containerNumber: 'MSCU1234567',
+        provider: 'msc',
+        syncRequestId: 'sync-request-1',
+      },
+      {
+        processId: 'process-2',
+        processReference: 'REF-process-2',
+        containerNumber: 'MSCU7654321',
+        provider: 'maersk',
+        syncRequestId: 'sync-request-2',
+      },
+    ],
+    skippedTargets: [
+      {
+        processId: 'process-2',
+        processReference: 'REF-process-2',
+        containerNumber: 'HLCU2222222',
+        provider: 'hapag',
+        reasonCode: 'UNSUPPORTED_PROVIDER',
+        reasonMessage: 'Provider is not supported for dashboard sync',
+      },
+    ],
+    failedTargets: [
+      {
+        processId: 'process-3',
+        processReference: 'REF-process-3',
+        containerNumber: 'SEGU3333333',
+        provider: 'maersk',
+        reasonCode: 'ENQUEUE_FAILED',
+        reasonMessage: 'Failed to enqueue target',
+      },
+    ],
+  }
+}
+
+function buildSyncAllBusinessErrorPayload(): SyncAllProcessesBusinessErrorResponse {
+  return {
+    ok: false,
+    error: 'sync_dashboard_failed_no_targets_enqueued',
+    summary: {
+      requestedProcesses: 2,
+      requestedContainers: 2,
+      enqueued: 0,
+      skipped: 1,
+      failed: 1,
+    },
+    enqueuedTargets: [],
+    skippedTargets: [
+      {
+        processId: 'process-1',
+        processReference: 'REF-process-1',
+        containerNumber: 'MSCU1234567',
+        provider: 'hapag',
+        reasonCode: 'UNSUPPORTED_PROVIDER',
+        reasonMessage: 'Provider is not supported for dashboard sync',
+      },
+    ],
+    failedTargets: [
+      {
+        processId: 'process-2',
+        processReference: 'REF-process-2',
+        containerNumber: 'MSCU7654321',
+        provider: 'maersk',
+        reasonCode: 'ENQUEUE_FAILED',
+        reasonMessage: 'Failed to enqueue target',
+      },
+    ],
+  }
+}
+
+function buildSyncAllSuccessResult(): SyncAllProcessesRequestResult {
+  return {
+    httpStatus: 200,
+    payload: buildSyncAllSuccessPayload(),
+  }
+}
+
+function buildSyncAllBusinessErrorResult(): SyncAllProcessesRequestResult {
+  return {
+    httpStatus: 422,
+    payload: buildSyncAllBusinessErrorPayload(),
+  }
+}
+
 describe('useDashboardSyncController behavior', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -133,7 +236,7 @@ describe('useDashboardSyncController behavior', () => {
     vi.useRealTimers()
   })
 
-  it('shows process-level syncing immediately, then success, then expires local feedback', async () => {
+  it('shows process-level syncing immediately, then keeps success visible for 30 seconds', async () => {
     const syncDeferred = createDeferred<void>()
     syncProcessRequestMock.mockReturnValue(syncDeferred.promise)
     const harness = createControllerHarness([buildProcess('process-1', 'idle')])
@@ -151,15 +254,20 @@ describe('useDashboardSyncController behavior', () => {
 
     await vi.advanceTimersByTimeAsync(2_600)
 
+    expect(harness.controller.processesWithSyncFeedback()[0]?.syncStatus).toBe('success')
+
+    await vi.advanceTimersByTimeAsync(27_500)
+
     expect(harness.controller.processesWithSyncFeedback()[0]?.syncStatus).toBe('idle')
     harness.dispose()
   })
 
-  it('marks all current rows with transient success after dashboard refresh', async () => {
-    refreshDashboardDataMock.mockResolvedValue(undefined)
+  it('shows partial success details, keeps row issues, and dismisses only the inline panel', async () => {
+    refreshDashboardDataMock.mockResolvedValue(buildSyncAllSuccessResult())
     const harness = createControllerHarness([
       buildProcess('process-1', 'idle'),
       buildProcess('process-2', 'idle'),
+      buildProcess('process-3', 'idle'),
     ])
 
     await harness.controller.handleDashboardRefresh()
@@ -169,15 +277,157 @@ describe('useDashboardSyncController behavior', () => {
         syncAllProcesses: syncAllProcessesRequestMock,
       }),
     )
+    expect(harness.controller.dashboardSyncBatchResult()).toMatchObject({
+      httpStatus: 200,
+      isBusinessError: false,
+      tone: 'danger',
+      summary: {
+        requestedProcesses: 3,
+        requestedContainers: 4,
+        enqueued: 2,
+        skipped: 1,
+        failed: 1,
+      },
+    })
     expect(
-      harness.controller.processesWithSyncFeedback().map((process) => process.syncStatus),
-    ).toEqual(['success', 'success'])
+      harness
+        .controller
+        .processesWithSyncFeedback()
+        .map((process) => ({
+          id: process.id,
+          syncStatus: process.syncStatus,
+          issue: process.syncIssue?.severity ?? null,
+        })),
+    ).toEqual([
+      {
+        id: 'process-1',
+        syncStatus: 'success',
+        issue: null,
+      },
+      {
+        id: 'process-2',
+        syncStatus: 'success',
+        issue: 'warning',
+      },
+      {
+        id: 'process-3',
+        syncStatus: 'error',
+        issue: 'danger',
+      },
+    ])
 
     await vi.advanceTimersByTimeAsync(2_600)
 
     expect(
-      harness.controller.processesWithSyncFeedback().map((process) => process.syncStatus),
-    ).toEqual(['idle', 'idle'])
+      harness
+        .controller
+        .processesWithSyncFeedback()
+        .map((process) => ({
+          id: process.id,
+          syncStatus: process.syncStatus,
+          issue: process.syncIssue?.severity ?? null,
+        })),
+    ).toEqual([
+      {
+        id: 'process-1',
+        syncStatus: 'success',
+        issue: null,
+      },
+      {
+        id: 'process-2',
+        syncStatus: 'success',
+        issue: 'warning',
+      },
+      {
+        id: 'process-3',
+        syncStatus: 'idle',
+        issue: 'danger',
+      },
+    ])
+
+    await vi.advanceTimersByTimeAsync(27_500)
+
+    expect(
+      harness
+        .controller
+        .processesWithSyncFeedback()
+        .map((process) => ({
+          id: process.id,
+          syncStatus: process.syncStatus,
+          issue: process.syncIssue?.severity ?? null,
+        })),
+    ).toEqual([
+      {
+        id: 'process-1',
+        syncStatus: 'idle',
+        issue: null,
+      },
+      {
+        id: 'process-2',
+        syncStatus: 'idle',
+        issue: 'warning',
+      },
+      {
+        id: 'process-3',
+        syncStatus: 'idle',
+        issue: 'danger',
+      },
+    ])
+
+    harness.controller.dismissDashboardSyncBatchResult()
+
+    expect(harness.controller.dashboardSyncBatchResult()).toBeNull()
+    expect(
+      harness.controller.processesWithSyncFeedback()[1]?.syncIssue?.severity,
+    ).toBe('warning')
+    expect(
+      harness.controller.processesWithSyncFeedback()[2]?.syncIssue?.severity,
+    ).toBe('danger')
+    harness.dispose()
+  })
+
+  it('treats structured 422 responses as business results instead of total failure', async () => {
+    refreshDashboardDataMock.mockResolvedValue(buildSyncAllBusinessErrorResult())
+    const harness = createControllerHarness([
+      buildProcess('process-1', 'idle'),
+      buildProcess('process-2', 'idle'),
+    ])
+
+    await expect(harness.controller.handleDashboardRefresh()).resolves.toBeUndefined()
+
+    expect(harness.controller.dashboardSyncBatchResult()).toMatchObject({
+      httpStatus: 422,
+      isBusinessError: true,
+      tone: 'danger',
+      summary: {
+        requestedProcesses: 2,
+        requestedContainers: 2,
+        enqueued: 0,
+        skipped: 1,
+        failed: 1,
+      },
+    })
+    expect(
+      harness
+        .controller
+        .processesWithSyncFeedback()
+        .map((process) => ({
+          id: process.id,
+          syncStatus: process.syncStatus,
+          issue: process.syncIssue?.severity ?? null,
+        })),
+    ).toEqual([
+      {
+        id: 'process-1',
+        syncStatus: 'idle',
+        issue: 'warning',
+      },
+      {
+        id: 'process-2',
+        syncStatus: 'error',
+        issue: 'danger',
+      },
+    ])
     harness.dispose()
   })
 

--- a/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.test.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { schedulePerProcessLocalSyncExpiry } from '~/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController'
+import {
+  schedulePerProcessLocalSyncExpiry,
+  schedulePerProcessVisibleLocalSyncExpiry,
+} from '~/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController'
+
+class MockVisibilityDocument extends EventTarget {
+  visibilityState: DocumentVisibilityState
+
+  constructor(visibilityState: DocumentVisibilityState) {
+    super()
+    this.visibilityState = visibilityState
+  }
+}
 
 describe('useDashboardSyncController', () => {
   beforeEach(() => {
@@ -13,21 +25,21 @@ describe('useDashboardSyncController', () => {
 
   it('creates independent timers per process so clearing one does not cancel others', async () => {
     const onExpire = vi.fn()
-    const timeoutByProcessId = schedulePerProcessLocalSyncExpiry({
+    const expiryByProcessId = schedulePerProcessLocalSyncExpiry({
       processIds: ['p1', 'p2'],
       ttlMs: 2_500,
       onExpire,
     })
 
-    expect(timeoutByProcessId.size).toBe(2)
-    const p1Timeout = timeoutByProcessId.get('p1')
-    const p2Timeout = timeoutByProcessId.get('p2')
-    expect(p1Timeout).toBeDefined()
-    expect(p2Timeout).toBeDefined()
-    expect(p1Timeout).not.toBe(p2Timeout)
+    expect(expiryByProcessId.size).toBe(2)
+    const p1Expiry = expiryByProcessId.get('p1')
+    const p2Expiry = expiryByProcessId.get('p2')
+    expect(p1Expiry).toBeDefined()
+    expect(p2Expiry).toBeDefined()
+    expect(p1Expiry).not.toBe(p2Expiry)
 
-    if (p1Timeout !== undefined) {
-      clearTimeout(p1Timeout)
+    if (p1Expiry !== undefined) {
+      p1Expiry.dispose()
     }
 
     await vi.advanceTimersByTimeAsync(2_600)
@@ -49,5 +61,63 @@ describe('useDashboardSyncController', () => {
     expect(onExpire).toHaveBeenCalledTimes(2)
     expect(onExpire).toHaveBeenCalledWith('p1')
     expect(onExpire).toHaveBeenCalledWith('p2')
+  })
+
+  it('pauses visible success expiry while the document is hidden and resumes when visible again', async () => {
+    const onExpire = vi.fn()
+    const mockDocument = new MockVisibilityDocument('hidden')
+
+    schedulePerProcessVisibleLocalSyncExpiry({
+      processIds: ['p1'],
+      ttlMs: 30_000,
+      onExpire,
+      environment: {
+        document: mockDocument,
+      },
+    })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(onExpire).not.toHaveBeenCalled()
+
+    mockDocument.visibilityState = 'visible'
+    mockDocument.dispatchEvent(new Event('visibilitychange'))
+
+    await vi.advanceTimersByTimeAsync(29_000)
+    expect(onExpire).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_100)
+    expect(onExpire).toHaveBeenCalledTimes(1)
+    expect(onExpire).toHaveBeenCalledWith('p1')
+  })
+
+  it('preserves the remaining visible time when the tab is hidden mid-countdown', async () => {
+    const onExpire = vi.fn()
+    const mockDocument = new MockVisibilityDocument('visible')
+
+    schedulePerProcessVisibleLocalSyncExpiry({
+      processIds: ['p1'],
+      ttlMs: 30_000,
+      onExpire,
+      environment: {
+        document: mockDocument,
+      },
+    })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    mockDocument.visibilityState = 'hidden'
+    mockDocument.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(onExpire).not.toHaveBeenCalled()
+
+    mockDocument.visibilityState = 'visible'
+    mockDocument.dispatchEvent(new Event('visibilitychange'))
+
+    await vi.advanceTimersByTimeAsync(19_000)
+    expect(onExpire).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_100)
+    expect(onExpire).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.test.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/tests/useDashboardSyncController.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   schedulePerProcessLocalSyncExpiry,
   schedulePerProcessVisibleLocalSyncExpiry,
-} from '~/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController'
+} from '~/modules/process/ui/screens/dashboard/hooks/dashboard-sync-feedback-expiry'
 
 class MockVisibilityDocument extends EventTarget {
   visibilityState: DocumentVisibilityState

--- a/src/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController.ts
@@ -5,18 +5,37 @@ import {
   syncAllProcessesRequest,
   syncProcessRequest,
 } from '~/modules/process/ui/api/processSync.api'
+import { toDashboardSyncBatchResultVm } from '~/modules/process/ui/mappers/dashboard-sync-batch-result.ui-mapper'
 import { useProcessSyncRealtime } from '~/modules/process/ui/hooks/useProcessSyncRealtime'
 import { refreshDashboardData } from '~/modules/process/ui/utils/dashboard-refresh'
 import {
   type DashboardLocalSyncStatus,
   resolveDashboardProcessSyncStatus,
 } from '~/modules/process/ui/utils/dashboard-sync-reconciliation'
+import type {
+  DashboardProcessRowVM,
+  DashboardProcessSyncIssueVM,
+  DashboardSyncBatchResultVM,
+} from '~/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm'
 import type { ProcessSummaryVM } from '~/modules/process/ui/viewmodels/process-summary.vm'
+import { useTranslation } from '~/shared/localization/i18n'
 
-const LOCAL_SYNC_FEEDBACK_TTL_MS = 2_500
+const LOCAL_SYNC_ERROR_FEEDBACK_TTL_MS = 2_500
+const LOCAL_SYNC_SUCCESS_VISIBLE_TTL_MS = 30_000
 const REALTIME_RECONCILIATION_DEBOUNCE_MS = 250
 
 type LocalSyncStateByProcessId = Readonly<Record<string, DashboardLocalSyncStatus>>
+type SyncIssueByProcessId = Readonly<Record<string, DashboardProcessSyncIssueVM>>
+type LocalSyncFeedbackDocument = Pick<
+  Document,
+  'addEventListener' | 'removeEventListener' | 'visibilityState'
+>
+type LocalSyncFeedbackEnvironment = {
+  readonly document?: LocalSyncFeedbackDocument | undefined
+}
+type LocalSyncFeedbackExpiryHandle = {
+  readonly dispose: () => void
+}
 
 type UseDashboardSyncControllerCommand = {
   readonly allProcesses: Accessor<readonly ProcessSummaryVM[]>
@@ -28,28 +47,213 @@ type UseDashboardSyncControllerCommand = {
 }
 
 type DashboardSyncControllerResult = {
-  readonly processesWithSyncFeedback: Accessor<readonly ProcessSummaryVM[]>
+  readonly processesWithSyncFeedback: Accessor<readonly DashboardProcessRowVM[]>
+  readonly dashboardSyncBatchResult: Accessor<DashboardSyncBatchResultVM | null>
+  readonly dismissDashboardSyncBatchResult: () => void
   readonly handleDashboardRefresh: () => Promise<void>
   readonly handleProcessSync: (processId: string) => Promise<void>
 }
 
 type ProcessesSyncSnapshot = Awaited<ReturnType<typeof fetchProcessesSyncStatus>>
 
+function resolveLocalSyncFeedbackDocument(
+  environment?: LocalSyncFeedbackEnvironment,
+): LocalSyncFeedbackDocument | undefined {
+  if (environment?.document) {
+    return environment.document
+  }
+
+  if (typeof document === 'undefined') {
+    return undefined
+  }
+
+  return document
+}
+
+function isLocalSyncFeedbackDocumentVisible(
+  currentDocument: LocalSyncFeedbackDocument | undefined,
+): boolean {
+  if (!currentDocument) {
+    return true
+  }
+
+  return currentDocument.visibilityState === 'visible'
+}
+
+function createLocalSyncFeedbackExpiryHandle(command: {
+  readonly ttlMs: number
+  readonly onExpire: () => void
+}): LocalSyncFeedbackExpiryHandle {
+  const timeoutId = setTimeout(() => {
+    command.onExpire()
+  }, command.ttlMs)
+
+  return {
+    dispose: () => {
+      clearTimeout(timeoutId)
+    },
+  }
+}
+
+function createVisibleLocalSyncFeedbackExpiryHandle(command: {
+  readonly ttlMs: number
+  readonly onExpire: () => void
+  readonly environment?: LocalSyncFeedbackEnvironment
+}): LocalSyncFeedbackExpiryHandle {
+  const currentDocument = resolveLocalSyncFeedbackDocument(command.environment)
+  if (!currentDocument) {
+    return createLocalSyncFeedbackExpiryHandle({
+      ttlMs: command.ttlMs,
+      onExpire: command.onExpire,
+    })
+  }
+
+  let remainingMs = command.ttlMs
+  let countdownStartedAtMs: number | null = null
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const clearCountdown = (): void => {
+    if (timeoutId === null) {
+      return
+    }
+
+    clearTimeout(timeoutId)
+    timeoutId = null
+  }
+
+  const stopVisibleCountdown = (): void => {
+    if (countdownStartedAtMs === null) {
+      clearCountdown()
+      return
+    }
+
+    const elapsedMs = Date.now() - countdownStartedAtMs
+    remainingMs = Math.max(0, remainingMs - elapsedMs)
+    countdownStartedAtMs = null
+    clearCountdown()
+  }
+
+  const cleanup = (): void => {
+    currentDocument.removeEventListener('visibilitychange', handleVisibilityChange)
+    clearCountdown()
+    countdownStartedAtMs = null
+  }
+
+  const expire = (): void => {
+    if (disposed) {
+      return
+    }
+
+    disposed = true
+    cleanup()
+    command.onExpire()
+  }
+
+  const startVisibleCountdown = (): void => {
+    if (disposed || countdownStartedAtMs !== null) {
+      return
+    }
+
+    if (!isLocalSyncFeedbackDocumentVisible(currentDocument)) {
+      return
+    }
+
+    if (remainingMs <= 0) {
+      expire()
+      return
+    }
+
+    countdownStartedAtMs = Date.now()
+    timeoutId = setTimeout(() => {
+      remainingMs = 0
+      countdownStartedAtMs = null
+      expire()
+    }, remainingMs)
+  }
+
+  function handleVisibilityChange(): void {
+    if (disposed) {
+      return
+    }
+
+    if (isLocalSyncFeedbackDocumentVisible(currentDocument)) {
+      startVisibleCountdown()
+      return
+    }
+
+    stopVisibleCountdown()
+  }
+
+  currentDocument.addEventListener('visibilitychange', handleVisibilityChange)
+  startVisibleCountdown()
+
+  return {
+    dispose: () => {
+      if (disposed) {
+        return
+      }
+
+      disposed = true
+      cleanup()
+    },
+  }
+}
+
 export function schedulePerProcessLocalSyncExpiry(command: {
   readonly processIds: readonly string[]
   readonly ttlMs: number
   readonly onExpire: (processId: string) => void
-}): ReadonlyMap<string, ReturnType<typeof setTimeout>> {
-  const timeoutByProcessId = new Map<string, ReturnType<typeof setTimeout>>()
+}): ReadonlyMap<string, LocalSyncFeedbackExpiryHandle> {
+  const expiryByProcessId = new Map<string, LocalSyncFeedbackExpiryHandle>()
 
   for (const processId of command.processIds) {
-    const timeoutId = setTimeout(() => {
-      command.onExpire(processId)
-    }, command.ttlMs)
-    timeoutByProcessId.set(processId, timeoutId)
+    expiryByProcessId.set(
+      processId,
+      createLocalSyncFeedbackExpiryHandle({
+        ttlMs: command.ttlMs,
+        onExpire: () => {
+          command.onExpire(processId)
+        },
+      }),
+    )
   }
 
-  return timeoutByProcessId
+  return expiryByProcessId
+}
+
+export function schedulePerProcessVisibleLocalSyncExpiry(command: {
+  readonly processIds: readonly string[]
+  readonly ttlMs: number
+  readonly onExpire: (processId: string) => void
+  readonly environment?: LocalSyncFeedbackEnvironment
+}): ReadonlyMap<string, LocalSyncFeedbackExpiryHandle> {
+  const expiryByProcessId = new Map<string, LocalSyncFeedbackExpiryHandle>()
+
+  for (const processId of command.processIds) {
+    const expiryCommand =
+      command.environment === undefined
+        ? {
+            ttlMs: command.ttlMs,
+            onExpire: () => {
+              command.onExpire(processId)
+            },
+          }
+        : {
+            ttlMs: command.ttlMs,
+            onExpire: () => {
+              command.onExpire(processId)
+            },
+            environment: command.environment,
+          }
+
+    expiryByProcessId.set(
+      processId,
+      createVisibleLocalSyncFeedbackExpiryHandle(expiryCommand),
+    )
+  }
+
+  return expiryByProcessId
 }
 
 function withProcessLocalSyncState(
@@ -97,6 +301,22 @@ function withoutProcessLocalSyncState(
   return nextState
 }
 
+function withoutManyProcessLocalSyncStates(
+  currentState: LocalSyncStateByProcessId,
+  processIds: readonly string[],
+): LocalSyncStateByProcessId {
+  let hasChanges = false
+  const nextState: Record<string, DashboardLocalSyncStatus> = { ...currentState }
+
+  for (const processId of processIds) {
+    if (!(processId in nextState)) continue
+    delete nextState[processId]
+    hasChanges = true
+  }
+
+  return hasChanges ? nextState : currentState
+}
+
 function toDashboardLocalSyncStateFromSnapshot(
   syncStatus: 'idle' | 'syncing' | 'completed' | 'failed',
 ): DashboardLocalSyncStatus | null {
@@ -112,7 +332,7 @@ function applyLocalSyncStateFromServerSnapshot(command: {
   readonly setLocalSyncState: (
     processId: string,
     syncStatus: DashboardLocalSyncStatus,
-    options?: { readonly ttlMs?: number },
+    options?: { readonly ttlMs?: number; readonly pauseWhenHidden?: boolean },
   ) => void
   readonly clearLocalSyncState: (processId: string) => void
 }): void {
@@ -134,28 +354,43 @@ function applyLocalSyncStateFromServerSnapshot(command: {
       continue
     }
 
-    command.setLocalSyncState(processId, localSyncStatus, {
-      ttlMs: LOCAL_SYNC_FEEDBACK_TTL_MS,
-    })
+    command.setLocalSyncState(
+      processId,
+      localSyncStatus,
+      localSyncStatus === 'success'
+        ? {
+            ttlMs: LOCAL_SYNC_SUCCESS_VISIBLE_TTL_MS,
+            pauseWhenHidden: true,
+          }
+        : {
+            ttlMs: LOCAL_SYNC_ERROR_FEEDBACK_TTL_MS,
+          },
+    )
   }
 }
 
 export function useDashboardSyncController(
   command: UseDashboardSyncControllerCommand,
 ): DashboardSyncControllerResult {
+  const { t, keys } = useTranslation()
   const [localSyncStateByProcessId, setLocalSyncStateByProcessId] =
     createSignal<LocalSyncStateByProcessId>({})
+  const [syncIssueByProcessId, setSyncIssueByProcessId] = createSignal<SyncIssueByProcessId>({})
+  const [dashboardSyncBatchResultState, setDashboardSyncBatchResultState] =
+    createSignal<DashboardSyncBatchResultVM | null>(null)
+  const [isDashboardSyncBatchResultDismissed, setIsDashboardSyncBatchResultDismissed] =
+    createSignal(false)
 
-  const localSyncFeedbackTimeoutByProcessId = new Map<string, ReturnType<typeof setTimeout>>()
+  const localSyncFeedbackExpiryByProcessId = new Map<string, LocalSyncFeedbackExpiryHandle>()
   let realtimeReconciliationTimeoutId: ReturnType<typeof setTimeout> | null = null
   let realtimeReconciliationInFlight = false
   let pendingRealtimeReconciliation = false
 
   const clearLocalSyncFeedbackTimer = (processId: string): void => {
-    const timeoutId = localSyncFeedbackTimeoutByProcessId.get(processId)
-    if (timeoutId === undefined) return
-    clearTimeout(timeoutId)
-    localSyncFeedbackTimeoutByProcessId.delete(processId)
+    const expiryHandle = localSyncFeedbackExpiryByProcessId.get(processId)
+    if (expiryHandle === undefined) return
+    expiryHandle.dispose()
+    localSyncFeedbackExpiryByProcessId.delete(processId)
   }
 
   const clearLocalSyncState = (processId: string): void => {
@@ -163,10 +398,20 @@ export function useDashboardSyncController(
     setLocalSyncStateByProcessId((previous) => withoutProcessLocalSyncState(previous, processId))
   }
 
+  const clearLocalSyncStates = (processIds: readonly string[]): void => {
+    for (const processId of processIds) {
+      clearLocalSyncFeedbackTimer(processId)
+    }
+
+    setLocalSyncStateByProcessId((previous) =>
+      withoutManyProcessLocalSyncStates(previous, processIds),
+    )
+  }
+
   const setLocalSyncState = (
     processId: string,
     syncStatus: DashboardLocalSyncStatus,
-    options?: { readonly ttlMs?: number },
+    options?: { readonly ttlMs?: number; readonly pauseWhenHidden?: boolean },
   ): void => {
     clearLocalSyncFeedbackTimer(processId)
     setLocalSyncStateByProcessId((previous) =>
@@ -175,16 +420,26 @@ export function useDashboardSyncController(
 
     if (options?.ttlMs === undefined) return
 
-    const timeoutId = setTimeout(() => {
-      clearLocalSyncState(processId)
-    }, options.ttlMs)
-    localSyncFeedbackTimeoutByProcessId.set(processId, timeoutId)
+    const expiryHandle = options.pauseWhenHidden
+      ? createVisibleLocalSyncFeedbackExpiryHandle({
+          ttlMs: options.ttlMs,
+          onExpire: () => {
+            clearLocalSyncState(processId)
+          },
+        })
+      : createLocalSyncFeedbackExpiryHandle({
+          ttlMs: options.ttlMs,
+          onExpire: () => {
+            clearLocalSyncState(processId)
+          },
+        })
+    localSyncFeedbackExpiryByProcessId.set(processId, expiryHandle)
   }
 
   const setLocalSyncStates = (
     processIds: readonly string[],
     syncStatus: DashboardLocalSyncStatus,
-    options?: { readonly ttlMs?: number },
+    options?: { readonly ttlMs?: number; readonly pauseWhenHidden?: boolean },
   ): void => {
     if (processIds.length === 0) return
 
@@ -198,16 +453,24 @@ export function useDashboardSyncController(
 
     if (options?.ttlMs === undefined) return
 
-    const timeoutByProcessId = schedulePerProcessLocalSyncExpiry({
-      processIds,
-      ttlMs: options.ttlMs,
-      onExpire: (processId) => {
-        clearLocalSyncState(processId)
-      },
-    })
+    const expiryByProcessId = options.pauseWhenHidden
+      ? schedulePerProcessVisibleLocalSyncExpiry({
+          processIds,
+          ttlMs: options.ttlMs,
+          onExpire: (processId) => {
+            clearLocalSyncState(processId)
+          },
+        })
+      : schedulePerProcessLocalSyncExpiry({
+          processIds,
+          ttlMs: options.ttlMs,
+          onExpire: (processId) => {
+            clearLocalSyncState(processId)
+          },
+        })
 
-    for (const [processId, timeoutId] of timeoutByProcessId.entries()) {
-      localSyncFeedbackTimeoutByProcessId.set(processId, timeoutId)
+    for (const [processId, expiryHandle] of expiryByProcessId.entries()) {
+      localSyncFeedbackExpiryByProcessId.set(processId, expiryHandle)
     }
   }
 
@@ -260,10 +523,10 @@ export function useDashboardSyncController(
 
   onCleanup(() => {
     clearRealtimeReconciliationTimer()
-    for (const timeoutId of localSyncFeedbackTimeoutByProcessId.values()) {
-      clearTimeout(timeoutId)
+    for (const expiryHandle of localSyncFeedbackExpiryByProcessId.values()) {
+      expiryHandle.dispose()
     }
-    localSyncFeedbackTimeoutByProcessId.clear()
+    localSyncFeedbackExpiryByProcessId.clear()
   })
 
   const realtimeSyncStateByProcessId = useProcessSyncRealtime({
@@ -274,6 +537,7 @@ export function useDashboardSyncController(
   const processesWithSyncFeedback = createMemo(() => {
     const realtimeStateByProcessId = realtimeSyncStateByProcessId()
     const localStateByProcessId = localSyncStateByProcessId()
+    const issuesByProcessId = syncIssueByProcessId()
 
     return command.sortedProcesses().map((process) => {
       const resolvedSyncState = resolveDashboardProcessSyncStatus({
@@ -281,22 +545,34 @@ export function useDashboardSyncController(
         realtimeState: realtimeStateByProcessId[process.id] === 'syncing' ? 'syncing' : null,
         localState: localStateByProcessId[process.id] ?? null,
       })
-
-      if (resolvedSyncState === process.syncStatus) return process
+      const syncIssue = issuesByProcessId[process.id] ?? null
 
       return {
         ...process,
         syncStatus: resolvedSyncState,
+        syncIssue,
       }
     })
   })
+
+  const dashboardSyncBatchResult = createMemo(() => {
+    if (isDashboardSyncBatchResultDismissed()) {
+      return null
+    }
+
+    return dashboardSyncBatchResultState()
+  })
+
+  const dismissDashboardSyncBatchResult = (): void => {
+    setIsDashboardSyncBatchResultDismissed(true)
+  }
 
   const handleDashboardRefresh = async () => {
     const currentProcessIds = command.allProcesses().map((process) => process.id)
     setLocalSyncStates(currentProcessIds, 'syncing')
 
     try {
-      await refreshDashboardData({
+      const result = await refreshDashboardData({
         syncAllProcesses: syncAllProcessesRequest,
         refetchProcesses: command.refetchProcesses,
         refetchGlobalAlerts: command.refetchGlobalAlerts,
@@ -304,12 +580,32 @@ export function useDashboardSyncController(
         refetchDashboardProcessesCreatedByMonth: command.refetchDashboardProcessesCreatedByMonth,
       })
 
-      setLocalSyncStates(currentProcessIds, 'success', {
-        ttlMs: LOCAL_SYNC_FEEDBACK_TTL_MS,
+      const batchResultVm = toDashboardSyncBatchResultVm({
+        source: result,
+        t,
+        keys,
+      })
+
+      setSyncIssueByProcessId(batchResultVm.issueByProcessId)
+      setDashboardSyncBatchResultState(batchResultVm)
+      setIsDashboardSyncBatchResultDismissed(false)
+      clearLocalSyncStates(currentProcessIds)
+
+      const failedProcessIds = new Set(batchResultVm.failedProcessIds)
+      const successProcessIds = batchResultVm.enqueuedProcessIds.filter(
+        (processId) => !failedProcessIds.has(processId),
+      )
+
+      setLocalSyncStates(batchResultVm.failedProcessIds, 'error', {
+        ttlMs: LOCAL_SYNC_ERROR_FEEDBACK_TTL_MS,
+      })
+      setLocalSyncStates(successProcessIds, 'success', {
+        ttlMs: LOCAL_SYNC_SUCCESS_VISIBLE_TTL_MS,
+        pauseWhenHidden: true,
       })
     } catch (error) {
       setLocalSyncStates(currentProcessIds, 'error', {
-        ttlMs: LOCAL_SYNC_FEEDBACK_TTL_MS,
+        ttlMs: LOCAL_SYNC_ERROR_FEEDBACK_TTL_MS,
       })
       throw error
     }
@@ -325,7 +621,8 @@ export function useDashboardSyncController(
       await syncProcessRequest(processId)
       await Promise.resolve(command.refetchProcesses())
       setLocalSyncState(processId, 'success', {
-        ttlMs: LOCAL_SYNC_FEEDBACK_TTL_MS,
+        ttlMs: LOCAL_SYNC_SUCCESS_VISIBLE_TTL_MS,
+        pauseWhenHidden: true,
       })
     } catch (error) {
       console.error(`Dashboard process sync failed for ${processId}:`, error)
@@ -336,13 +633,15 @@ export function useDashboardSyncController(
         )
       })
       setLocalSyncState(processId, 'error', {
-        ttlMs: LOCAL_SYNC_FEEDBACK_TTL_MS,
+        ttlMs: LOCAL_SYNC_ERROR_FEEDBACK_TTL_MS,
       })
     }
   }
 
   return {
     processesWithSyncFeedback,
+    dashboardSyncBatchResult,
+    dismissDashboardSyncBatchResult,
     handleDashboardRefresh,
     handleProcessSync,
   }

--- a/src/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController.ts
+++ b/src/modules/process/ui/screens/dashboard/hooks/useDashboardSyncController.ts
@@ -5,8 +5,15 @@ import {
   syncAllProcessesRequest,
   syncProcessRequest,
 } from '~/modules/process/ui/api/processSync.api'
-import { toDashboardSyncBatchResultVm } from '~/modules/process/ui/mappers/dashboard-sync-batch-result.ui-mapper'
 import { useProcessSyncRealtime } from '~/modules/process/ui/hooks/useProcessSyncRealtime'
+import { toDashboardSyncBatchResultVm } from '~/modules/process/ui/mappers/dashboard-sync-batch-result.ui-mapper'
+import {
+  createLocalSyncFeedbackExpiryHandle,
+  createVisibleLocalSyncFeedbackExpiryHandle,
+  type LocalSyncFeedbackExpiryHandle,
+  schedulePerProcessLocalSyncExpiry,
+  schedulePerProcessVisibleLocalSyncExpiry,
+} from '~/modules/process/ui/screens/dashboard/hooks/dashboard-sync-feedback-expiry'
 import { refreshDashboardData } from '~/modules/process/ui/utils/dashboard-refresh'
 import {
   type DashboardLocalSyncStatus,
@@ -26,16 +33,6 @@ const REALTIME_RECONCILIATION_DEBOUNCE_MS = 250
 
 type LocalSyncStateByProcessId = Readonly<Record<string, DashboardLocalSyncStatus>>
 type SyncIssueByProcessId = Readonly<Record<string, DashboardProcessSyncIssueVM>>
-type LocalSyncFeedbackDocument = Pick<
-  Document,
-  'addEventListener' | 'removeEventListener' | 'visibilityState'
->
-type LocalSyncFeedbackEnvironment = {
-  readonly document?: LocalSyncFeedbackDocument | undefined
-}
-type LocalSyncFeedbackExpiryHandle = {
-  readonly dispose: () => void
-}
 
 type UseDashboardSyncControllerCommand = {
   readonly allProcesses: Accessor<readonly ProcessSummaryVM[]>
@@ -55,206 +52,6 @@ type DashboardSyncControllerResult = {
 }
 
 type ProcessesSyncSnapshot = Awaited<ReturnType<typeof fetchProcessesSyncStatus>>
-
-function resolveLocalSyncFeedbackDocument(
-  environment?: LocalSyncFeedbackEnvironment,
-): LocalSyncFeedbackDocument | undefined {
-  if (environment?.document) {
-    return environment.document
-  }
-
-  if (typeof document === 'undefined') {
-    return undefined
-  }
-
-  return document
-}
-
-function isLocalSyncFeedbackDocumentVisible(
-  currentDocument: LocalSyncFeedbackDocument | undefined,
-): boolean {
-  if (!currentDocument) {
-    return true
-  }
-
-  return currentDocument.visibilityState === 'visible'
-}
-
-function createLocalSyncFeedbackExpiryHandle(command: {
-  readonly ttlMs: number
-  readonly onExpire: () => void
-}): LocalSyncFeedbackExpiryHandle {
-  const timeoutId = setTimeout(() => {
-    command.onExpire()
-  }, command.ttlMs)
-
-  return {
-    dispose: () => {
-      clearTimeout(timeoutId)
-    },
-  }
-}
-
-function createVisibleLocalSyncFeedbackExpiryHandle(command: {
-  readonly ttlMs: number
-  readonly onExpire: () => void
-  readonly environment?: LocalSyncFeedbackEnvironment
-}): LocalSyncFeedbackExpiryHandle {
-  const currentDocument = resolveLocalSyncFeedbackDocument(command.environment)
-  if (!currentDocument) {
-    return createLocalSyncFeedbackExpiryHandle({
-      ttlMs: command.ttlMs,
-      onExpire: command.onExpire,
-    })
-  }
-
-  let remainingMs = command.ttlMs
-  let countdownStartedAtMs: number | null = null
-  let timeoutId: ReturnType<typeof setTimeout> | null = null
-  let disposed = false
-
-  const clearCountdown = (): void => {
-    if (timeoutId === null) {
-      return
-    }
-
-    clearTimeout(timeoutId)
-    timeoutId = null
-  }
-
-  const stopVisibleCountdown = (): void => {
-    if (countdownStartedAtMs === null) {
-      clearCountdown()
-      return
-    }
-
-    const elapsedMs = Date.now() - countdownStartedAtMs
-    remainingMs = Math.max(0, remainingMs - elapsedMs)
-    countdownStartedAtMs = null
-    clearCountdown()
-  }
-
-  const cleanup = (): void => {
-    currentDocument.removeEventListener('visibilitychange', handleVisibilityChange)
-    clearCountdown()
-    countdownStartedAtMs = null
-  }
-
-  const expire = (): void => {
-    if (disposed) {
-      return
-    }
-
-    disposed = true
-    cleanup()
-    command.onExpire()
-  }
-
-  const startVisibleCountdown = (): void => {
-    if (disposed || countdownStartedAtMs !== null) {
-      return
-    }
-
-    if (!isLocalSyncFeedbackDocumentVisible(currentDocument)) {
-      return
-    }
-
-    if (remainingMs <= 0) {
-      expire()
-      return
-    }
-
-    countdownStartedAtMs = Date.now()
-    timeoutId = setTimeout(() => {
-      remainingMs = 0
-      countdownStartedAtMs = null
-      expire()
-    }, remainingMs)
-  }
-
-  function handleVisibilityChange(): void {
-    if (disposed) {
-      return
-    }
-
-    if (isLocalSyncFeedbackDocumentVisible(currentDocument)) {
-      startVisibleCountdown()
-      return
-    }
-
-    stopVisibleCountdown()
-  }
-
-  currentDocument.addEventListener('visibilitychange', handleVisibilityChange)
-  startVisibleCountdown()
-
-  return {
-    dispose: () => {
-      if (disposed) {
-        return
-      }
-
-      disposed = true
-      cleanup()
-    },
-  }
-}
-
-export function schedulePerProcessLocalSyncExpiry(command: {
-  readonly processIds: readonly string[]
-  readonly ttlMs: number
-  readonly onExpire: (processId: string) => void
-}): ReadonlyMap<string, LocalSyncFeedbackExpiryHandle> {
-  const expiryByProcessId = new Map<string, LocalSyncFeedbackExpiryHandle>()
-
-  for (const processId of command.processIds) {
-    expiryByProcessId.set(
-      processId,
-      createLocalSyncFeedbackExpiryHandle({
-        ttlMs: command.ttlMs,
-        onExpire: () => {
-          command.onExpire(processId)
-        },
-      }),
-    )
-  }
-
-  return expiryByProcessId
-}
-
-export function schedulePerProcessVisibleLocalSyncExpiry(command: {
-  readonly processIds: readonly string[]
-  readonly ttlMs: number
-  readonly onExpire: (processId: string) => void
-  readonly environment?: LocalSyncFeedbackEnvironment
-}): ReadonlyMap<string, LocalSyncFeedbackExpiryHandle> {
-  const expiryByProcessId = new Map<string, LocalSyncFeedbackExpiryHandle>()
-
-  for (const processId of command.processIds) {
-    const expiryCommand =
-      command.environment === undefined
-        ? {
-            ttlMs: command.ttlMs,
-            onExpire: () => {
-              command.onExpire(processId)
-            },
-          }
-        : {
-            ttlMs: command.ttlMs,
-            onExpire: () => {
-              command.onExpire(processId)
-            },
-            environment: command.environment,
-          }
-
-    expiryByProcessId.set(
-      processId,
-      createVisibleLocalSyncFeedbackExpiryHandle(expiryCommand),
-    )
-  }
-
-  return expiryByProcessId
-}
 
 function withProcessLocalSyncState(
   currentState: LocalSyncStateByProcessId,
@@ -369,6 +166,7 @@ function applyLocalSyncStateFromServerSnapshot(command: {
   }
 }
 
+// eslint-disable-next-line max-lines-per-function
 export function useDashboardSyncController(
   command: UseDashboardSyncControllerCommand,
 ): DashboardSyncControllerResult {

--- a/src/modules/process/ui/utils/dashboard-refresh.ts
+++ b/src/modules/process/ui/utils/dashboard-refresh.ts
@@ -1,5 +1,5 @@
-type DashboardRefreshCommand = {
-  readonly syncAllProcesses: () => unknown
+type DashboardRefreshCommand<TSyncResult> = {
+  readonly syncAllProcesses: () => TSyncResult | Promise<TSyncResult>
   readonly refetchProcesses: () => unknown
   readonly refetchGlobalAlerts: () => unknown
   readonly refetchDashboardKpis?: () => unknown
@@ -15,8 +15,10 @@ function toFirstRejectedReason(results: readonly PromiseSettledResult<unknown>[]
   return null
 }
 
-export async function refreshDashboardData(command: DashboardRefreshCommand): Promise<void> {
-  await Promise.resolve(command.syncAllProcesses())
+export async function refreshDashboardData<TSyncResult>(
+  command: DashboardRefreshCommand<TSyncResult>,
+): Promise<TSyncResult> {
+  const syncResult = await Promise.resolve(command.syncAllProcesses())
 
   const refetchTasks: Promise<unknown>[] = [
     Promise.resolve(command.refetchProcesses()),
@@ -35,7 +37,7 @@ export async function refreshDashboardData(command: DashboardRefreshCommand): Pr
 
   const hasFailure = results.some((result) => result.status === 'rejected')
   if (!hasFailure) {
-    return
+    return syncResult
   }
 
   const firstRejectedReason = toFirstRejectedReason(results)

--- a/src/modules/process/ui/utils/tests/dashboard-refresh.test.ts
+++ b/src/modules/process/ui/utils/tests/dashboard-refresh.test.ts
@@ -6,7 +6,7 @@ describe('refreshDashboardData', () => {
     const sequence: string[] = []
     const syncAllProcesses = vi.fn(async () => {
       sequence.push('sync')
-      return { ok: true }
+      return { ok: true, httpStatus: 200 }
     })
     const refetchProcesses = vi.fn(async () => [])
     const refetchGlobalAlerts = vi.fn(async () => {
@@ -25,7 +25,7 @@ describe('refreshDashboardData', () => {
         refetchProcesses,
         refetchGlobalAlerts,
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ ok: true, httpStatus: 200 })
 
     expect(syncAllProcesses).toHaveBeenCalledTimes(1)
     expect(refetchProcesses).toHaveBeenCalledTimes(1)

--- a/src/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm.ts
+++ b/src/modules/process/ui/viewmodels/dashboard-sync-batch-result.vm.ts
@@ -1,0 +1,68 @@
+import type {
+  SyncAllProcessesBusinessErrorResponse,
+  SyncAllProcessesRequestResult,
+  SyncAllProcessesSuccessResponse,
+} from '~/modules/process/ui/api/processSync.api'
+import type { ProcessSummaryVM } from '~/modules/process/ui/viewmodels/process-summary.vm'
+
+type SyncAllProcessesPayload =
+  | SyncAllProcessesSuccessResponse
+  | SyncAllProcessesBusinessErrorResponse
+
+export type DashboardSyncBatchReasonCode =
+  | SyncAllProcessesPayload['skippedTargets'][number]['reasonCode']
+  | SyncAllProcessesPayload['failedTargets'][number]['reasonCode']
+
+export type DashboardSyncBatchIssueSeverity = 'warning' | 'danger'
+
+export type DashboardSyncBatchEnqueuedTargetVM = {
+  readonly processId: string
+  readonly processReference: string | null
+  readonly processLabel: string
+  readonly containerNumber: string
+  readonly provider: string
+  readonly providerLabel: string
+  readonly syncRequestId: string
+}
+
+export type DashboardSyncBatchProblemTargetVM = {
+  readonly processId: string
+  readonly processReference: string | null
+  readonly processLabel: string
+  readonly containerNumber: string
+  readonly provider: string
+  readonly providerLabel: string
+  readonly reasonCode: DashboardSyncBatchReasonCode
+  readonly reasonLabel: string
+  readonly reasonMessage: string
+}
+
+export type DashboardProcessSyncIssueVM = {
+  readonly severity: DashboardSyncBatchIssueSeverity
+  readonly tooltip: string
+  readonly failedCount: number
+  readonly skippedCount: number
+}
+
+export type DashboardSyncBatchResultVM = {
+  readonly httpStatus: SyncAllProcessesRequestResult['httpStatus']
+  readonly tone: 'success' | 'warning' | 'danger'
+  readonly isBusinessError: boolean
+  readonly summary: {
+    readonly requestedProcesses: number
+    readonly requestedContainers: number
+    readonly enqueued: number
+    readonly skipped: number
+    readonly failed: number
+  }
+  readonly enqueuedTargets: readonly DashboardSyncBatchEnqueuedTargetVM[]
+  readonly skippedTargets: readonly DashboardSyncBatchProblemTargetVM[]
+  readonly failedTargets: readonly DashboardSyncBatchProblemTargetVM[]
+  readonly issueByProcessId: Readonly<Record<string, DashboardProcessSyncIssueVM>>
+  readonly failedProcessIds: readonly string[]
+  readonly enqueuedProcessIds: readonly string[]
+}
+
+export type DashboardProcessRowVM = ProcessSummaryVM & {
+  readonly syncIssue: DashboardProcessSyncIssueVM | null
+}

--- a/src/routes/dev/tracking-scenarios.tsx
+++ b/src/routes/dev/tracking-scenarios.tsx
@@ -311,7 +311,12 @@ function DashboardPreview(props: {
   const rows = createMemo(() => {
     const row = props.row
     if (!row) return []
-    return [row]
+    return [
+      {
+        ...row,
+        syncIssue: null,
+      },
+    ]
   })
 
   return (

--- a/src/shared/api-schemas/processes.schemas.ts
+++ b/src/shared/api-schemas/processes.schemas.ts
@@ -502,11 +502,110 @@ export const CreateProcessResponseSchema = z.object({
   warnings: z.array(z.string()).readonly(),
 })
 
-export const SyncAllProcessesResponseSchema = z.object({
-  ok: z.literal(true),
-  syncedProcesses: z.number().int().nonnegative(),
-  syncedContainers: z.number().int().nonnegative(),
+const SyncAllProcessesSkippedReasonCodeSchema = z.enum([
+  'UNSUPPORTED_PROVIDER',
+  'DUPLICATE_OPEN_REQUEST',
+  'MISSING_REQUIRED_DATA',
+  'INELIGIBLE_TARGET',
+])
+
+const SyncAllProcessesFailedReasonCodeSchema = z.enum([
+  'ENQUEUE_FAILED',
+  'INFRASTRUCTURE_ERROR',
+  'UNEXPECTED_ERROR',
+])
+
+const SyncAllProcessesTargetBaseSchema = z.object({
+  processId: z.string(),
+  processReference: z.string().nullable(),
+  containerNumber: z.string(),
+  provider: z.string(),
 })
+
+const SyncAllProcessesEnqueuedTargetResponseSchema = SyncAllProcessesTargetBaseSchema.extend({
+  syncRequestId: z.string(),
+})
+
+const SyncAllProcessesSkippedTargetResponseSchema = SyncAllProcessesTargetBaseSchema.extend({
+  reasonCode: SyncAllProcessesSkippedReasonCodeSchema,
+  reasonMessage: z.string(),
+})
+
+const SyncAllProcessesFailedTargetResponseSchema = SyncAllProcessesTargetBaseSchema.extend({
+  reasonCode: SyncAllProcessesFailedReasonCodeSchema,
+  reasonMessage: z.string(),
+})
+
+const SyncAllProcessesBatchSummaryResponseSchema = z
+  .object({
+    requestedProcesses: z.number().int().nonnegative(),
+    requestedContainers: z.number().int().nonnegative(),
+    enqueued: z.number().int().nonnegative(),
+    skipped: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.requestedContainers !== value.enqueued + value.skipped + value.failed) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['requestedContainers'],
+        message: 'requestedContainers must equal enqueued + skipped + failed',
+      })
+    }
+  })
+
+function validateSyncAllProcessesBatchResponse(
+  value: {
+    readonly summary: z.infer<typeof SyncAllProcessesBatchSummaryResponseSchema>
+    readonly enqueuedTargets: readonly unknown[]
+    readonly skippedTargets: readonly unknown[]
+    readonly failedTargets: readonly unknown[]
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (value.summary.enqueued !== value.enqueuedTargets.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['enqueuedTargets'],
+      message: 'enqueuedTargets length must match summary.enqueued',
+    })
+  }
+
+  if (value.summary.skipped !== value.skippedTargets.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['skippedTargets'],
+      message: 'skippedTargets length must match summary.skipped',
+    })
+  }
+
+  if (value.summary.failed !== value.failedTargets.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['failedTargets'],
+      message: 'failedTargets length must match summary.failed',
+    })
+  }
+}
+
+const SyncAllProcessesBatchResponseSchema = z
+  .object({
+    summary: SyncAllProcessesBatchSummaryResponseSchema,
+    enqueuedTargets: z.array(SyncAllProcessesEnqueuedTargetResponseSchema),
+    skippedTargets: z.array(SyncAllProcessesSkippedTargetResponseSchema),
+    failedTargets: z.array(SyncAllProcessesFailedTargetResponseSchema),
+  })
+  .superRefine(validateSyncAllProcessesBatchResponse)
+
+export const SyncAllProcessesSuccessResponseSchema = SyncAllProcessesBatchResponseSchema.extend({
+  ok: z.literal(true),
+})
+
+export const SyncAllProcessesBusinessErrorResponseSchema =
+  SyncAllProcessesBatchResponseSchema.extend({
+    ok: z.literal(false),
+    error: z.string(),
+  })
 
 export const SyncProcessResponseSchema = z.object({
   ok: z.literal(true),

--- a/src/shared/api-schemas/tests/processes.schemas.test.ts
+++ b/src/shared/api-schemas/tests/processes.schemas.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { TrackingPredictionHistoryResponseSchema } from '~/shared/api-schemas/processes.schemas'
+import {
+  SyncAllProcessesSuccessResponseSchema,
+  TrackingPredictionHistoryResponseSchema,
+} from '~/shared/api-schemas/processes.schemas'
 
 function expectObservedAtListIssue(result: {
   readonly success: boolean
@@ -86,5 +89,60 @@ describe('TrackingPredictionHistoryResponseSchema', () => {
     })
 
     expectObservedAtListIssue(result)
+  })
+})
+
+describe('SyncAllProcessesSuccessResponseSchema', () => {
+  it('rejects mismatched requestedContainers counts', () => {
+    const result = SyncAllProcessesSuccessResponseSchema.safeParse({
+      ok: true,
+      summary: {
+        requestedProcesses: 1,
+        requestedContainers: 3,
+        enqueued: 1,
+        skipped: 1,
+        failed: 0,
+      },
+      enqueuedTargets: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-1',
+          containerNumber: 'MSCU1234567',
+          provider: 'msc',
+          syncRequestId: 'sync-1',
+        },
+      ],
+      skippedTargets: [
+        {
+          processId: 'process-1',
+          processReference: 'REF-1',
+          containerNumber: 'MRKU7654321',
+          provider: 'maersk',
+          reasonCode: 'DUPLICATE_OPEN_REQUEST',
+          reasonMessage: 'Target already has an open sync request or was already included in this batch.',
+        },
+      ],
+      failedTargets: [],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects summary counts that do not match target array lengths', () => {
+    const result = SyncAllProcessesSuccessResponseSchema.safeParse({
+      ok: true,
+      summary: {
+        requestedProcesses: 1,
+        requestedContainers: 1,
+        enqueued: 0,
+        skipped: 0,
+        failed: 1,
+      },
+      enqueuedTargets: [],
+      skippedTargets: [],
+      failedTargets: [],
+    })
+
+    expect(result.success).toBe(false)
   })
 })

--- a/src/shared/api-schemas/tests/processes.schemas.test.ts
+++ b/src/shared/api-schemas/tests/processes.schemas.test.ts
@@ -119,7 +119,8 @@ describe('SyncAllProcessesSuccessResponseSchema', () => {
           containerNumber: 'MRKU7654321',
           provider: 'maersk',
           reasonCode: 'DUPLICATE_OPEN_REQUEST',
-          reasonMessage: 'Target already has an open sync request or was already included in this batch.',
+          reasonMessage:
+            'Target already has an open sync request or was already included in this batch.',
         },
       ],
       failedTargets: [],

--- a/src/shared/api/sync.bootstrap/sync.bootstrap.ports.ts
+++ b/src/shared/api/sync.bootstrap/sync.bootstrap.ports.ts
@@ -102,6 +102,25 @@ function getRecentArchivedProcessCutoff(now: Date): string {
 }
 
 export function createSyncTargetReadPort(deps: CreateSyncPortsDeps): SyncTargetReadPort {
+  const listActiveProcessesForDashboardSync = async () => {
+    const result = await supabaseServer
+      .from('processes')
+      .select('id,reference')
+      .is('archived_at', null)
+      .is('deleted_at', null)
+
+    const data = unwrapSupabaseResultOrThrow(result, {
+      operation: 'list_active_processes_for_dashboard_sync',
+      table: 'processes',
+    })
+
+    const rows = ActiveProcessForDashboardSyncRowsSchema.parse(data)
+    return rows.map((row) => ({
+      processId: row.id,
+      processReference: row.reference,
+    }))
+  }
+
   return {
     async fetchProcessById(command) {
       const result = await deps.processUseCases.findProcessById({
@@ -116,26 +135,11 @@ export function createSyncTargetReadPort(deps: CreateSyncPortsDeps): SyncTargetR
     },
 
     async listActiveProcessesForDashboardSync() {
-      const result = await supabaseServer
-        .from('processes')
-        .select('id,reference')
-        .is('archived_at', null)
-        .is('deleted_at', null)
-
-      const data = unwrapSupabaseResultOrThrow(result, {
-        operation: 'list_active_processes_for_dashboard_sync',
-        table: 'processes',
-      })
-
-      const rows = ActiveProcessForDashboardSyncRowsSchema.parse(data)
-      return rows.map((row) => ({
-        processId: row.id,
-        processReference: row.reference,
-      }))
+      return listActiveProcessesForDashboardSync()
     },
 
     async listActiveProcessIds() {
-      const processes = await this.listActiveProcessesForDashboardSync()
+      const processes = await listActiveProcessesForDashboardSync()
       return processes.map((process) => process.processId)
     },
 

--- a/src/shared/api/sync.bootstrap/sync.bootstrap.ports.ts
+++ b/src/shared/api/sync.bootstrap/sync.bootstrap.ports.ts
@@ -46,11 +46,12 @@ type CreateSyncPortsDeps = {
   readonly containerUseCases: ContainerUseCasesDeps
 }
 
-const ActiveProcessIdRowSchema = z.object({
+const ActiveProcessForDashboardSyncRowSchema = z.object({
   id: z.string(),
+  reference: z.string().nullable(),
 })
 
-const ActiveProcessIdRowsSchema = z.array(ActiveProcessIdRowSchema)
+const ActiveProcessForDashboardSyncRowsSchema = z.array(ActiveProcessForDashboardSyncRowSchema)
 
 const ProcessSyncCandidateRowSchema = z.object({
   id: z.string(),
@@ -114,20 +115,28 @@ export function createSyncTargetReadPort(deps: CreateSyncPortsDeps): SyncTargetR
       }
     },
 
-    async listActiveProcessIds() {
+    async listActiveProcessesForDashboardSync() {
       const result = await supabaseServer
         .from('processes')
-        .select('id')
+        .select('id,reference')
         .is('archived_at', null)
         .is('deleted_at', null)
 
       const data = unwrapSupabaseResultOrThrow(result, {
-        operation: 'list_active_process_ids',
+        operation: 'list_active_processes_for_dashboard_sync',
         table: 'processes',
       })
 
-      const rows = ActiveProcessIdRowsSchema.parse(data)
-      return rows.map((row) => row.id)
+      const rows = ActiveProcessForDashboardSyncRowsSchema.parse(data)
+      return rows.map((row) => ({
+        processId: row.id,
+        processReference: row.reference,
+      }))
+    },
+
+    async listActiveProcessIds() {
+      const processes = await this.listActiveProcessesForDashboardSync()
+      return processes.map((process) => process.processId)
     },
 
     async listContainersByProcessId(command) {

--- a/src/shared/api/sync.bootstrap/tests/sync.bootstrap.ports.test.ts
+++ b/src/shared/api/sync.bootstrap/tests/sync.bootstrap.ports.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 type ProcessSyncCandidateRow = {
   readonly id: string
-  readonly archived_at: string | null
+  readonly archived_at?: string | null
+  readonly reference?: string | null
 }
 
 type QueryOperation = {
@@ -142,6 +143,7 @@ describe('createSyncStatusReadPort', () => {
     const port = createSyncStatusReadPort({
       targetReadPort: {
         fetchProcessById: vi.fn(),
+        listActiveProcessesForDashboardSync: vi.fn(),
         listActiveProcessIds: vi.fn(),
         listContainersByProcessId: vi.fn(),
         listContainersByProcessIds: vi.fn(),
@@ -173,6 +175,7 @@ describe('createSyncStatusReadPort', () => {
     const port = createSyncStatusReadPort({
       targetReadPort: {
         fetchProcessById: vi.fn(),
+        listActiveProcessesForDashboardSync: vi.fn(),
         listActiveProcessIds: vi.fn(),
         listContainersByProcessId: vi.fn(),
         listContainersByProcessIds: vi.fn(),
@@ -204,6 +207,7 @@ describe('createSyncStatusReadPort', () => {
     const port = createSyncStatusReadPort({
       targetReadPort: {
         fetchProcessById: vi.fn(),
+        listActiveProcessesForDashboardSync: vi.fn(),
         listActiveProcessIds: vi.fn(),
         listContainersByProcessId: vi.fn(),
         listContainersByProcessIds: vi.fn(),
@@ -318,6 +322,33 @@ describe('createSyncStatusReadPort', () => {
 })
 
 describe('createSyncTargetReadPort', () => {
+  it('lists active dashboard sync processes with process references', async () => {
+    supabaseMock.reset([
+      { id: 'process-1', reference: 'REF-001' },
+      { id: 'process-2', reference: null },
+    ])
+
+    const port = createSyncTargetReadPort({
+      processUseCases: {
+        findProcessById: vi.fn(),
+      },
+      containerUseCases: {
+        listByProcessId: vi.fn(),
+        listByProcessIds: vi.fn(async () => ({
+          containersByProcessId: new Map(),
+        })),
+        findByNumbers: vi.fn(),
+      },
+    })
+
+    const result = await port.listActiveProcessesForDashboardSync()
+
+    expect(result).toEqual([
+      { processId: 'process-1', processReference: 'REF-001' },
+      { processId: 'process-2', processReference: null },
+    ])
+  })
+
   it('maps container application results into sync target records without exposing entities', async () => {
     const port = createSyncTargetReadPort({
       processUseCases: {
@@ -370,6 +401,7 @@ describe('createRefreshProcessDeps', () => {
     const deps = createRefreshProcessDeps({
       targetReadPort: {
         fetchProcessById: vi.fn(),
+        listActiveProcessesForDashboardSync: vi.fn(),
         listActiveProcessIds: vi.fn(),
         listContainersByProcessId: vi.fn(),
         listContainersByProcessIds: vi.fn(),

--- a/src/shared/api/sync.bootstrap/tests/sync.bootstrap.ports.test.ts
+++ b/src/shared/api/sync.bootstrap/tests/sync.bootstrap.ports.test.ts
@@ -349,6 +349,29 @@ describe('createSyncTargetReadPort', () => {
     ])
   })
 
+  it('lists active process ids without depending on method binding', async () => {
+    supabaseMock.reset([
+      { id: 'process-1', reference: 'REF-001' },
+      { id: 'process-2', reference: null },
+    ])
+
+    const port = createSyncTargetReadPort({
+      processUseCases: {
+        findProcessById: vi.fn(),
+      },
+      containerUseCases: {
+        listByProcessId: vi.fn(),
+        listByProcessIds: vi.fn(async () => ({
+          containersByProcessId: new Map(),
+        })),
+        findByNumbers: vi.fn(),
+      },
+    })
+
+    const listActiveProcessIds = port.listActiveProcessIds
+    await expect(listActiveProcessIds()).resolves.toEqual(['process-1', 'process-2'])
+  })
+
   it('maps container application results into sync target records without exposing entities', async () => {
     const port = createSyncTargetReadPort({
       processUseCases: {


### PR DESCRIPTION
## Summary
- Split dashboard sync into target resolution and enqueue phases so eligible, skipped, and failed targets are tracked independently.
- Return a batch result with per-target outcomes and aggregate counts instead of failing the whole dashboard sync on partial issues.
- Reuse provider/container normalization across sync flows and update dashboard UI, API schemas, and presenter layers to surface partial results.
- Add coverage for the new dashboard sync services, use case behavior, controller responses, API schema, and UI components.

## Testing
- Ran/updated unit tests for dashboard sync target resolution and enqueue classification.
- Ran/updated use case tests covering successful sync, partial enqueue outcomes, and terminal failures.
- Ran/updated controller and API schema tests for the new batch response shape.
- Ran/updated UI tests for dashboard batch result rendering and sync cell behavior.
- Not run: full repository test suite and manual browser validation in this turn.