### PR TITLE
Fix CMA-CGM temporal normalization for local-port events

### DIFF
--- a/apps/agent/src/providers/cmacgm/run-cmacgm-sync.ts
+++ b/apps/agent/src/providers/cmacgm/run-cmacgm-sync.ts
@@ -21,19 +21,54 @@ function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function toPayloadShapeError(payload: unknown): string | null {
+function hasNonEmptyText(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function assessPayload(payload: unknown): {
+  readonly parseError: string | null
+  readonly warnings: readonly string[]
+} {
   const parseResult = CmaCgmApiSchema.safeParse(payload)
-  if (parseResult.success) {
-    return null
+  if (!parseResult.success) {
+    const firstIssue = parseResult.error.issues[0]
+    if (firstIssue === undefined) {
+      return {
+        parseError: 'CMA-CGM payload does not match expected snapshot shape',
+        warnings: [],
+      }
+    }
+
+    const path = firstIssue.path.length > 0 ? firstIssue.path.join('.') : 'payload'
+    return {
+      parseError: `CMA-CGM payload invalid at ${path}: ${firstIssue.message}`,
+      warnings: [],
+    }
   }
 
-  const firstIssue = parseResult.error.issues[0]
-  if (firstIssue === undefined) {
-    return 'CMA-CGM payload does not match expected snapshot shape'
+  const allMoves = [
+    ...(parseResult.data.PastMoves ?? []),
+    ...(parseResult.data.CurrentMoves ?? []),
+    ...(parseResult.data.ProvisionalMoves ?? []),
+  ]
+
+  const hasSemanticMove = allMoves.some(
+    (move) =>
+      hasNonEmptyText(move.StatusDescription) &&
+      (hasNonEmptyText(move.Date) || hasNonEmptyText(move.DateString)),
+  )
+
+  if (!hasSemanticMove) {
+    return {
+      parseError: null,
+      warnings: ['CMA-CGM payload accepted with low confidence: moves missing status/date'],
+    }
   }
 
-  const path = firstIssue.path.length > 0 ? firstIssue.path.join('.') : 'payload'
-  return `CMA-CGM payload invalid at ${path}: ${firstIssue.message}`
+  return {
+    parseError: null,
+    warnings: [],
+  }
 }
 
 export function createCmaCgmRunner(deps?: {
@@ -48,8 +83,8 @@ export function createCmaCgmRunner(deps?: {
 
       try {
         const result = await fetchStatus(input.ref)
-        const payloadShapeError = toPayloadShapeError(result.payload)
-        const parseError = result.parseError ?? payloadShapeError
+        const payloadAssessment = assessPayload(result.payload)
+        const parseError = result.parseError ?? payloadAssessment.parseError
 
         if (parseError !== null) {
           const classification = classifyProviderParseError(parseError)
@@ -67,12 +102,21 @@ export function createCmaCgmRunner(deps?: {
           })
         }
 
+        if (payloadAssessment.warnings.length > 0) {
+          console.warn('[agent] provider payload warning', {
+            provider: input.provider,
+            ref: input.ref,
+            warnings: payloadAssessment.warnings,
+          })
+        }
+
         return buildProviderSuccess({
           startedAtMs,
           observedAt: result.fetchedAt,
           raw: result.payload,
           diagnostics: {
             provider: input.provider,
+            warnings: payloadAssessment.warnings,
           },
         })
       } catch (error) {

--- a/apps/agent/src/providers/cmacgm/run-cmacgm-sync.ts
+++ b/apps/agent/src/providers/cmacgm/run-cmacgm-sync.ts
@@ -9,6 +9,7 @@ import {
   type ProviderRunner,
 } from '@agent/providers/common/provider-result'
 import { fetchCmaCgmStatus } from '~/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher'
+import { CmaCgmApiSchema } from '~/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema'
 
 type CmaCgmFetcher = (containerNumber: string) => Promise<{
   readonly payload: unknown
@@ -18,6 +19,21 @@ type CmaCgmFetcher = (containerNumber: string) => Promise<{
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+function toPayloadShapeError(payload: unknown): string | null {
+  const parseResult = CmaCgmApiSchema.safeParse(payload)
+  if (parseResult.success) {
+    return null
+  }
+
+  const firstIssue = parseResult.error.issues[0]
+  if (firstIssue === undefined) {
+    return 'CMA-CGM payload does not match expected snapshot shape'
+  }
+
+  const path = firstIssue.path.length > 0 ? firstIssue.path.join('.') : 'payload'
+  return `CMA-CGM payload invalid at ${path}: ${firstIssue.message}`
 }
 
 export function createCmaCgmRunner(deps?: {
@@ -32,15 +48,17 @@ export function createCmaCgmRunner(deps?: {
 
       try {
         const result = await fetchStatus(input.ref)
+        const payloadShapeError = toPayloadShapeError(result.payload)
+        const parseError = result.parseError ?? payloadShapeError
 
-        if (result.parseError) {
-          const classification = classifyProviderParseError(result.parseError)
+        if (parseError !== null) {
+          const classification = classifyProviderParseError(parseError)
           return buildProviderFailure({
             startedAtMs,
             status: classification.status,
             errorCode: classification.code,
             errorMessage: classification.message,
-            parseError: result.parseError,
+            parseError,
             raw: result.payload,
             observedAt: result.fetchedAt,
             diagnostics: {

--- a/apps/agent/src/providers/cmacgm/run-cmacgm-sync.ts
+++ b/apps/agent/src/providers/cmacgm/run-cmacgm-sync.ts
@@ -9,7 +9,7 @@ import {
   type ProviderRunner,
 } from '@agent/providers/common/provider-result'
 import { fetchCmaCgmStatus } from '~/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher'
-import { CmaCgmApiSchema } from '~/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema'
+import { CmaCgmApiStrictSchema } from '~/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema'
 
 type CmaCgmFetcher = (containerNumber: string) => Promise<{
   readonly payload: unknown
@@ -29,9 +29,9 @@ function assessPayload(payload: unknown): {
   readonly parseError: string | null
   readonly warnings: readonly string[]
 } {
-  const parseResult = CmaCgmApiSchema.safeParse(payload)
-  if (!parseResult.success) {
-    const firstIssue = parseResult.error.issues[0]
+  const strictParseResult = CmaCgmApiStrictSchema.safeParse(payload)
+  if (!strictParseResult.success) {
+    const firstIssue = strictParseResult.error.issues[0]
     if (firstIssue === undefined) {
       return {
         parseError: 'CMA-CGM payload does not match expected snapshot shape',
@@ -47,9 +47,9 @@ function assessPayload(payload: unknown): {
   }
 
   const allMoves = [
-    ...(parseResult.data.PastMoves ?? []),
-    ...(parseResult.data.CurrentMoves ?? []),
-    ...(parseResult.data.ProvisionalMoves ?? []),
+    ...(strictParseResult.data.PastMoves ?? []),
+    ...(strictParseResult.data.CurrentMoves ?? []),
+    ...(strictParseResult.data.ProvisionalMoves ?? []),
   ]
 
   const hasSemanticMove = allMoves.some(

--- a/apps/agent/src/sync/application/execute-sync-job.ts
+++ b/apps/agent/src/sync/application/execute-sync-job.ts
@@ -49,6 +49,33 @@ function toDurationMs(result: ProviderRunResult): number {
   return result.timing.durationMs
 }
 
+function logProviderResult(command: {
+  readonly job: AgentSyncJob
+  readonly providerResult: ProviderRunResult
+}): void {
+  const common = {
+    syncRequestId: command.job.syncRequestId,
+    provider: command.job.provider,
+    refType: command.job.refType,
+    ref: command.job.ref,
+    providerStatus: command.providerResult.status,
+    durationMs: command.providerResult.timing.durationMs,
+    observedAt: command.providerResult.observedAt,
+  }
+
+  if (command.providerResult.status === 'success') {
+    console.log('[agent] provider fetch success', common)
+    return
+  }
+
+  console.error('[agent] provider fetch failed', {
+    ...common,
+    errorCode: command.providerResult.errorCode,
+    errorMessage: command.providerResult.errorMessage,
+    parseError: command.providerResult.parseError,
+  })
+}
+
 function toUnsupportedProviderResult(provider: string): ProviderRunResult {
   const now = new Date().toISOString()
   const classification = unsupportedProviderError(provider)
@@ -79,16 +106,26 @@ export async function executeSyncJob(command: {
     registry: command.providerRegistry,
     provider: command.job.provider,
   })
+  const providerInput = toProviderInput({
+    job: command.job,
+    config: command.config,
+    agentVersion: command.agentVersion,
+  })
+  console.log('[agent] provider fetch request', {
+    syncRequestId: providerInput.syncRequestId,
+    provider: providerInput.provider,
+    refType: providerInput.refType,
+    ref: providerInput.ref,
+  })
+
   const providerResult =
     runner === null
       ? toUnsupportedProviderResult(command.job.provider)
-      : await runner.run(
-          toProviderInput({
-            job: command.job,
-            config: command.config,
-            agentVersion: command.agentVersion,
-          }),
-        )
+      : await runner.run(providerInput)
+  logProviderResult({
+    job: command.job,
+    providerResult,
+  })
 
   const occurredAt = new Date().toISOString()
   const retryDecision = decideSyncRetryPolicy(providerResult)
@@ -161,6 +198,14 @@ export async function executeSyncJob(command: {
       snapshotId: ingestResult.snapshotId,
     }
   }
+
+  console.warn('[agent] provider result skipped snapshot ingest', {
+    syncRequestId: command.job.syncRequestId,
+    provider: command.job.provider,
+    ref: command.job.ref,
+    providerStatus: providerResult.status,
+    retryDecision: retryDecision.reason,
+  })
 
   if (shouldReportFailure(providerResult)) {
     const backendFailure = reportSyncFailure({

--- a/apps/agent/src/sync/infrastructure/sync-backend.client.ts
+++ b/apps/agent/src/sync/infrastructure/sync-backend.client.ts
@@ -62,6 +62,28 @@ function safeStringify(value: unknown): string {
   }
 }
 
+function normalizeLogText(value: string, maxLength = 240): string {
+  const compact = value.replace(/\s+/g, ' ').trim()
+  if (compact.length <= maxLength) {
+    return compact
+  }
+  return `${compact.slice(0, maxLength)}...`
+}
+
+function toLeaseWindowSeconds(leasedUntil: string | null): number | null {
+  if (leasedUntil === null) {
+    return null
+  }
+
+  const leaseEndsAtMs = Date.parse(leasedUntil)
+  if (Number.isNaN(leaseEndsAtMs)) {
+    return null
+  }
+
+  const deltaMs = leaseEndsAtMs - Date.now()
+  return Math.max(0, Math.round(deltaMs / 1000))
+}
+
 export function createSyncBackendClient(command: {
   readonly config: ValidatedAgentConfig
   readonly fetchImpl?: typeof fetch
@@ -76,10 +98,23 @@ export function createSyncBackendClient(command: {
       if (fetchCommand.recoverOwnedLeases) {
         url.searchParams.set('recover_owned_leases', 'true')
       }
+      const leaseRequestLog = {
+        tenantId: command.config.TENANT_ID,
+        limit: fetchCommand.limit,
+        recoverOwnedLeases: fetchCommand.recoverOwnedLeases,
+      }
+
+      console.log('[agent] lease targets request', leaseRequestLog)
 
       const response = await fetchImpl(url, {
         method: 'GET',
         headers: buildHeaders(command.config, false),
+      })
+
+      console.log('[agent] lease targets response', {
+        ...leaseRequestLog,
+        status: response.status,
+        ok: response.ok,
       })
 
       if (response.status === 401) {
@@ -97,6 +132,17 @@ export function createSyncBackendClient(command: {
         throw new Error(`invalid targets response: ${parsed.error.message}`)
       }
 
+      const leasedTargetsCount = parsed.data.targets.length
+      const leaseWindowSeconds = toLeaseWindowSeconds(parsed.data.leased_until)
+      console.log('[agent] lease targets acquired', {
+        ...leaseRequestLog,
+        availableTargets: leasedTargetsCount,
+        leasedByAgent: leasedTargetsCount,
+        leasedUntil: parsed.data.leased_until,
+        leaseWindowSeconds,
+        queueLagSeconds: parsed.data.queue_lag_seconds,
+      })
+
       return {
         targets: parsed.data.targets.map((target) => toAgentSyncJob(target)),
         leasedUntil: parsed.data.leased_until,
@@ -105,6 +151,15 @@ export function createSyncBackendClient(command: {
     },
 
     async ingestSnapshot(ingestCommand): Promise<IngestSnapshotResult> {
+      const ingestRequestLog = {
+        syncRequestId: ingestCommand.job.syncRequestId,
+        provider: ingestCommand.job.provider,
+        refType: ingestCommand.job.refType,
+        ref: ingestCommand.job.ref,
+        providerStatus: ingestCommand.providerResult.status,
+      }
+      console.log('[agent] snapshot ingest request', ingestRequestLog)
+
       const response = await fetchImpl(
         `${command.config.BACKEND_URL}/api/tracking/snapshots/ingest`,
         {
@@ -132,8 +187,14 @@ export function createSyncBackendClient(command: {
           }),
         },
       )
+      console.log('[agent] snapshot ingest response', {
+        ...ingestRequestLog,
+        status: response.status,
+        ok: response.ok,
+      })
 
       if (response.status === 409) {
+        console.warn('[agent] snapshot ingest lease conflict', ingestRequestLog)
         return { kind: 'lease_conflict' }
       }
 
@@ -143,6 +204,12 @@ export function createSyncBackendClient(command: {
         if (!parsed.success) {
           throw new Error(`invalid ingest failure response: ${parsed.error.message}`)
         }
+
+        console.error('[agent] snapshot ingest rejected', {
+          ...ingestRequestLog,
+          error: parsed.data.error,
+          snapshotId: parsed.data.snapshot_id ?? null,
+        })
 
         return {
           kind: 'failed',
@@ -157,6 +224,11 @@ export function createSyncBackendClient(command: {
 
       if (!response.ok) {
         const details = await response.text().catch(() => '')
+        console.error('[agent] snapshot ingest transport failed', {
+          ...ingestRequestLog,
+          status: response.status,
+          details: normalizeLogText(details),
+        })
         throw new Error(`ingest failed (${response.status}): ${details}`)
       }
 
@@ -167,6 +239,14 @@ export function createSyncBackendClient(command: {
           `invalid ingest response: ${parsed.error.message}; payload=${safeStringify(payload)}`,
         )
       }
+
+      console.log('[agent] snapshot ingest accepted', {
+        ...ingestRequestLog,
+        snapshotId: parsed.data.snapshot_id,
+        newObservationsCount: parsed.data.new_observations_count ?? null,
+        newAlertsCount: parsed.data.new_alerts_count ?? null,
+        observationCreated: (parsed.data.new_observations_count ?? 0) > 0,
+      })
 
       return {
         kind: 'accepted',

--- a/apps/agent/src/tests/provider-runners.test.ts
+++ b/apps/agent/src/tests/provider-runners.test.ts
@@ -76,6 +76,32 @@ describe('provider runners', () => {
     expect(result.errorCode).toBe('PROVIDER_PARSE_ERROR')
   })
 
+  it('cmacgm runner classifies blank container reference as terminal failure', async () => {
+    const runner = createCmaCgmRunner({
+      async fetchStatus() {
+        return {
+          payload: {
+            ContainerReference: '   ',
+            PastMoves: [
+              {
+                DateString: 'Friday,24-APR-2026',
+                TimeString: '07:00 PM',
+                State: 'DONE',
+                StatusDescription: 'Loaded on board',
+              },
+            ],
+          },
+          fetchedAt: '2026-04-15T00:00:00.000Z',
+          parseError: null,
+        }
+      },
+    })
+
+    const result = await runner.run(makeInput('cmacgm'))
+    expect(result.status).toBe('terminal_failure')
+    expect(result.errorCode).toBe('PROVIDER_PARSE_ERROR')
+  })
+
   it('cmacgm runner keeps close-enough payload as success and emits diagnostics warning', async () => {
     const runner = createCmaCgmRunner({
       async fetchStatus() {

--- a/apps/agent/src/tests/provider-runners.test.ts
+++ b/apps/agent/src/tests/provider-runners.test.ts
@@ -76,6 +76,32 @@ describe('provider runners', () => {
     expect(result.errorCode).toBe('PROVIDER_PARSE_ERROR')
   })
 
+  it('cmacgm runner keeps close-enough payload as success and emits diagnostics warning', async () => {
+    const runner = createCmaCgmRunner({
+      async fetchStatus() {
+        return {
+          payload: {
+            ContainerReference: 'MSCU1234567',
+            PastMoves: [
+              {
+                Date: null,
+                DateString: null,
+                State: 'DONE',
+                StatusDescription: null,
+              },
+            ],
+          },
+          fetchedAt: '2026-04-15T00:00:00.000Z',
+          parseError: null,
+        }
+      },
+    })
+
+    const result = await runner.run(makeInput('cmacgm'))
+    expect(result.status).toBe('success')
+    expect(Array.isArray(result.diagnostics.warnings)).toBe(true)
+  })
+
   it('pil runner classifies timeout exceptions as retryable failures', async () => {
     const runner = createPilRunner({
       async fetchStatus() {

--- a/apps/agent/src/tests/provider-runners.test.ts
+++ b/apps/agent/src/tests/provider-runners.test.ts
@@ -58,6 +58,24 @@ describe('provider runners', () => {
     expect(result.status).toBe('blocked')
   })
 
+  it('cmacgm runner classifies unexpected snapshot shape as terminal failure', async () => {
+    const runner = createCmaCgmRunner({
+      async fetchStatus() {
+        return {
+          payload: {
+            html: '<html><body>unknown</body></html>',
+          },
+          fetchedAt: '2026-04-15T00:00:00.000Z',
+          parseError: null,
+        }
+      },
+    })
+
+    const result = await runner.run(makeInput('cmacgm'))
+    expect(result.status).toBe('terminal_failure')
+    expect(result.errorCode).toBe('PROVIDER_PARSE_ERROR')
+  })
+
   it('pil runner classifies timeout exceptions as retryable failures', async () => {
     const runner = createPilRunner({
       async fetchStatus() {

--- a/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
+++ b/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
@@ -2,17 +2,9 @@ import axios from 'axios'
 import type { FetchResult } from '~/modules/tracking/infrastructure/carriers/fetchers/fetch-result'
 import { systemClock } from '~/shared/time/clock'
 
-function normalizeLogText(value: string, maxLength = 180): string {
-  const compact = value.replace(/\s+/g, ' ').trim()
-  if (compact.length <= maxLength) {
-    return compact
-  }
-  return `${compact.slice(0, maxLength)}...`
-}
-
 function isParseFailurePayload(payload: unknown): payload is {
   readonly parse_failure: true
-  readonly raw_html_snippet: string
+  readonly response_bytes: number
   readonly reason: 'response_data_not_found' | 'invalid_response_data_json'
 } {
   if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
@@ -103,6 +95,7 @@ export async function fetchCmaCgmStatus(containerNumber: string): Promise<FetchR
     })
 
   const html: string = response.data
+  const responseBytes = Buffer.byteLength(html, 'utf8')
   console.log('[tracking:cmacgm] response', {
     method: 'POST',
     url,
@@ -110,7 +103,7 @@ export async function fetchCmaCgmStatus(containerNumber: string): Promise<FetchR
     status: response.status,
     ok: response.status >= 200 && response.status < 300,
     durationMs: Date.now() - startedAtMs,
-    htmlPreview: normalizeLogText(html),
+    responseBytes,
   })
 
   const payload = extractResponseData(html)
@@ -120,10 +113,9 @@ export async function fetchCmaCgmStatus(containerNumber: string): Promise<FetchR
       method: 'POST',
       url,
       containerNumber,
-      error: normalizeLogText(parseError),
-      htmlSnippet: isParseFailurePayload(payload)
-        ? normalizeLogText(payload.raw_html_snippet)
-        : null,
+      error: parseError,
+      parseFailureReason: isParseFailurePayload(payload) ? payload.reason : null,
+      responseBytes: isParseFailurePayload(payload) ? payload.response_bytes : responseBytes,
     })
   } else {
     console.log('[tracking:cmacgm] parse success', {
@@ -150,11 +142,11 @@ function extractResponseData(html: string): unknown {
   const match = html.match(regex)
 
   if (!match?.[2]) {
-    // No embedded JSON found — store the raw HTML snippet for debugging
+    // No embedded JSON found — expose non-sensitive metadata only.
     return {
       parse_failure: true,
       reason: 'response_data_not_found',
-      raw_html_snippet: html.slice(0, 2000),
+      response_bytes: Buffer.byteLength(html, 'utf8'),
     }
   }
 
@@ -173,7 +165,7 @@ function extractResponseData(html: string): unknown {
     return {
       parse_failure: true,
       reason: 'invalid_response_data_json',
-      raw_html_snippet: html.slice(0, 2000),
+      response_bytes: Buffer.byteLength(html, 'utf8'),
     }
   }
 }

--- a/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
+++ b/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import type { FetchResult } from '~/modules/tracking/infrastructure/carriers/fetchers/fetch-result'
+import { CmaCgmApiSchema } from '~/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema'
 import { systemClock } from '~/shared/time/clock'
 
 function normalizeLogText(value: string, maxLength = 180): string {
@@ -10,9 +11,11 @@ function normalizeLogText(value: string, maxLength = 180): string {
   return `${compact.slice(0, maxLength)}...`
 }
 
-function isParseFailurePayload(
-  payload: unknown,
-): payload is { readonly parse_failure: true; readonly raw_html_snippet: string } {
+function isParseFailurePayload(payload: unknown): payload is {
+  readonly parse_failure: true
+  readonly raw_html_snippet: string
+  readonly reason: 'response_data_not_found' | 'invalid_response_data_json'
+} {
   if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
     return false
   }
@@ -20,6 +23,28 @@ function isParseFailurePayload(
     return false
   }
   return payload.parse_failure === true
+}
+
+function toPayloadSchemaError(payload: unknown): string | null {
+  if (isParseFailurePayload(payload)) {
+    if (payload.reason === 'response_data_not_found') {
+      return 'CMA-CGM response HTML missing expected options.responseData payload'
+    }
+    return 'CMA-CGM response HTML contained invalid options.responseData JSON'
+  }
+
+  const schemaResult = CmaCgmApiSchema.safeParse(payload)
+  if (schemaResult.success) {
+    return null
+  }
+
+  const firstIssue = schemaResult.error.issues[0]
+  if (firstIssue === undefined) {
+    return 'CMA-CGM response JSON does not match expected snapshot shape'
+  }
+
+  const path = firstIssue.path.length > 0 ? firstIssue.path.join('.') : 'payload'
+  return `CMA-CGM response JSON invalid at ${path}: ${firstIssue.message}`
 }
 
 /**
@@ -102,12 +127,16 @@ export async function fetchCmaCgmStatus(containerNumber: string): Promise<FetchR
   })
 
   const payload = extractResponseData(html)
-  if (isParseFailurePayload(payload)) {
+  const parseError = toPayloadSchemaError(payload)
+  if (parseError !== null) {
     console.warn('[tracking:cmacgm] parse failed', {
       method: 'POST',
       url,
       containerNumber,
-      htmlSnippet: normalizeLogText(payload.raw_html_snippet),
+      error: normalizeLogText(parseError),
+      htmlSnippet: isParseFailurePayload(payload)
+        ? normalizeLogText(payload.raw_html_snippet)
+        : null,
     })
   } else {
     console.log('[tracking:cmacgm] parse success', {
@@ -121,6 +150,7 @@ export async function fetchCmaCgmStatus(containerNumber: string): Promise<FetchR
     provider: 'cmacgm',
     payload,
     fetchedAt: systemClock.now().toIsoString(),
+    parseError,
   }
 }
 
@@ -134,7 +164,11 @@ function extractResponseData(html: string): unknown {
 
   if (!match?.[2]) {
     // No embedded JSON found — store the raw HTML snippet for debugging
-    return { parse_failure: true, raw_html_snippet: html.slice(0, 2000) }
+    return {
+      parse_failure: true,
+      reason: 'response_data_not_found',
+      raw_html_snippet: html.slice(0, 2000),
+    }
   }
 
   const inner = match[2]
@@ -149,6 +183,10 @@ function extractResponseData(html: string): unknown {
   try {
     return JSON.parse(inner)
   } catch {
-    return { parse_failure: true, raw_html_snippet: html.slice(0, 2000) }
+    return {
+      parse_failure: true,
+      reason: 'invalid_response_data_json',
+      raw_html_snippet: html.slice(0, 2000),
+    }
   }
 }

--- a/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
+++ b/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import type { FetchResult } from '~/modules/tracking/infrastructure/carriers/fetchers/fetch-result'
-import { CmaCgmApiSchema } from '~/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema'
 import { systemClock } from '~/shared/time/clock'
 
 function normalizeLogText(value: string, maxLength = 180): string {
@@ -25,26 +24,14 @@ function isParseFailurePayload(payload: unknown): payload is {
   return payload.parse_failure === true
 }
 
-function toPayloadSchemaError(payload: unknown): string | null {
+function toCmaCgmHtmlParseError(payload: unknown): string | null {
   if (isParseFailurePayload(payload)) {
     if (payload.reason === 'response_data_not_found') {
       return 'CMA-CGM response HTML missing expected options.responseData payload'
     }
     return 'CMA-CGM response HTML contained invalid options.responseData JSON'
   }
-
-  const schemaResult = CmaCgmApiSchema.safeParse(payload)
-  if (schemaResult.success) {
-    return null
-  }
-
-  const firstIssue = schemaResult.error.issues[0]
-  if (firstIssue === undefined) {
-    return 'CMA-CGM response JSON does not match expected snapshot shape'
-  }
-
-  const path = firstIssue.path.length > 0 ? firstIssue.path.join('.') : 'payload'
-  return `CMA-CGM response JSON invalid at ${path}: ${firstIssue.message}`
+  return null
 }
 
 /**
@@ -127,7 +114,7 @@ export async function fetchCmaCgmStatus(containerNumber: string): Promise<FetchR
   })
 
   const payload = extractResponseData(html)
-  const parseError = toPayloadSchemaError(payload)
+  const parseError = toCmaCgmHtmlParseError(payload)
   if (parseError !== null) {
     console.warn('[tracking:cmacgm] parse failed', {
       method: 'POST',

--- a/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
+++ b/src/modules/tracking/infrastructure/carriers/fetchers/cmacgm.fetcher.ts
@@ -2,6 +2,26 @@ import axios from 'axios'
 import type { FetchResult } from '~/modules/tracking/infrastructure/carriers/fetchers/fetch-result'
 import { systemClock } from '~/shared/time/clock'
 
+function normalizeLogText(value: string, maxLength = 180): string {
+  const compact = value.replace(/\s+/g, ' ').trim()
+  if (compact.length <= maxLength) {
+    return compact
+  }
+  return `${compact.slice(0, maxLength)}...`
+}
+
+function isParseFailurePayload(
+  payload: unknown,
+): payload is { readonly parse_failure: true; readonly raw_html_snippet: string } {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return false
+  }
+  if (!('parse_failure' in payload)) {
+    return false
+  }
+  return payload.parse_failure === true
+}
+
 /**
  * Fetch tracking data from CMA-CGM's public tracking endpoint.
  *
@@ -9,48 +29,93 @@ import { systemClock } from '~/shared/time/clock'
  * We extract and parse that JSON payload.
  */
 export async function fetchCmaCgmStatus(containerNumber: string): Promise<FetchResult> {
-  const response = await axios.post(
-    'https://www.cma-cgm.com/ebusiness/tracking/search',
-    new URLSearchParams({
-      __RequestVerificationToken:
-        'WSKXu5mATqHpEopOTqNHnfZdedqy3gil1IV1XMncr66exbjY5Ks6KO4ekvCROhP42Lkh9F3zegXkzFIPlO2aRnDgxFaIQU61qzAI_9dNZtc1',
-      'SearchViewModel.SearchBy': 'Container',
-      'SearchViewModel.Reference': containerNumber,
-      'SearchViewModel.FromHome': 'true',
-      search: '',
-    }),
-    {
-      responseType: 'text',
-      decompress: true,
-      timeout: 30_000,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0',
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.5',
-        'Accept-Encoding': 'gzip, deflate',
-        Referer: 'https://www.cma-cgm.com/ebusiness/tracking/search',
-        Origin: 'https://www.cma-cgm.com',
-        'Sec-GPC': '1',
-        'Alt-Used': 'www.cma-cgm.com',
-        Connection: 'keep-alive',
-        Cookie:
-          'datadome=F4C3piYK84t_34olK3LkOba3h0iWGmhXKlZa51JSvQmBWRd5iyiy2~zZkfLDt3bsQEv5RQQqkzXiZ65kQRDQ0UX8aSfy4dYURaY~HTFsNcHROHWDkSZMnjmW8D6VEPYk; __RequestVerificationToken=64dS2BI8rYboYSq-JMaZn8dlXYijOkaLdFJIT0yXutdjqNzUCLbsLr61l1KUejvvPx1wCOqIFdpoh3vDBPBgt1B2j80asuEgtNeRpz0H2lI1; dtCookie=v_4_srv_2_sn_786CC8D9A19CFA6CC105F857BA5985D7_perc_100000_ol_0_mul_1_app-3A0b422508580a7b79_0_rcs-3Acss_0; Human_Search=1; MustRelease=22.0.4.0',
-        'Upgrade-Insecure-Requests': '1',
-        'Sec-Fetch-Dest': 'document',
-        'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'same-origin',
-        'Sec-Fetch-User': '?1',
-        Priority: 'u=0, i',
-        Pragma: 'no-cache',
-        'Cache-Control': 'no-cache',
-        TE: 'trailers',
+  const url = 'https://www.cma-cgm.com/ebusiness/tracking/search'
+  const startedAtMs = Date.now()
+  console.log('[tracking:cmacgm] request', {
+    method: 'POST',
+    url,
+    containerNumber,
+  })
+
+  const response = await axios
+    .post(
+      url,
+      new URLSearchParams({
+        __RequestVerificationToken:
+          'WSKXu5mATqHpEopOTqNHnfZdedqy3gil1IV1XMncr66exbjY5Ks6KO4ekvCROhP42Lkh9F3zegXkzFIPlO2aRnDgxFaIQU61qzAI_9dNZtc1',
+        'SearchViewModel.SearchBy': 'Container',
+        'SearchViewModel.Reference': containerNumber,
+        'SearchViewModel.FromHome': 'true',
+        search: '',
+      }),
+      {
+        responseType: 'text',
+        decompress: true,
+        timeout: 30_000,
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0',
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.5',
+          'Accept-Encoding': 'gzip, deflate',
+          Referer: 'https://www.cma-cgm.com/ebusiness/tracking/search',
+          Origin: 'https://www.cma-cgm.com',
+          'Sec-GPC': '1',
+          'Alt-Used': 'www.cma-cgm.com',
+          Connection: 'keep-alive',
+          Cookie:
+            'datadome=F4C3piYK84t_34olK3LkOba3h0iWGmhXKlZa51JSvQmBWRd5iyiy2~zZkfLDt3bsQEv5RQQqkzXiZ65kQRDQ0UX8aSfy4dYURaY~HTFsNcHROHWDkSZMnjmW8D6VEPYk; __RequestVerificationToken=64dS2BI8rYboYSq-JMaZn8dlXYijOkaLdFJIT0yXutdjqNzUCLbsLr61l1KUejvvPx1wCOqIFdpoh3vDBPBgt1B2j80asuEgtNeRpz0H2lI1; dtCookie=v_4_srv_2_sn_786CC8D9A19CFA6CC105F857BA5985D7_perc_100000_ol_0_mul_1_app-3A0b422508580a7b79_0_rcs-3Acss_0; Human_Search=1; MustRelease=22.0.4.0',
+          'Upgrade-Insecure-Requests': '1',
+          'Sec-Fetch-Dest': 'document',
+          'Sec-Fetch-Mode': 'navigate',
+          'Sec-Fetch-Site': 'same-origin',
+          'Sec-Fetch-User': '?1',
+          Priority: 'u=0, i',
+          Pragma: 'no-cache',
+          'Cache-Control': 'no-cache',
+          TE: 'trailers',
+        },
       },
-    },
-  )
+    )
+    .catch((error: unknown) => {
+      if (axios.isAxiosError(error)) {
+        console.error('[tracking:cmacgm] response error', {
+          method: 'POST',
+          url,
+          containerNumber,
+          status: error.response?.status ?? null,
+          message: error.message,
+          durationMs: Date.now() - startedAtMs,
+        })
+      }
+      throw error
+    })
 
   const html: string = response.data
-  console.debug('Fetched CMA-CGM HTML response:', html.slice(0, 2000)) // Log the raw HTML for debugging (truncated to avoid huge logs)
+  console.log('[tracking:cmacgm] response', {
+    method: 'POST',
+    url,
+    containerNumber,
+    status: response.status,
+    ok: response.status >= 200 && response.status < 300,
+    durationMs: Date.now() - startedAtMs,
+    htmlPreview: normalizeLogText(html),
+  })
+
   const payload = extractResponseData(html)
+  if (isParseFailurePayload(payload)) {
+    console.warn('[tracking:cmacgm] parse failed', {
+      method: 'POST',
+      url,
+      containerNumber,
+      htmlSnippet: normalizeLogText(payload.raw_html_snippet),
+    })
+  } else {
+    console.log('[tracking:cmacgm] parse success', {
+      method: 'POST',
+      url,
+      containerNumber,
+    })
+  }
 
   return {
     provider: 'cmacgm',

--- a/src/modules/tracking/infrastructure/carriers/fetchers/msc.fetcher.ts
+++ b/src/modules/tracking/infrastructure/carriers/fetchers/msc.fetcher.ts
@@ -15,6 +15,12 @@ export async function fetchMscStatus(containerNumber: string): Promise<FetchResu
     trackingNumber: String(containerNumber),
     trackingMode: '0',
   }
+  const startedAtMs = Date.now()
+  console.log('[tracking:msc] request', {
+    method: 'POST',
+    url,
+    containerNumber,
+  })
 
   const headers: Record<string, string> = {
     'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0',
@@ -34,13 +40,42 @@ export async function fetchMscStatus(containerNumber: string): Promise<FetchResu
     TE: 'trailers',
   }
 
-  const resp = await axios.post(url, body, {
-    headers,
-    responseType: 'arraybuffer',
-    timeout: 30_000,
-  })
+  const resp = await axios
+    .post(url, body, {
+      headers,
+      responseType: 'arraybuffer',
+      timeout: 30_000,
+    })
+    .catch((error: unknown) => {
+      if (axios.isAxiosError(error)) {
+        console.error('[tracking:msc] response error', {
+          method: 'POST',
+          url,
+          containerNumber,
+          status: error.response?.status ?? null,
+          message: error.message,
+          durationMs: Date.now() - startedAtMs,
+        })
+      }
+      throw error
+    })
 
   const contentEncoding: string | undefined = resp.headers?.['content-encoding'] ?? undefined
+  let responseBytes: number | null = null
+  if (resp.data instanceof ArrayBuffer || ArrayBuffer.isView(resp.data)) {
+    responseBytes = resp.data.byteLength
+  }
+  console.log('[tracking:msc] response', {
+    method: 'POST',
+    url,
+    containerNumber,
+    status: resp.status,
+    ok: resp.status >= 200 && resp.status < 300,
+    durationMs: Date.now() - startedAtMs,
+    contentEncoding: typeof contentEncoding === 'string' ? contentEncoding : null,
+    responseBytes,
+  })
+
   const text = decodeResponseBuffer(
     Buffer.from(resp.data),
     typeof contentEncoding === 'string' ? contentEncoding : null,

--- a/src/modules/tracking/infrastructure/carriers/fetchers/one.fetcher.ts
+++ b/src/modules/tracking/infrastructure/carriers/fetchers/one.fetcher.ts
@@ -58,6 +58,12 @@ function isSuccessfulCarrierEnvelope(envelope: {
 }
 
 async function postOneSearch(containerNumber: string): Promise<OneHttpResult> {
+  console.log('[tracking:one] request', {
+    endpoint: 'search',
+    method: 'POST',
+    containerNumber,
+  })
+
   const response = await axios.post(
     `${ONE_BASE_URL}/api/v1/edh/containers/track-and-trace/search`,
     {
@@ -85,6 +91,7 @@ async function postOneSearch(containerNumber: string): Promise<OneHttpResult> {
     endpoint: 'search',
     containerNumber,
     statusCode: response.status,
+    ok: response.status >= 200 && response.status < 300,
   })
 
   return {
@@ -97,6 +104,13 @@ async function getOneEndpoint(command: {
   readonly endpoint: 'voyage-list' | 'cop-events'
   readonly params: Record<string, string>
 }): Promise<OneHttpResult> {
+  console.log('[tracking:one] request', {
+    endpoint: command.endpoint,
+    method: 'GET',
+    bookingNo: command.params.booking_no,
+    containerNumber: command.params.container_no ?? null,
+  })
+
   const response = await axios.get(
     `${ONE_BASE_URL}/api/v1/edh/${command.endpoint === 'voyage-list' ? 'vessel' : 'containers'}/track-and-trace/${command.endpoint}`,
     {
@@ -117,6 +131,7 @@ async function getOneEndpoint(command: {
     bookingNo: command.params.booking_no,
     containerNumber: command.params.container_no ?? null,
     statusCode: response.status,
+    ok: response.status >= 200 && response.status < 300,
   })
 
   return {

--- a/src/modules/tracking/infrastructure/carriers/fetchers/pil.fetcher.ts
+++ b/src/modules/tracking/infrastructure/carriers/fetchers/pil.fetcher.ts
@@ -9,6 +9,14 @@ type PilNoncePayload = {
   readonly n: string
 }
 
+function normalizeLogText(value: string, maxLength = 180): string {
+  const compact = value.replace(/\s+/g, ' ').trim()
+  if (compact.length <= maxLength) {
+    return compact
+  }
+  return `${compact.slice(0, maxLength)}...`
+}
+
 function tryParseJson(value: string): unknown | null {
   try {
     return JSON.parse(value)
@@ -56,22 +64,37 @@ async function fetchPilNonce(
   readonly payload: unknown
   readonly parseError: string | null
 }> {
-  const response = await axios.get(
-    `https://www.pilship.com/wp-content/themes/hello-theme-child-master/pil-api/common/get-n.php?timestamp=${timestampMs}`,
-    {
-      responseType: 'text',
-      decompress: true,
-      timeout: 30_000,
-      validateStatus: () => true,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
-        Accept: '*/*',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'X-Requested-With': 'XMLHttpRequest',
-        Referer: `https://www.pilship.com/digital-solutions/?tab=customer&id=track-trace&label=containerTandT&module=TrackContStatus&refNo=${encodeURIComponent(containerNumber)}`,
-      },
+  const url = `https://www.pilship.com/wp-content/themes/hello-theme-child-master/pil-api/common/get-n.php?timestamp=${timestampMs}`
+  const startedAtMs = Date.now()
+  console.log('[tracking:pil] request', {
+    endpoint: 'nonce',
+    method: 'GET',
+    url,
+    containerNumber,
+  })
+
+  const response = await axios.get(url, {
+    responseType: 'text',
+    decompress: true,
+    timeout: 30_000,
+    validateStatus: () => true,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
+      Accept: '*/*',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'X-Requested-With': 'XMLHttpRequest',
+      Referer: `https://www.pilship.com/digital-solutions/?tab=customer&id=track-trace&label=containerTandT&module=TrackContStatus&refNo=${encodeURIComponent(containerNumber)}`,
     },
-  )
+  })
+  console.log('[tracking:pil] response', {
+    endpoint: 'nonce',
+    method: 'GET',
+    url,
+    containerNumber,
+    status: response.status,
+    ok: response.status >= 200 && response.status < 300,
+    durationMs: Date.now() - startedAtMs,
+  })
 
   const rawText = typeof response.data === 'string' ? response.data : String(response.data)
   const payload = tryParseJson(rawText) ?? { raw_text: rawText }
@@ -130,6 +153,10 @@ export async function fetchPilStatus(containerNumber: string): Promise<FetchResu
   const timestampMs = Date.now()
   const nonceResult = await fetchPilNonce(timestampMs, containerNumber)
   if (nonceResult.parseError !== null || nonceResult.nonce === null) {
+    console.warn('[tracking:pil] nonce parse failed', {
+      containerNumber,
+      error: nonceResult.parseError,
+    })
     return {
       provider: 'pil',
       payload: {
@@ -146,27 +173,41 @@ export async function fetchPilStatus(containerNumber: string): Promise<FetchResu
     n: nonceResult.nonce,
     timestamp: String(timestampMs),
   })
+  const url = `https://www.pilship.com/wp-content/themes/hello-theme-child-master/pil-api/trackntrace-containertnt.php?${params.toString()}`
+  const startedAtMs = Date.now()
+  console.log('[tracking:pil] request', {
+    endpoint: 'trackntrace-containertnt',
+    method: 'GET',
+    url,
+    containerNumber,
+  })
 
-  const response = await axios.get(
-    `https://www.pilship.com/wp-content/themes/hello-theme-child-master/pil-api/trackntrace-containertnt.php?${params.toString()}`,
-    {
-      responseType: 'text',
-      decompress: true,
-      timeout: 30_000,
-      validateStatus: () => true,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
-        Accept: '*/*',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Accept-Encoding': 'gzip, deflate, br, zstd',
-        'X-Requested-With': 'XMLHttpRequest',
-        Referer: `https://www.pilship.com/digital-solutions/?tab=customer&id=track-trace&label=containerTandT&module=TrackContStatus&refNo=${encodeURIComponent(containerNumber)}`,
-        Connection: 'keep-alive',
-        Pragma: 'no-cache',
-        'Cache-Control': 'no-cache',
-      },
+  const response = await axios.get(url, {
+    responseType: 'text',
+    decompress: true,
+    timeout: 30_000,
+    validateStatus: () => true,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0',
+      Accept: '*/*',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Accept-Encoding': 'gzip, deflate, br, zstd',
+      'X-Requested-With': 'XMLHttpRequest',
+      Referer: `https://www.pilship.com/digital-solutions/?tab=customer&id=track-trace&label=containerTandT&module=TrackContStatus&refNo=${encodeURIComponent(containerNumber)}`,
+      Connection: 'keep-alive',
+      Pragma: 'no-cache',
+      'Cache-Control': 'no-cache',
     },
-  )
+  })
+  console.log('[tracking:pil] response', {
+    endpoint: 'trackntrace-containertnt',
+    method: 'GET',
+    url,
+    containerNumber,
+    status: response.status,
+    ok: response.status >= 200 && response.status < 300,
+    durationMs: Date.now() - startedAtMs,
+  })
 
   const rawText = typeof response.data === 'string' ? response.data : String(response.data)
   const payload = tryParseJson(rawText) ?? { raw_text: rawText }
@@ -175,6 +216,18 @@ export async function fetchPilStatus(containerNumber: string): Promise<FetchResu
   if (response.status < 200 || response.status >= 300) {
     const statusError = `PIL request failed with status ${response.status}`
     parseError = parseError === null ? statusError : `${statusError}: ${parseError}`
+  }
+  if (parseError !== null) {
+    console.warn('[tracking:pil] parse failed', {
+      endpoint: 'trackntrace-containertnt',
+      containerNumber,
+      error: normalizeLogText(parseError),
+    })
+  } else {
+    console.log('[tracking:pil] parse success', {
+      endpoint: 'trackntrace-containertnt',
+      containerNumber,
+    })
   }
 
   return {

--- a/src/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer.ts
+++ b/src/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer.ts
@@ -11,7 +11,6 @@ import {
   buildDateOnlyTrackingTemporal,
   buildLocalDateTimeTrackingTemporal,
   composeTrackingRawEventTime,
-  resolveTrackingEventTimezone,
 } from '~/modules/tracking/infrastructure/carriers/normalizers/tracking-temporal-resolution'
 import { CmaCgmApiSchema } from '~/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema'
 import { CalendarDate } from '~/shared/time/calendar-date'
@@ -231,8 +230,7 @@ function parseCmaCgmDate(
     if (parsedDate) {
       if (timeStringField) {
         const parsedTime = parseCmaCgmMeridiemTime(timeStringField)
-        const timezone = resolveTrackingEventTimezone(temporalLocationContext)
-        if (parsedTime && timezone !== null) {
+        if (parsedTime) {
           return buildLocalDateTimeTrackingTemporal({
             localDateTime: `${parsedDate.toIsoDate()}T${parsedTime}`,
             rawEventTime,

--- a/src/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer.ts
+++ b/src/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer.ts
@@ -101,39 +101,11 @@ const MONTHS_BY_ABBREVIATION = new Map<string, number>([
 const CMA_DATE_TEXT_PATTERN = /(?:[A-Z]{3,9}[,\s]+)?(\d{1,2})-([A-Z]{3})-(\d{4})/iu
 const CMA_ISO_DATE_PREFIX_PATTERN = /^(\d{4})-(\d{2})-(\d{2})(?:\b|T)/u
 const CMA_TIME_TEXT_PATTERN = /^(\d{1,2}):(\d{2})\s*(AM|PM)$/iu
-const LBBEY_LOCATION_CODE = 'LBBEY'
-const LBBEY_LOCATION_DISPLAY_FALLBACK = 'BEIRUT'
 
 function toTrimmedOrNull(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
   return trimmed.length === 0 ? null : trimmed
-}
-
-function resolveCmaCgmTemporalLocationContext(
-  locationCode: string | null | undefined,
-  locationDisplay: string | null | undefined,
-): {
-  readonly locationCode: string | null
-  readonly locationDisplay: string | null
-} {
-  const normalizedCode = toTrimmedOrNull(locationCode)?.toUpperCase() ?? null
-  const normalizedDisplay = toTrimmedOrNull(locationDisplay)
-
-  if (
-    normalizedCode === LBBEY_LOCATION_CODE &&
-    (normalizedDisplay === null || !/BEIRUT/iu.test(normalizedDisplay))
-  ) {
-    return {
-      locationCode: normalizedCode,
-      locationDisplay: LBBEY_LOCATION_DISPLAY_FALLBACK,
-    }
-  }
-
-  return {
-    locationCode: normalizedCode,
-    locationDisplay: normalizedDisplay,
-  }
 }
 
 function parseCmaCgmCalendarDate(value: string): CalendarDate | null {
@@ -220,10 +192,8 @@ function parseCmaCgmDate(
   const normalizedDateField = toTrimmedOrNull(dateField)
   const rawEventTime =
     composeTrackingRawEventTime(dateStringField, timeStringField) ?? normalizedDateField
-  const temporalLocationContext = resolveCmaCgmTemporalLocationContext(
-    locationCode,
-    locationDisplay,
-  )
+  const normalizedLocationCode = toTrimmedOrNull(locationCode)?.toUpperCase() ?? null
+  const normalizedLocationDisplay = toTrimmedOrNull(locationDisplay)
 
   if (dateStringField) {
     const parsedDate = parseCmaCgmCalendarDate(dateStringField)
@@ -234,8 +204,8 @@ function parseCmaCgmDate(
           return buildLocalDateTimeTrackingTemporal({
             localDateTime: `${parsedDate.toIsoDate()}T${parsedTime}`,
             rawEventTime,
-            locationCode: temporalLocationContext.locationCode,
-            locationDisplay: temporalLocationContext.locationDisplay,
+            locationCode: normalizedLocationCode,
+            locationDisplay: normalizedLocationDisplay,
           })
         }
       }
@@ -243,8 +213,8 @@ function parseCmaCgmDate(
       return buildDateOnlyTrackingTemporal({
         date: parsedDate,
         rawEventTime,
-        locationCode: temporalLocationContext.locationCode,
-        locationDisplay: temporalLocationContext.locationDisplay,
+        locationCode: normalizedLocationCode,
+        locationDisplay: normalizedLocationDisplay,
       })
     }
   }
@@ -328,7 +298,7 @@ export function normalizeCmaCgmSnapshot(snapshot: Snapshot): ObservationDraft[] 
   }
 
   const cmacgmData = parseResult.data
-  const containerNumber = cmacgmData.ContainerReference?.toUpperCase() ?? 'UNKNOWN'
+  const containerNumber = toTrimmedOrNull(cmacgmData.ContainerReference)?.toUpperCase() ?? 'UNKNOWN'
 
   const drafts: ObservationDraft[] = []
 

--- a/src/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer.ts
+++ b/src/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer.ts
@@ -11,12 +11,13 @@ import {
   buildDateOnlyTrackingTemporal,
   buildLocalDateTimeTrackingTemporal,
   composeTrackingRawEventTime,
+  resolveTrackingEventTimezone,
 } from '~/modules/tracking/infrastructure/carriers/normalizers/tracking-temporal-resolution'
 import { CmaCgmApiSchema } from '~/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema'
 import { CalendarDate } from '~/shared/time/calendar-date'
 import { systemClock } from '~/shared/time/clock'
 import { parseInstantFromIso } from '~/shared/time/parsing'
-import { parseIsoOrRfcString, parseMsDateString } from '~/shared/utils/parseDate'
+import { parseMsDateString } from '~/shared/utils/parseDate'
 
 /**
  * Maps CMA-CGM `StatusDescription` strings to canonical ObservationType.
@@ -99,10 +100,62 @@ const MONTHS_BY_ABBREVIATION = new Map<string, number>([
 ])
 
 const CMA_DATE_TEXT_PATTERN = /(?:[A-Z]{3,9}[,\s]+)?(\d{1,2})-([A-Z]{3})-(\d{4})/iu
+const CMA_ISO_DATE_PREFIX_PATTERN = /^(\d{4})-(\d{2})-(\d{2})(?:\b|T)/u
 const CMA_TIME_TEXT_PATTERN = /^(\d{1,2}):(\d{2})\s*(AM|PM)$/iu
+const LBBEY_LOCATION_CODE = 'LBBEY'
+const LBBEY_LOCATION_DISPLAY_FALLBACK = 'BEIRUT'
+
+function toTrimmedOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length === 0 ? null : trimmed
+}
+
+function resolveCmaCgmTemporalLocationContext(
+  locationCode: string | null | undefined,
+  locationDisplay: string | null | undefined,
+): {
+  readonly locationCode: string | null
+  readonly locationDisplay: string | null
+} {
+  const normalizedCode = toTrimmedOrNull(locationCode)?.toUpperCase() ?? null
+  const normalizedDisplay = toTrimmedOrNull(locationDisplay)
+
+  if (
+    normalizedCode === LBBEY_LOCATION_CODE &&
+    (normalizedDisplay === null || !/BEIRUT/iu.test(normalizedDisplay))
+  ) {
+    return {
+      locationCode: normalizedCode,
+      locationDisplay: LBBEY_LOCATION_DISPLAY_FALLBACK,
+    }
+  }
+
+  return {
+    locationCode: normalizedCode,
+    locationDisplay: normalizedDisplay,
+  }
+}
 
 function parseCmaCgmCalendarDate(value: string): CalendarDate | null {
-  const match = value.trim().match(CMA_DATE_TEXT_PATTERN)
+  const normalized = value.trim()
+  const isoPrefixMatch = normalized.match(CMA_ISO_DATE_PREFIX_PATTERN)
+  if (
+    isoPrefixMatch &&
+    isoPrefixMatch[1] !== undefined &&
+    isoPrefixMatch[2] !== undefined &&
+    isoPrefixMatch[3] !== undefined
+  ) {
+    try {
+      return CalendarDate.fromIsoDate(
+        `${isoPrefixMatch[1]}-${isoPrefixMatch[2]}-${isoPrefixMatch[3]}`,
+      )
+    } catch {
+      return null
+    }
+  }
+
+  const match = normalized.match(CMA_DATE_TEXT_PATTERN)
   if (!match || match[1] === undefined || match[2] === undefined || match[3] === undefined) {
     return null
   }
@@ -140,6 +193,18 @@ function parseCmaCgmMeridiemTime(value: string): string | null {
   return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00.000`
 }
 
+function parseCmaCgmExplicitAbsoluteInstant(
+  value: string | null | undefined,
+): ReturnType<typeof parseInstantFromIso> {
+  const normalized = toTrimmedOrNull(value)
+  if (normalized === null) return null
+
+  const msDate = parseMsDateString(normalized)
+  if (msDate !== null) return msDate
+
+  return parseInstantFromIso(normalized)
+}
+
 /**
  * Parse CMA-CGM date strings.
  *
@@ -153,57 +218,45 @@ function parseCmaCgmDate(
   locationCode: string | null | undefined,
   locationDisplay: string | null | undefined,
 ): Pick<ObservationDraft, 'event_time' | 'raw_event_time' | 'event_time_source'> {
-  const rawEventTime = composeTrackingRawEventTime(dateStringField, timeStringField)
-
-  // Prefer the provider absolute timestamp when it exists.
-  if (dateField) {
-    const ms = parseMsDateString(dateField)
-    if (ms) {
-      return buildAbsoluteTrackingTemporal({
-        instant: ms,
-        rawEventTime: rawEventTime ?? dateField.trim(),
-      })
-    }
-
-    const d = parseIsoOrRfcString(dateField)
-    if (d) {
-      return buildAbsoluteTrackingTemporal({
-        instant: d,
-        rawEventTime: rawEventTime ?? dateField.trim(),
-      })
-    }
-  }
+  const normalizedDateField = toTrimmedOrNull(dateField)
+  const rawEventTime =
+    composeTrackingRawEventTime(dateStringField, timeStringField) ?? normalizedDateField
+  const temporalLocationContext = resolveCmaCgmTemporalLocationContext(
+    locationCode,
+    locationDisplay,
+  )
 
   if (dateStringField) {
-    const explicitInstant = parseInstantFromIso(dateStringField.trim())
-    if (explicitInstant) {
-      return buildAbsoluteTrackingTemporal({
-        instant: explicitInstant,
-        rawEventTime: rawEventTime ?? dateStringField.trim(),
-      })
-    }
-
     const parsedDate = parseCmaCgmCalendarDate(dateStringField)
     if (parsedDate) {
       if (timeStringField) {
         const parsedTime = parseCmaCgmMeridiemTime(timeStringField)
-        if (parsedTime) {
+        const timezone = resolveTrackingEventTimezone(temporalLocationContext)
+        if (parsedTime && timezone !== null) {
           return buildLocalDateTimeTrackingTemporal({
             localDateTime: `${parsedDate.toIsoDate()}T${parsedTime}`,
-            rawEventTime: rawEventTime ?? dateStringField.trim(),
-            locationCode,
-            locationDisplay,
+            rawEventTime,
+            locationCode: temporalLocationContext.locationCode,
+            locationDisplay: temporalLocationContext.locationDisplay,
           })
         }
       }
 
       return buildDateOnlyTrackingTemporal({
         date: parsedDate,
-        rawEventTime: rawEventTime ?? dateStringField.trim(),
-        locationCode,
-        locationDisplay,
+        rawEventTime,
+        locationCode: temporalLocationContext.locationCode,
+        locationDisplay: temporalLocationContext.locationDisplay,
       })
     }
+  }
+
+  const explicitAbsoluteInstant = parseCmaCgmExplicitAbsoluteInstant(normalizedDateField)
+  if (explicitAbsoluteInstant !== null) {
+    return buildAbsoluteTrackingTemporal({
+      instant: explicitAbsoluteInstant,
+      rawEventTime,
+    })
   }
 
   return {

--- a/src/modules/tracking/infrastructure/carriers/normalizers/tracking-temporal-resolution.ts
+++ b/src/modules/tracking/infrastructure/carriers/normalizers/tracking-temporal-resolution.ts
@@ -30,6 +30,7 @@ const LOCATION_CODE_TIMEZONES: Readonly<Record<string, string>> = {
   ESZAZ: 'Europe/Madrid',
   ESTUD: 'Europe/Madrid',
   ITNAP: 'Europe/Rome',
+  LBBEY: 'Asia/Beirut',
   MAPTM: 'Africa/Casablanca',
   PKKHI: 'Asia/Karachi',
   PKLHE: 'Asia/Karachi',

--- a/src/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema.ts
+++ b/src/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema.ts
@@ -74,20 +74,5 @@ export const CmaCgmApiSchema = z
         path: ['PastMoves'],
         message: 'CMA-CGM snapshot missing movement arrays',
       })
-      return
-    }
-
-    const hasSemanticMove = allMoves.some(
-      (move) =>
-        hasNonEmptyText(move.StatusDescription) &&
-        (hasNonEmptyText(move.Date) || hasNonEmptyText(move.DateString)),
-    )
-
-    if (!hasSemanticMove) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['PastMoves'],
-        message: 'CMA-CGM snapshot has no recognizable movement entries',
-      })
     }
   })

--- a/src/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema.ts
+++ b/src/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema.ts
@@ -26,25 +26,68 @@ const CmaCgmMoveSchema = z.object({
   raw: z.any().optional(),
 })
 
-export const CmaCgmApiSchema = z.object({
-  ContainerReference: z.string().nullable().optional(),
-  EstimatedTimeOfArrival: z.string().nullable().optional(), // "/Date(...)\/"
-  ABPExportDate: z.string().nullable().optional(),
-  ABPImportDate: z.string().nullable().optional(),
-  CurrentMoves: z.array(CmaCgmMoveSchema).optional(),
-  PastMoves: z.array(CmaCgmMoveSchema).optional(),
-  ProvisionalMoves: z.array(CmaCgmMoveSchema).optional(),
-  PlaceOfLoading: z.string().nullable().optional(),
-  LastDischargePort: z.string().nullable().optional(),
-  ContainerStatus: z.number().nullable().optional(),
-  IsEtaAtPod: z.boolean().nullable().optional(),
-  IsEtaAtFpd: z.boolean().nullable().optional(),
-  ContextInfo: z.any().optional(),
-  CollectionAddress: z.any().optional(),
-  LaraContainerCode: z.string().nullable().optional(),
-  RemainingDays: z.number().nullable().optional(),
-  DefaultZoomLevel: z.number().nullable().optional(),
-  ModeOfTransport: z.string().nullable().optional(),
-  EstimatedTimeOfArrivalString: z.string().nullable().optional(),
-  raw: z.any().optional(),
-})
+function hasNonEmptyText(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+export const CmaCgmApiSchema = z
+  .object({
+    ContainerReference: z.string().nullable().optional(),
+    EstimatedTimeOfArrival: z.string().nullable().optional(), // "/Date(...)\/"
+    ABPExportDate: z.string().nullable().optional(),
+    ABPImportDate: z.string().nullable().optional(),
+    CurrentMoves: z.array(CmaCgmMoveSchema).optional(),
+    PastMoves: z.array(CmaCgmMoveSchema).optional(),
+    ProvisionalMoves: z.array(CmaCgmMoveSchema).optional(),
+    PlaceOfLoading: z.string().nullable().optional(),
+    LastDischargePort: z.string().nullable().optional(),
+    ContainerStatus: z.number().nullable().optional(),
+    IsEtaAtPod: z.boolean().nullable().optional(),
+    IsEtaAtFpd: z.boolean().nullable().optional(),
+    ContextInfo: z.any().optional(),
+    CollectionAddress: z.any().optional(),
+    LaraContainerCode: z.string().nullable().optional(),
+    RemainingDays: z.number().nullable().optional(),
+    DefaultZoomLevel: z.number().nullable().optional(),
+    ModeOfTransport: z.string().nullable().optional(),
+    EstimatedTimeOfArrivalString: z.string().nullable().optional(),
+    raw: z.any().optional(),
+  })
+  .superRefine((payload, context) => {
+    if (!hasNonEmptyText(payload.ContainerReference)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['ContainerReference'],
+        message: 'CMA-CGM snapshot missing ContainerReference',
+      })
+    }
+
+    const allMoves = [
+      ...(payload.PastMoves ?? []),
+      ...(payload.CurrentMoves ?? []),
+      ...(payload.ProvisionalMoves ?? []),
+    ]
+
+    if (allMoves.length === 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['PastMoves'],
+        message: 'CMA-CGM snapshot missing movement arrays',
+      })
+      return
+    }
+
+    const hasSemanticMove = allMoves.some(
+      (move) =>
+        hasNonEmptyText(move.StatusDescription) &&
+        (hasNonEmptyText(move.Date) || hasNonEmptyText(move.DateString)),
+    )
+
+    if (!hasSemanticMove) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['PastMoves'],
+        message: 'CMA-CGM snapshot has no recognizable movement entries',
+      })
+    }
+  })

--- a/src/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema.ts
+++ b/src/modules/tracking/infrastructure/carriers/schemas/api/cmacgm.api.schema.ts
@@ -30,49 +30,49 @@ function hasNonEmptyText(value: string | null | undefined): boolean {
   return typeof value === 'string' && value.trim().length > 0
 }
 
-export const CmaCgmApiSchema = z
-  .object({
-    ContainerReference: z.string().nullable().optional(),
-    EstimatedTimeOfArrival: z.string().nullable().optional(), // "/Date(...)\/"
-    ABPExportDate: z.string().nullable().optional(),
-    ABPImportDate: z.string().nullable().optional(),
-    CurrentMoves: z.array(CmaCgmMoveSchema).optional(),
-    PastMoves: z.array(CmaCgmMoveSchema).optional(),
-    ProvisionalMoves: z.array(CmaCgmMoveSchema).optional(),
-    PlaceOfLoading: z.string().nullable().optional(),
-    LastDischargePort: z.string().nullable().optional(),
-    ContainerStatus: z.number().nullable().optional(),
-    IsEtaAtPod: z.boolean().nullable().optional(),
-    IsEtaAtFpd: z.boolean().nullable().optional(),
-    ContextInfo: z.any().optional(),
-    CollectionAddress: z.any().optional(),
-    LaraContainerCode: z.string().nullable().optional(),
-    RemainingDays: z.number().nullable().optional(),
-    DefaultZoomLevel: z.number().nullable().optional(),
-    ModeOfTransport: z.string().nullable().optional(),
-    EstimatedTimeOfArrivalString: z.string().nullable().optional(),
-    raw: z.any().optional(),
-  })
-  .superRefine((payload, context) => {
-    if (!hasNonEmptyText(payload.ContainerReference)) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['ContainerReference'],
-        message: 'CMA-CGM snapshot missing ContainerReference',
-      })
-    }
+export const CmaCgmApiSchema = z.object({
+  ContainerReference: z.string().nullable().optional(),
+  EstimatedTimeOfArrival: z.string().nullable().optional(), // "/Date(...)\/"
+  ABPExportDate: z.string().nullable().optional(),
+  ABPImportDate: z.string().nullable().optional(),
+  CurrentMoves: z.array(CmaCgmMoveSchema).optional(),
+  PastMoves: z.array(CmaCgmMoveSchema).optional(),
+  ProvisionalMoves: z.array(CmaCgmMoveSchema).optional(),
+  PlaceOfLoading: z.string().nullable().optional(),
+  LastDischargePort: z.string().nullable().optional(),
+  ContainerStatus: z.number().nullable().optional(),
+  IsEtaAtPod: z.boolean().nullable().optional(),
+  IsEtaAtFpd: z.boolean().nullable().optional(),
+  ContextInfo: z.any().optional(),
+  CollectionAddress: z.any().optional(),
+  LaraContainerCode: z.string().nullable().optional(),
+  RemainingDays: z.number().nullable().optional(),
+  DefaultZoomLevel: z.number().nullable().optional(),
+  ModeOfTransport: z.string().nullable().optional(),
+  EstimatedTimeOfArrivalString: z.string().nullable().optional(),
+  raw: z.any().optional(),
+})
 
-    const allMoves = [
-      ...(payload.PastMoves ?? []),
-      ...(payload.CurrentMoves ?? []),
-      ...(payload.ProvisionalMoves ?? []),
-    ]
+export const CmaCgmApiStrictSchema = CmaCgmApiSchema.superRefine((payload, context) => {
+  if (!hasNonEmptyText(payload.ContainerReference)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['ContainerReference'],
+      message: 'CMA-CGM snapshot missing ContainerReference',
+    })
+  }
 
-    if (allMoves.length === 0) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['PastMoves'],
-        message: 'CMA-CGM snapshot missing movement arrays',
-      })
-    }
-  })
+  const allMoves = [
+    ...(payload.PastMoves ?? []),
+    ...(payload.CurrentMoves ?? []),
+    ...(payload.ProvisionalMoves ?? []),
+  ]
+
+  if (allMoves.length === 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['PastMoves'],
+      message: 'CMA-CGM snapshot missing movement arrays',
+    })
+  }
+})

--- a/src/modules/tracking/infrastructure/carriers/tests/cmacgm.temporal-stability.regression.test.ts
+++ b/src/modules/tracking/infrastructure/carriers/tests/cmacgm.temporal-stability.regression.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { computeFingerprint } from '~/modules/tracking/domain/identity/fingerprint'
+import type { Snapshot } from '~/modules/tracking/domain/model/snapshot'
+import { diffObservations } from '~/modules/tracking/features/observation/application/orchestration/diffObservations'
+import { normalizeCmaCgmSnapshot } from '~/modules/tracking/infrastructure/carriers/normalizers/cmacgm.normalizer'
+import { temporalCanonicalText } from '~/shared/time/tests/helpers'
+
+const CONTAINER_ID = '00000000-0000-0000-0000-000000000991'
+const CONTAINER_NUMBER = 'MSCU9990001'
+
+function makeSnapshot(snapshotId: string, moveDate: string): Snapshot {
+  return {
+    id: snapshotId,
+    container_id: CONTAINER_ID,
+    provider: 'cmacgm',
+    fetched_at: '2026-04-18T10:00:00.000Z',
+    payload: {
+      ContainerReference: CONTAINER_NUMBER,
+      PastMoves: [
+        {
+          Date: moveDate,
+          DateString: 'Friday,24-APR-2026',
+          TimeString: '07:00 PM',
+          State: 'NONE',
+          StatusDescription: 'Vessel Arrival',
+          LocationCode: 'BRSSZ',
+          Location: 'SANTOS',
+          Vessel: 'CMA CGM LISA MARIE',
+          Voyage: '0NSN7S1MA',
+        },
+      ],
+    },
+  }
+}
+
+describe('CMA-CGM temporal stability regression', () => {
+  it('normalizes semantically equivalent snapshots to the same canonical temporal representation', () => {
+    const snapshots = [
+      makeSnapshot('00000000-0000-0000-0000-000000000101', '2026-04-24T00:00:00'),
+      makeSnapshot('00000000-0000-0000-0000-000000000102', '2026-04-24T16:00:00'),
+      makeSnapshot('00000000-0000-0000-0000-000000000103', '2026-04-24T19:00:00'),
+    ]
+
+    const drafts = snapshots.map((snapshot) => normalizeCmaCgmSnapshot(snapshot)[0] ?? null)
+    expect(drafts).toHaveLength(3)
+    for (const draft of drafts) {
+      expect(draft).not.toBeNull()
+      expect(draft?.event_time?.kind).toBe('local-datetime')
+      expect(draft?.event_time_source).toBe('carrier_local_port_time')
+      expect(draft?.raw_event_time).toBe('Friday,24-APR-2026 07:00 PM')
+    }
+
+    const canonicalTimes = drafts.map((draft) => temporalCanonicalText(draft?.event_time ?? null))
+    expect(canonicalTimes).toEqual([
+      '2026-04-24T19:00:00.000[America/Sao_Paulo]',
+      '2026-04-24T19:00:00.000[America/Sao_Paulo]',
+      '2026-04-24T19:00:00.000[America/Sao_Paulo]',
+    ])
+  })
+
+  it('keeps fingerprint stable and lets diffObservations deduplicate downstream', () => {
+    const snapshots = [
+      makeSnapshot('00000000-0000-0000-0000-000000000201', '2026-04-24T00:00:00'),
+      makeSnapshot('00000000-0000-0000-0000-000000000202', '2026-04-24T16:00:00'),
+      makeSnapshot('00000000-0000-0000-0000-000000000203', '2026-04-24T19:00:00'),
+    ]
+
+    const drafts = snapshots.map((snapshot) => normalizeCmaCgmSnapshot(snapshot)[0] ?? null)
+    const fingerprints = drafts.map((draft) => (draft === null ? null : computeFingerprint(draft)))
+    expect(fingerprints).toEqual([fingerprints[0], fingerprints[0], fingerprints[0]])
+
+    const [firstDraft, secondDraft, thirdDraft] = drafts
+    if (firstDraft == null || secondDraft == null || thirdDraft == null) {
+      throw new Error('Expected normalized drafts for all snapshots')
+    }
+
+    const existingFingerprints = new Set<string>()
+    const firstBatch = diffObservations(existingFingerprints, [firstDraft], CONTAINER_ID)
+    expect(firstBatch).toHaveLength(1)
+    const firstFingerprint = firstBatch[0]?.fingerprint
+    if (!firstFingerprint) {
+      throw new Error('Expected a fingerprint in first batch')
+    }
+    existingFingerprints.add(firstFingerprint)
+
+    const secondBatch = diffObservations(existingFingerprints, [secondDraft], CONTAINER_ID)
+    const thirdBatch = diffObservations(existingFingerprints, [thirdDraft], CONTAINER_ID)
+    expect(secondBatch).toHaveLength(0)
+    expect(thirdBatch).toHaveLength(0)
+  })
+})

--- a/src/modules/tracking/infrastructure/carriers/tests/cmacgmNormalizer.test.ts
+++ b/src/modules/tracking/infrastructure/carriers/tests/cmacgmNormalizer.test.ts
@@ -323,6 +323,25 @@ describe('normalizeCmaCgmSnapshot', () => {
       expect(drafts[0]?.event_time_source).toBe('carrier_date_only')
     })
 
+    it('uses derived fallback when DateString and TimeString exist but timezone cannot be resolved', () => {
+      const drafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            DateString: 'Friday,24-APR-2026',
+            TimeString: '07:00 PM',
+            LocationCode: 'ZZZZZ',
+            Location: 'UNKNOWN TERMINAL',
+          }),
+        ),
+      )
+
+      expect(drafts).toHaveLength(1)
+      expect(drafts[0]?.event_time?.kind).toBe('date')
+      expect(temporalCanonicalText(drafts[0]?.event_time ?? null)).toBe('2026-04-24')
+      expect(drafts[0]?.event_time_source).toBe('derived_fallback')
+      expect(drafts[0]?.raw_event_time).toBe('Friday,24-APR-2026 07:00 PM')
+    })
+
     it('uses move.Date as instant only for explicitly absolute timestamps', () => {
       const msDateDrafts = normalizeCmaCgmSnapshot(
         makeSnapshot(

--- a/src/modules/tracking/infrastructure/carriers/tests/cmacgmNormalizer.test.ts
+++ b/src/modules/tracking/infrastructure/carriers/tests/cmacgmNormalizer.test.ts
@@ -17,6 +17,19 @@ function makeSnapshot(payload: unknown, fetchedAt: string = '2026-02-03T12:00:00
   }
 }
 
+function makeSingleMovePayload(move: Record<string, unknown>): unknown {
+  return {
+    ContainerReference: 'TGBU7416510',
+    PastMoves: [
+      {
+        State: 'DONE',
+        StatusDescription: 'Loaded on board',
+        ...move,
+      },
+    ],
+  }
+}
+
 describe('normalizeCmaCgmSnapshot', () => {
   describe('full payload fixture', () => {
     it('should produce observation drafts from all move arrays', () => {
@@ -138,6 +151,279 @@ describe('normalizeCmaCgmSnapshot', () => {
       expect(drafts[0]?.event_time_type).toBe('EXPECTED')
       expect(drafts[0]?.raw_event_time).toBe('Fri 24-APR-2026 07:00 PM')
       expect(drafts[0]?.event_time_source).toBe('carrier_local_port_time')
+    })
+  })
+
+  describe('temporal priority hotfix (CMA local-port first)', () => {
+    it('keeps local datetime for real CMA cases with DateString + TimeString + location', () => {
+      const payload = {
+        ContainerReference: 'CMAU1234567',
+        PastMoves: [
+          {
+            Date: '2026-02-23T16:00:00',
+            DateString: 'Monday,23-FEB-2026',
+            TimeString: '04:00 PM',
+            State: 'DONE',
+            StatusDescription: 'Empty to shipper',
+            LocationCode: 'LBBEY',
+            Location: 'BEIRUT',
+          },
+          {
+            Date: '2026-03-19T23:13:00',
+            DateString: 'Thursday,19-MAR-2026',
+            TimeString: '11:13 PM',
+            State: 'DONE',
+            StatusDescription: 'Loaded on board',
+            LocationCode: 'LBBEY',
+            Location: 'BEIRUT',
+            Vessel: 'CMA CGM TEST',
+            Voyage: 'V1',
+          },
+          {
+            Date: '2026-04-04T07:48:00',
+            DateString: 'Saturday,04-APR-2026',
+            TimeString: '07:48 AM',
+            State: 'DONE',
+            StatusDescription: 'Vessel Arrival',
+            LocationCode: 'MAPTM',
+            Location: 'TANGER MED',
+            Vessel: 'CMA CGM TEST',
+            Voyage: 'V2',
+          },
+          {
+            Date: '2026-04-04T21:46:00',
+            DateString: 'Saturday,04-APR-2026',
+            TimeString: '09:46 PM',
+            State: 'DONE',
+            StatusDescription: 'Discharged in transhipment',
+            LocationCode: 'MAPTM',
+            Location: 'TANGER MED',
+            Vessel: 'CMA CGM TEST',
+            Voyage: 'V2',
+          },
+          {
+            Date: '2026-04-11T14:25:00',
+            DateString: 'Saturday,11-APR-2026',
+            TimeString: '02:25 PM',
+            State: 'DONE',
+            StatusDescription: 'Loaded on board',
+            LocationCode: 'MAPTM',
+            Location: 'TANGER MED',
+            Vessel: 'CMA CGM TEST',
+            Voyage: 'V3',
+          },
+          {
+            Date: '2026-04-12T04:15:00',
+            DateString: 'Sunday,12-APR-2026',
+            TimeString: '04:15 AM',
+            State: 'DONE',
+            StatusDescription: 'Vessel Departure',
+            LocationCode: 'MAPTM',
+            Location: 'TANGER MED',
+            Vessel: 'CMA CGM TEST',
+            Voyage: 'V3',
+          },
+          {
+            Date: '2026-04-24T19:00:00',
+            DateString: 'Friday,24-APR-2026',
+            TimeString: '07:00 PM',
+            State: 'NONE',
+            StatusDescription: 'Vessel Arrival',
+            LocationCode: 'BRSSZ',
+            Location: 'SANTOS',
+            Vessel: 'CMA CGM TEST',
+            Voyage: 'V4',
+          },
+        ],
+      }
+
+      const drafts = normalizeCmaCgmSnapshot(makeSnapshot(payload, '2026-04-02T12:00:00.000Z'))
+      expect(drafts).toHaveLength(7)
+
+      expect(temporalCanonicalText(drafts[0]?.event_time ?? null)).toBe(
+        '2026-02-23T16:00:00.000[Asia/Beirut]',
+      )
+      expect(drafts[0]?.event_time?.kind).toBe('local-datetime')
+
+      expect(temporalCanonicalText(drafts[1]?.event_time ?? null)).toBe(
+        '2026-03-19T23:13:00.000[Asia/Beirut]',
+      )
+      expect(drafts[1]?.event_time?.kind).toBe('local-datetime')
+
+      expect(temporalCanonicalText(drafts[2]?.event_time ?? null)).toBe(
+        '2026-04-04T07:48:00.000[Africa/Casablanca]',
+      )
+      expect(drafts[2]?.event_time?.kind).toBe('local-datetime')
+
+      expect(temporalCanonicalText(drafts[3]?.event_time ?? null)).toBe(
+        '2026-04-04T21:46:00.000[Africa/Casablanca]',
+      )
+      expect(drafts[3]?.event_time?.kind).toBe('local-datetime')
+
+      expect(temporalCanonicalText(drafts[4]?.event_time ?? null)).toBe(
+        '2026-04-11T14:25:00.000[Africa/Casablanca]',
+      )
+      expect(drafts[4]?.event_time?.kind).toBe('local-datetime')
+
+      expect(temporalCanonicalText(drafts[5]?.event_time ?? null)).toBe(
+        '2026-04-12T04:15:00.000[Africa/Casablanca]',
+      )
+      expect(drafts[5]?.event_time?.kind).toBe('local-datetime')
+
+      expect(temporalCanonicalText(drafts[6]?.event_time ?? null)).toBe(
+        '2026-04-24T19:00:00.000[America/Sao_Paulo]',
+      )
+      expect(drafts[6]?.event_time?.kind).toBe('local-datetime')
+      expect(drafts[6]?.event_time_type).toBe('EXPECTED')
+
+      for (const draft of drafts) {
+        expect(draft.event_time_source).toBe('carrier_local_port_time')
+      }
+    })
+
+    it('falls back to Beirut timezone for LBBEY when location text is missing/noisy', () => {
+      const drafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            Date: '2026-02-23T16:00:00',
+            DateString: 'Monday,23-FEB-2026',
+            TimeString: '04:00 PM',
+            LocationCode: 'LBBEY',
+            Location: 'LBBEY TERMINAL UNKNOWN',
+            StatusDescription: 'Empty to shipper',
+          }),
+        ),
+      )
+
+      expect(drafts).toHaveLength(1)
+      expect(temporalCanonicalText(drafts[0]?.event_time ?? null)).toBe(
+        '2026-02-23T16:00:00.000[Asia/Beirut]',
+      )
+      expect(drafts[0]?.event_time?.kind).toBe('local-datetime')
+      expect(drafts[0]?.event_time_source).toBe('carrier_local_port_time')
+    })
+
+    it('uses date-only when DateString is present but TimeString is missing', () => {
+      const drafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            DateString: 'Friday,24-APR-2026',
+            TimeString: null,
+            LocationCode: 'BRSSZ',
+            Location: 'SANTOS',
+          }),
+        ),
+      )
+
+      expect(drafts).toHaveLength(1)
+      expect(drafts[0]?.event_time?.kind).toBe('date')
+      expect(temporalCanonicalText(drafts[0]?.event_time ?? null)).toBe(
+        '2026-04-24[America/Sao_Paulo]',
+      )
+      expect(drafts[0]?.event_time_source).toBe('carrier_date_only')
+    })
+
+    it('uses move.Date as instant only for explicitly absolute timestamps', () => {
+      const msDateDrafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            Date: '/Date(1764659520000)/',
+            DateString: null,
+            TimeString: null,
+            LocationCode: 'ESZAZ',
+            Location: 'ZARAGOZA',
+          }),
+        ),
+      )
+      const zuluDrafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            Date: '2026-04-24T19:00:00.000Z',
+            DateString: null,
+            TimeString: null,
+            LocationCode: 'BRSSZ',
+            Location: 'SANTOS',
+          }),
+        ),
+      )
+      const offsetDrafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            Date: '2026-04-24T19:00:00-03:00',
+            DateString: null,
+            TimeString: null,
+            LocationCode: 'BRSSZ',
+            Location: 'SANTOS',
+          }),
+        ),
+      )
+
+      expect(msDateDrafts[0]?.event_time?.kind).toBe('instant')
+      expect(zuluDrafts[0]?.event_time?.kind).toBe('instant')
+      expect(offsetDrafts[0]?.event_time?.kind).toBe('instant')
+      expect(msDateDrafts[0]?.event_time_source).toBe('carrier_explicit_timezone')
+      expect(zuluDrafts[0]?.event_time_source).toBe('carrier_explicit_timezone')
+      expect(offsetDrafts[0]?.event_time_source).toBe('carrier_explicit_timezone')
+    })
+
+    it('ignores ambiguous move.Date as instant and preserves raw_event_time for audit', () => {
+      const drafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            Date: '2026-04-11T14:25:00',
+            DateString: null,
+            TimeString: null,
+            LocationCode: 'MAPTM',
+            Location: 'TANGER MED',
+          }),
+        ),
+      )
+
+      expect(drafts).toHaveLength(1)
+      expect(drafts[0]?.event_time).toBeNull()
+      expect(drafts[0]?.event_time_source).toBeNull()
+      expect(drafts[0]?.raw_event_time).toBe('2026-04-11T14:25:00')
+    })
+
+    it('keeps local datetime precedence over ambiguous move.Date', () => {
+      const drafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            Date: '2026-04-11T14:25:00',
+            DateString: 'Saturday,11-APR-2026',
+            TimeString: '02:25 PM',
+            LocationCode: 'MAPTM',
+            Location: 'TANGER MED',
+          }),
+        ),
+      )
+
+      expect(drafts).toHaveLength(1)
+      expect(drafts[0]?.event_time?.kind).toBe('local-datetime')
+      expect(temporalCanonicalText(drafts[0]?.event_time ?? null)).toBe(
+        '2026-04-11T14:25:00.000[Africa/Casablanca]',
+      )
+      expect(drafts[0]?.event_time_source).toBe('carrier_local_port_time')
+    })
+
+    it('parses ISO-like DateString prefixes as date-only for compatibility', () => {
+      const drafts = normalizeCmaCgmSnapshot(
+        makeSnapshot(
+          makeSingleMovePayload({
+            DateString: '2026-02-01T10:00:00.000Z',
+            TimeString: null,
+            LocationCode: 'BRSSZ',
+            Location: 'SANTOS',
+          }),
+        ),
+      )
+
+      expect(drafts).toHaveLength(1)
+      expect(drafts[0]?.event_time?.kind).toBe('date')
+      expect(temporalCanonicalText(drafts[0]?.event_time ?? null)).toBe(
+        '2026-02-01[America/Sao_Paulo]',
+      )
+      expect(drafts[0]?.event_time_source).toBe('carrier_date_only')
     })
   })
 

--- a/src/modules/tracking/infrastructure/carriers/tests/cmacgmNormalizer.test.ts
+++ b/src/modules/tracking/infrastructure/carriers/tests/cmacgmNormalizer.test.ts
@@ -594,6 +594,27 @@ describe('normalizeCmaCgmSnapshot', () => {
       expect(drafts).toHaveLength(0)
     })
 
+    it('uses UNKNOWN container number when ContainerReference is blank', () => {
+      const drafts = normalizeCmaCgmSnapshot(
+        makeSnapshot({
+          ContainerReference: '   ',
+          PastMoves: [
+            {
+              State: 'DONE',
+              StatusDescription: 'Loaded on board',
+              DateString: 'Friday,24-APR-2026',
+              TimeString: '07:00 PM',
+              LocationCode: 'ZZZZZ',
+              Location: 'Unknown Terminal',
+            },
+          ],
+        }),
+      )
+
+      expect(drafts).toHaveLength(1)
+      expect(drafts[0]?.container_number).toBe('UNKNOWN')
+    })
+
     it('should handle error marker payload gracefully', () => {
       const drafts = normalizeCmaCgmSnapshot(
         makeSnapshot({ _error: true, message: 'Request failed with status code 403' }),


### PR DESCRIPTION
## Summary
- Fixes CMA-CGM temporal parsing so local-port events prefer `DateString` + `TimeString` over ambiguous `Date` values.
- Adds timezone resolution for port-local CMA cases, including the `LBBEY` Beirut fallback when location text is missing or noisy.
- Preserves explicit absolute timestamps while treating ambiguous `Date` strings as audit-only raw event text.
- Adds regression coverage for temporal stability, fingerprint consistency, and downstream deduplication behavior.

## Testing
- `Not run` in this handoff.
- Added/updated Vitest coverage for CMA-CGM normalization edge cases and regression stability.
- Covered cases for local datetime precedence, date-only fallback, explicit absolute timestamps, ambiguous timestamps, and ISO-like `DateString` prefixes.